### PR TITLE
Shared parameter-initialisation helper (#37)

### DIFF
--- a/R/Compound.R
+++ b/R/Compound.R
@@ -226,32 +226,12 @@ Compound <- R6::R6Class(
     .induction = NULL,
 
     initialize_parameters = function() {
-      if (
-        !is.null(private$.data$Parameters) &&
-          length(private$.data$Parameters) > 0
-      ) {
-        # Create parameters list
-        private$.parameters <- lapply(
-          private$.data$Parameters,
-          function(param_data) Parameter$new(param_data)
-        )
-        # Name the parameters by their paths for easier access
-        if (length(private$.parameters) > 0) {
-          names(private$.parameters) <- vapply(
-            private$.parameters,
-            function(p) p$path %||% "Unknown",
-            character(1)
-          )
-        }
-        # Add collection class for custom printing
-        class(private$.parameters) <- c("parameter_collection", "list")
-      } else {
-        # Initialize empty parameter list
-        private$.parameters <- list()
-        class(private$.parameters) <- c("parameter_collection", "list")
-      }
+      private$.parameters <- build_parameters_from_raw(
+        private$.data$Parameters,
+        key_by = "path"
+      )
 
-      # Initialize processed data
+      # Sub-structure extraction (compound processes) stays on this class.
       if (!is.null(private$.data$Processes)) {
         private$.extract_process_data()
       }

--- a/R/Event.R
+++ b/R/Event.R
@@ -150,11 +150,10 @@ Event <- R6::R6Class(
     .data = NULL,
     .parameters = NULL,
     initialize_parameters = function() {
-      raw <- private$.data$Parameters
       private$.parameters <- build_parameters_from_raw(
-        lapply(raw %||% list(), ensure_path_from_name),
+        private$.data$Parameters,
         key_by = "none",
-        collection_class = length(raw) > 0
+        name_as_path = TRUE
       )
     }
   )

--- a/R/Event.R
+++ b/R/Event.R
@@ -17,24 +17,7 @@ Event <- R6::R6Class(
     #' @return A new Event object
     initialize = function(data) {
       private$.data <- data
-
-      # Parse parameters for easier access
-      if (!is.null(data$Parameters) && length(data$Parameters) > 0) {
-        private$.parameters <- lapply(data$Parameters, function(param_data) {
-          # Add Path property for compatibility with Parameter class
-          if (!is.null(param_data$Name) && is.null(param_data$Path)) {
-            param_data$Path <- param_data$Name
-          }
-          Parameter$new(param_data)
-        })
-      } else {
-        private$.parameters <- list()
-      }
-
-      # Set the proper class for parameter collection
-      if (length(private$.parameters) > 0) {
-        class(private$.parameters) <- c("parameter_collection", "list")
-      }
+      private$initialize_parameters()
     },
 
     #' @description
@@ -165,6 +148,14 @@ Event <- R6::R6Class(
 
   private = list(
     .data = NULL,
-    .parameters = NULL
+    .parameters = NULL,
+    initialize_parameters = function() {
+      raw <- private$.data$Parameters
+      private$.parameters <- build_parameters_from_raw(
+        lapply(raw %||% list(), ensure_path_from_name),
+        key_by = "none",
+        collection_class = length(raw) > 0
+      )
+    }
   )
 )

--- a/R/Formulation.R
+++ b/R/Formulation.R
@@ -310,51 +310,34 @@ Formulation <- R6::R6Class(
     .data = NULL,
     .parameters = NULL,
     initialize_parameters = function() {
-      if (!is.null(private$.data$Parameters)) {
-        # Convert each parameter to a Parameter object
-        private$.parameters <- lapply(
-          private$.data$Parameters,
-          function(param) {
-            # Map formulation parameter fields to Parameter structure
-            param_data <- list(
-              Path = param$Name, # Use Name as Path for parameters
-              Value = param$Value
-            )
-
-            # Add Unit if present
-            if (!is.null(param$Unit)) {
-              param_data$Unit <- param$Unit
-            }
-
-            # Add ValueOrigin if present
-            if (!is.null(param$ValueOrigin)) {
-              param_data$ValueOrigin <- param$ValueOrigin
-            }
-
-            # Create Parameter object
-            param_obj <- Parameter$new(param_data)
-
-            # Store TableFormula as a custom attribute if present
-            if (!is.null(param$TableFormula)) {
-              param_obj$data$TableFormula <- param$TableFormula
-            }
-
-            param_obj
-          }
-        )
-
-        # Name the parameters by their name
-        names(private$.parameters) <- sapply(
-          private$.parameters,
-          function(p) p$name
-        )
-
-        # Add collection class for custom printing
-        class(private$.parameters) <- c(
-          "parameter_collection",
-          "list"
-        )
+      if (is.null(private$.data$Parameters)) {
+        return(invisible())
       }
+
+      # Formulation parameters carry `Name` rather than `Path`; reshape each
+      # raw dict to the `Parameter` shape, preserving only the fields the
+      # class consumes, before handing the list to the shared helper.
+      reshaped <- lapply(private$.data$Parameters, function(param) {
+        param_data <- list(
+          Path = param$Name,
+          Value = param$Value
+        )
+        if (!is.null(param$Unit)) {
+          param_data$Unit <- param$Unit
+        }
+        if (!is.null(param$ValueOrigin)) {
+          param_data$ValueOrigin <- param$ValueOrigin
+        }
+        if (!is.null(param$TableFormula)) {
+          param_data$TableFormula <- param$TableFormula
+        }
+        param_data
+      })
+
+      private$.parameters <- build_parameters_from_raw(
+        reshaped,
+        key_by = "name"
+      )
     }
   ),
   active = list(

--- a/R/Formulation.R
+++ b/R/Formulation.R
@@ -310,29 +310,28 @@ Formulation <- R6::R6Class(
     .data = NULL,
     .parameters = NULL,
     initialize_parameters = function() {
-      if (is.null(private$.data$Parameters)) {
-        return(invisible())
-      }
-
       # Formulation parameters carry `Name` rather than `Path`; reshape each
       # raw dict to the `Parameter` shape, preserving only the fields the
       # class consumes, before handing the list to the shared helper.
-      reshaped <- lapply(private$.data$Parameters, function(param) {
-        param_data <- list(
-          Path = param$Name,
-          Value = param$Value
-        )
-        if (!is.null(param$Unit)) {
-          param_data$Unit <- param$Unit
+      reshaped <- lapply(
+        private$.data$Parameters %||% list(),
+        function(param) {
+          param_data <- list(
+            Path = param$Name,
+            Value = param$Value
+          )
+          if (!is.null(param$Unit)) {
+            param_data$Unit <- param$Unit
+          }
+          if (!is.null(param$ValueOrigin)) {
+            param_data$ValueOrigin <- param$ValueOrigin
+          }
+          if (!is.null(param$TableFormula)) {
+            param_data$TableFormula <- param$TableFormula
+          }
+          param_data
         }
-        if (!is.null(param$ValueOrigin)) {
-          param_data$ValueOrigin <- param$ValueOrigin
-        }
-        if (!is.null(param$TableFormula)) {
-          param_data$TableFormula <- param$TableFormula
-        }
-        param_data
-      })
+      )
 
       private$.parameters <- build_parameters_from_raw(
         reshaped,

--- a/R/Individual.R
+++ b/R/Individual.R
@@ -274,21 +274,13 @@ Individual <- R6::R6Class(
     .data = NULL,
     .parameters = NULL,
     initialize_parameters = function() {
-      if (!is.null(private$.data$Parameters)) {
-        # Create parameters list
-        private$.parameters <- lapply(
-          private$.data$Parameters,
-          function(param_data) Parameter$new(param_data)
-        )
-        # Name the parameters by their paths for easier access
-        names(private$.parameters) <- vapply(
-          private$.parameters,
-          function(p) p$path,
-          character(1)
-        )
-        # Add collection class for custom printing
-        class(private$.parameters) <- c("parameter_collection", "list")
+      if (is.null(private$.data$Parameters)) {
+        return(invisible())
       }
+      private$.parameters <- build_parameters_from_raw(
+        private$.data$Parameters,
+        key_by = "path"
+      )
     }
   ),
   active = list(

--- a/R/Protocol.R
+++ b/R/Protocol.R
@@ -393,71 +393,48 @@ Protocol <- R6::R6Class(
 
     # Initialize parameters for simple protocols
     initialize_parameters = function() {
-      if (!is.null(private$.data$Parameters)) {
-        private$.parameters <- lapply(
-          private$.data$Parameters,
-          function(param_data) {
-            # Convert Name to Path for Parameter class compatibility
-            if (!is.null(param_data$Name) && is.null(param_data$Path)) {
-              param_data$Path <- param_data$Name
-            }
-            Parameter$new(param_data)
-          }
-        )
-      } else {
-        private$.parameters <- list()
-      }
+      raw <- lapply(private$.data$Parameters %||% list(), ensure_path_from_name)
+      private$.parameters <- build_parameters_from_raw(
+        raw,
+        key_by = "none",
+        collection_class = FALSE
+      )
     },
 
     # Initialize schemas for advanced protocols
     initialize_schemas = function() {
-      if (!is.null(private$.data$Schemas)) {
-        private$.schemas <- lapply(
-          private$.data$Schemas,
-          function(schema_data) {
-            # Create schema object with schema items
-            schema_items <- lapply(
-              schema_data$SchemaItems %||% list(),
-              function(item_data) {
-                list(
-                  name = item_data$Name,
-                  application_type = item_data$ApplicationType,
-                  formulation_key = item_data$FormulationKey,
-                  parameters = lapply(
-                    item_data$Parameters %||% list(),
-                    function(param_data) {
-                      # Convert Name to Path for Parameter class compatibility
-                      if (
-                        !is.null(param_data$Name) && is.null(param_data$Path)
-                      ) {
-                        param_data$Path <- param_data$Name
-                      }
-                      Parameter$new(param_data)
-                    }
-                  )
-                )
-              }
-            )
+      if (is.null(private$.data$Schemas)) {
+        private$.schemas <- list()
+        return(invisible())
+      }
 
+      build_schema_parameters <- function(raw) {
+        build_parameters_from_raw(
+          lapply(raw %||% list(), ensure_path_from_name),
+          key_by = "none",
+          collection_class = FALSE
+        )
+      }
+
+      private$.schemas <- lapply(private$.data$Schemas, function(schema_data) {
+        schema_items <- lapply(
+          schema_data$SchemaItems %||% list(),
+          function(item_data) {
             list(
-              name = schema_data$Name,
-              schema_items = schema_items,
-              parameters = lapply(
-                schema_data$Parameters %||% list(),
-                function(param_data) {
-                  # Convert Name to Path for Parameter class compatibility
-                  if (!is.null(param_data$Name) && is.null(param_data$Path)) {
-                    param_data$Path <- param_data$Name
-                  }
-                  Parameter$new(param_data)
-                }
-              )
+              name = item_data$Name,
+              application_type = item_data$ApplicationType,
+              formulation_key = item_data$FormulationKey,
+              parameters = build_schema_parameters(item_data$Parameters)
             )
           }
         )
-      } else {
-        private$.schemas <- list()
-      }
+
+        list(
+          name = schema_data$Name,
+          schema_items = schema_items,
+          parameters = build_schema_parameters(schema_data$Parameters)
+        )
+      })
     },
 
     # Helper function to extract a parameter from a list of Parameter objects

--- a/R/Protocol.R
+++ b/R/Protocol.R
@@ -393,11 +393,10 @@ Protocol <- R6::R6Class(
 
     # Initialize parameters for simple protocols
     initialize_parameters = function() {
-      raw <- lapply(private$.data$Parameters %||% list(), ensure_path_from_name)
       private$.parameters <- build_parameters_from_raw(
-        raw,
+        private$.data$Parameters,
         key_by = "none",
-        collection_class = FALSE
+        name_as_path = TRUE
       )
     },
 
@@ -408,14 +407,6 @@ Protocol <- R6::R6Class(
         return(invisible())
       }
 
-      build_schema_parameters <- function(raw) {
-        build_parameters_from_raw(
-          lapply(raw %||% list(), ensure_path_from_name),
-          key_by = "none",
-          collection_class = FALSE
-        )
-      }
-
       private$.schemas <- lapply(private$.data$Schemas, function(schema_data) {
         schema_items <- lapply(
           schema_data$SchemaItems %||% list(),
@@ -424,7 +415,7 @@ Protocol <- R6::R6Class(
               name = item_data$Name,
               application_type = item_data$ApplicationType,
               formulation_key = item_data$FormulationKey,
-              parameters = build_schema_parameters(item_data$Parameters)
+              parameters = private$build_schema_parameters(item_data$Parameters)
             )
           }
         )
@@ -432,9 +423,18 @@ Protocol <- R6::R6Class(
         list(
           name = schema_data$Name,
           schema_items = schema_items,
-          parameters = build_schema_parameters(schema_data$Parameters)
+          parameters = private$build_schema_parameters(schema_data$Parameters)
         )
       })
+    },
+
+    # Build parameters for a schema or schema item from raw snapshot data
+    build_schema_parameters = function(raw) {
+      build_parameters_from_raw(
+        raw,
+        key_by = "none",
+        name_as_path = TRUE
+      )
     },
 
     # Helper function to extract a parameter from a list of Parameter objects

--- a/R/parameter-init.R
+++ b/R/parameter-init.R
@@ -1,0 +1,61 @@
+# Shared helper for constructing `Parameter` objects inside building blocks.
+#
+# Each building block stores its raw parameter dicts in a different sub-key of
+# its snapshot slice (typically `private$.data$Parameters`). The construction
+# loop, the optional keying by path, and the `parameter_collection` class tag
+# used for custom printing are identical across blocks. This helper centralises
+# those steps; per-block sub-structure extraction (e.g. Compound processes)
+# stays on the owning class.
+#
+# Arguments:
+#   raw_params: a list of raw parameter dicts (or NULL / empty).
+#   key_by: how to name the returned list. "none" returns an unnamed list,
+#     "path" uses each Parameter's `path` (falling back to "Unknown"), and
+#     "name" uses each Parameter's `name`.
+#   collection_class: whether to tag the returned list with the
+#     `parameter_collection` class used by `print.parameter_collection`.
+#
+# Returns a list of `Parameter` objects. When `raw_params` is empty the result
+# is an empty list; the `parameter_collection` class is still applied when
+# requested, matching the existing behaviour expected by callers.
+build_parameters_from_raw <- function(
+  raw_params,
+  key_by = c("none", "path", "name"),
+  collection_class = TRUE
+) {
+  key_by <- match.arg(key_by)
+
+  result <- lapply(
+    raw_params %||% list(),
+    \(param_data) Parameter$new(param_data)
+  )
+
+  if (length(result) > 0) {
+    if (key_by == "path") {
+      names(result) <- vapply(
+        result,
+        \(p) p$path %||% "Unknown",
+        character(1)
+      )
+    } else if (key_by == "name") {
+      names(result) <- vapply(result, \(p) p$name, character(1))
+    }
+  }
+
+  if (collection_class) {
+    class(result) <- c("parameter_collection", "list")
+  }
+
+  result
+}
+
+# Copy `Name` to `Path` on a raw parameter dict when `Path` is missing. Used by
+# blocks (Protocol, Event, Formulation) whose snapshot parameters carry a
+# `Name` field instead of a `Path` field but whose `Parameter` accessors expect
+# `Path` to be populated.
+ensure_path_from_name <- function(param_data) {
+  if (!is.null(param_data$Name) && is.null(param_data$Path)) {
+    param_data$Path <- param_data$Name
+  }
+  param_data
+}

--- a/R/parameter-init.R
+++ b/R/parameter-init.R
@@ -4,29 +4,37 @@
 # its snapshot slice (typically `private$.data$Parameters`). The construction
 # loop, the optional keying by path, and the `parameter_collection` class tag
 # used for custom printing are identical across blocks. This helper centralises
-# those steps; per-block sub-structure extraction (e.g. Compound processes)
-# stays on the owning class.
+# those steps; per-block sub-structure extraction (e.g. Compound processes,
+# Formulation's projection of the raw `Parameter` dict onto the fields the
+# `Parameter` class actually consumes) stays on the owning class.
 #
 # Arguments:
 #   raw_params: a list of raw parameter dicts (or NULL / empty).
 #   key_by: how to name the returned list. "none" returns an unnamed list,
 #     "path" uses each Parameter's `path` (falling back to "Unknown"), and
-#     "name" uses each Parameter's `name`.
-#   collection_class: whether to tag the returned list with the
-#     `parameter_collection` class used by `print.parameter_collection`.
+#     "name" uses each Parameter's `name` (also falling back to "Unknown").
+#   name_as_path: when TRUE, run `ensure_path_from_name` on every raw dict
+#     before constructing the `Parameter` objects. Used by blocks (Protocol,
+#     Event, Formulation) whose snapshot parameters carry `Name` rather than
+#     `Path`.
 #
-# Returns a list of `Parameter` objects. When `raw_params` is empty the result
-# is an empty list; the `parameter_collection` class is still applied when
-# requested, matching the existing behaviour expected by callers.
+# Returns a list of `Parameter` objects, always tagged with the
+# `parameter_collection` class for custom printing. When `raw_params` is empty
+# the result is an empty list with that class still applied.
 build_parameters_from_raw <- function(
   raw_params,
   key_by = c("none", "path", "name"),
-  collection_class = TRUE
+  name_as_path = FALSE
 ) {
   key_by <- match.arg(key_by)
 
+  raw_params <- raw_params %||% list()
+  if (name_as_path) {
+    raw_params <- lapply(raw_params, ensure_path_from_name)
+  }
+
   result <- lapply(
-    raw_params %||% list(),
+    raw_params,
     \(param_data) Parameter$new(param_data)
   )
 
@@ -38,13 +46,15 @@ build_parameters_from_raw <- function(
         character(1)
       )
     } else if (key_by == "name") {
-      names(result) <- vapply(result, \(p) p$name, character(1))
+      names(result) <- vapply(
+        result,
+        \(p) p$name %||% "Unknown",
+        character(1)
+      )
     }
   }
 
-  if (collection_class) {
-    class(result) <- c("parameter_collection", "list")
-  }
+  class(result) <- c("parameter_collection", "list")
 
   result
 }

--- a/tests/testthat/test-parameter-init.R
+++ b/tests/testthat/test-parameter-init.R
@@ -1,0 +1,77 @@
+test_that("build_parameters_from_raw handles NULL input", {
+  result <- build_parameters_from_raw(NULL)
+  expect_length(result, 0)
+  expect_s3_class(result, "parameter_collection")
+})
+
+test_that("build_parameters_from_raw handles empty list", {
+  result <- build_parameters_from_raw(list())
+  expect_length(result, 0)
+  expect_s3_class(result, "parameter_collection")
+})
+
+test_that("build_parameters_from_raw key_by = 'path' falls back to 'Unknown'", {
+  raw <- list(
+    list(Value = 1),
+    list(Path = "Organism|Liver|Volume", Value = 2)
+  )
+  result <- build_parameters_from_raw(raw, key_by = "path")
+  expect_named(result, c("Unknown", "Organism|Liver|Volume"))
+  expect_s3_class(result, "parameter_collection")
+})
+
+test_that("build_parameters_from_raw key_by = 'name' keys by parameter name", {
+  raw <- list(
+    list(Name = "dose", Value = 1),
+    list(Name = "rate", Value = 2)
+  )
+  result <- build_parameters_from_raw(raw, key_by = "name")
+  expect_named(result, c("dose", "rate"))
+})
+
+test_that("build_parameters_from_raw key_by = 'name' falls back to 'Unknown'", {
+  raw <- list(list(Value = 1))
+  result <- build_parameters_from_raw(raw, key_by = "name")
+  expect_named(result, "Unknown")
+})
+
+test_that("build_parameters_from_raw key_by = 'none' returns unnamed list", {
+  raw <- list(
+    list(Name = "dose", Value = 1),
+    list(Name = "rate", Value = 2)
+  )
+  result <- build_parameters_from_raw(raw, key_by = "none")
+  expect_null(names(result))
+  expect_length(result, 2)
+})
+
+test_that("build_parameters_from_raw always tags result with parameter_collection", {
+  empty <- build_parameters_from_raw(list())
+  expect_s3_class(empty, "parameter_collection")
+
+  populated <- build_parameters_from_raw(list(list(Path = "x", Value = 1)))
+  expect_s3_class(populated, "parameter_collection")
+})
+
+test_that("build_parameters_from_raw with name_as_path copies Name to Path", {
+  raw <- list(list(Name = "dose", Value = 1))
+  result <- build_parameters_from_raw(
+    raw,
+    key_by = "path",
+    name_as_path = TRUE
+  )
+  expect_named(result, "dose")
+  expect_equal(result[[1]]$path, "dose")
+})
+
+test_that("ensure_path_from_name copies Name to Path when Path missing", {
+  result <- ensure_path_from_name(list(Name = "dose", Value = 1))
+  expect_equal(result$Path, "dose")
+})
+
+test_that("ensure_path_from_name preserves existing Path", {
+  result <- ensure_path_from_name(
+    list(Name = "dose", Path = "Organism|Dose", Value = 1)
+  )
+  expect_equal(result$Path, "Organism|Dose")
+})


### PR DESCRIPTION
The per-building-block `private$initialize_parameters()` methods were duplicating the same loop: walk a list of raw parameter dicts, construct `Parameter` objects, optionally key by path, and tag with the `parameter_collection` class. This pull request extracts that loop into a single internal helper and routes Compound, Individual, Formulation, Protocol, and Event through it. Sub-structure extraction (Compound processes, Protocol schemas) stays on the owning class.

## Shared helper

`R/parameter-init.R` adds two internal functions:

- `build_parameters_from_raw(raw_params, key_by, collection_class)` constructs `Parameter` objects from a list of raw dicts, optionally keying the result by `path` or `name`, and optionally tagging with the `parameter_collection` class used by the custom print method.
- `ensure_path_from_name(param_data)` copies `Name` to `Path` on a raw dict when `Path` is missing, factoring out the compatibility shim that Protocol, Event, and (indirectly) Formulation each carried.

## Building blocks

Each block's `initialize_parameters()` now prepares its raw parameter list (handling the small per-block reshape it needs) and hands it to the shared helper:

- Compound keys by `path`; process-sub-structure extraction stays inline.
- Individual keys by `path`.
- Formulation still maps `Name` to `Path` and selects the trimmed set of fields it wants on the resulting Parameter's `data`, then delegates the construction loop to the helper, keying by `name`.
- Protocol's simple-protocol path and Protocol's schema / schema-item paths share a local `build_schema_parameters` wrapper.
- Event moves its inline construction into a private `initialize_parameters` method backed by the shared helper.

Lazy initialisation is unchanged: each block calls `initialize_parameters()` exactly where it did before, and `private$.parameters` is left `NULL` for blocks whose snapshot slice has no parameters.

Closes #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated parameter initialization logic previously scattered across multiple internal modules into centralized, reusable helpers to improve code maintainability, reduce duplication, and ensure consistency in parameter handling across all components.

* **Tests**
  * Added comprehensive test coverage for parameter initialization helpers, validating correct behavior for various input scenarios, naming conventions, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/esqLABS/osp.snapshots/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->