### PR TITLE
Lazy-load named-list collections

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 ## Bug fixes
 
+- Fixed `Snapshot$data` so observed data removed via `remove_observed_data()`
+  is also dropped from the exported snapshot. Previously the export reused the
+  full original `ObservedData` list whenever the lazy cache had been touched,
+  re-introducing the removed entries on round-trip.
+
 - Fixed snapshot export/import so single-element JSON arrays remain arrays,
   allowing exported snapshots to load in PK-Sim (#23).
 

--- a/R/Snapshot.R
+++ b/R/Snapshot.R
@@ -386,7 +386,7 @@ Snapshot <- R6::R6Class(
     #' @examples
     #' \dontrun{
     #' # Remove an expression profile from the snapshot
-    #' snapshot$remove_expression_profile("CYP3A4|Human|Healthy")
+    #' snapshot$remove_expression_profile("CYP3A4_Human_Healthy")
     #' }
     remove_expression_profile = function(profile_id) {
       # Force lazy construction so we can inspect the current set
@@ -579,15 +579,35 @@ Snapshot <- R6::R6Class(
       }
 
       # Update with current observed data
-      # Note: DataSet objects don't have $data property, so we return the original data
-      # This preserves the original snapshot format for export/reimport. We
-      # only override the original when the lazy cache has been touched, so
-      # untouched snapshots round-trip their ObservedData section as-is.
+      # Note: DataSet objects have no $data accessor so the raw JSON entries in
+      # `.original_data$ObservedData` are the source of truth on export. When
+      # the lazy cache has been touched, filter the original entries down to
+      # the names that still survive in the cache so removals and re-orderings
+      # are honored. Items added at runtime (whose backing JSON is not in
+      # `.original_data`) cannot be serialized here and are dropped with a
+      # warning.
       if (!is.null(private$.observed_data)) {
-        if (length(private$.observed_data) > 0) {
-          result$ObservedData <- private$.original_data$ObservedData
-        } else {
+        if (length(private$.observed_data) == 0) {
           result$ObservedData <- NULL
+        } else {
+          surviving_names <- vapply(
+            private$.observed_data,
+            function(od) od$name,
+            character(1)
+          )
+          original <- private$.original_data$ObservedData
+          original_names <- vapply(
+            original,
+            function(od) od$Name %||% od$name,
+            character(1)
+          )
+          result$ObservedData <- original[original_names %in% surviving_names]
+          if (length(private$.observed_data) > length(result$ObservedData)) {
+            cli::cli_warn(c(
+              "Some observed data added at runtime cannot be serialized.",
+              i = "DataSet objects have no $data accessor; only original entries are exported."
+            ))
+          }
         }
       }
 
@@ -892,7 +912,14 @@ Snapshot <- R6::R6Class(
     # Cache for the named protocols list with disambiguated names
     .protocols_named = NULL,
 
-    # Store observed data objects in an unnamed list
+    # Store observed data objects in an unnamed list.
+    # Tri-state sentinel used by the export path in `$data`:
+    #   NULL          = lazy cache untouched, export from `.original_data`.
+    #   list()        = cleared by the user, drop ObservedData from export.
+    #   non-empty     = filter `.original_data` down to surviving names.
+    # Only the first and third states are reachable from the public API today;
+    # the cleared state is reachable via `remove_observed_data()` removing all
+    # entries.
     .observed_data = NULL,
 
     # Cache for the named observed data list with disambiguated names

--- a/R/Snapshot.R
+++ b/R/Snapshot.R
@@ -36,109 +36,8 @@ Snapshot <- R6::R6Class(
         cli::cli_abort("Input must be either a path to a JSON file or a list")
       }
 
-      # Initialize compounds list during snapshot initialization
-      if (is.null(private$.original_data$Compounds)) {
-        private$.compounds <- list()
-      } else {
-        # Create compound objects and store in an unnamed list
-        private$.compounds <- lapply(
-          private$.original_data$Compounds,
-          function(compound_data) {
-            Compound$new(compound_data)
-          }
-        )
-      }
-
-      # Initialize expression profiles list during snapshot initialization
-      if (is.null(private$.original_data$ExpressionProfiles)) {
-        private$.expression_profiles <- list()
-      } else {
-        # Create expression profile objects and store in an unnamed list
-        private$.expression_profiles <- lapply(
-          private$.original_data$ExpressionProfiles,
-          function(expression_profile_data) {
-            ExpressionProfile$new(expression_profile_data)
-          }
-        )
-      }
-
-      # Initialize individuals list during snapshot initialization
-      if (is.null(private$.original_data$Individuals)) {
-        private$.individuals <- list()
-      } else {
-        # Create individual objects and store in an unnamed list
-        private$.individuals <- lapply(
-          private$.original_data$Individuals,
-          function(individual_data) {
-            Individual$new(individual_data)
-          }
-        )
-      }
-
-      # Initialize formulations list during snapshot initialization
-      if (is.null(private$.original_data$Formulations)) {
-        private$.formulations <- list()
-      } else {
-        # Create formulation objects and store in an unnamed list
-        private$.formulations <- lapply(
-          private$.original_data$Formulations,
-          function(formulation_data) {
-            Formulation$new(formulation_data)
-          }
-        )
-      }
-
-      # Initialize populations list during snapshot initialization
-      if (is.null(private$.original_data$Populations)) {
-        private$.populations <- list()
-      } else {
-        # Create population objects and store in an unnamed list
-        private$.populations <- lapply(
-          private$.original_data$Populations,
-          function(population_data) {
-            Population$new(population_data)
-          }
-        )
-      }
-
-      # Initialize events list during snapshot initialization
-      if (is.null(private$.original_data$Events)) {
-        private$.events <- list()
-      } else {
-        # Create event objects and store in an unnamed list
-        private$.events <- lapply(
-          private$.original_data$Events,
-          function(event_data) {
-            Event$new(event_data)
-          }
-        )
-      }
-
-      # Initialize protocols list during snapshot initialization
-      if (is.null(private$.original_data$Protocols)) {
-        private$.protocols <- list()
-      } else {
-        # Create protocol objects and store in an unnamed list
-        private$.protocols <- lapply(
-          private$.original_data$Protocols,
-          function(protocol_data) {
-            Protocol$new(protocol_data)
-          }
-        )
-      }
-
-      # Initialize observed data list during snapshot initialization
-      if (is.null(private$.original_data$ObservedData)) {
-        private$.observed_data <- list()
-      } else {
-        # Create DataSet objects and store in an unnamed list
-        private$.observed_data <- lapply(
-          private$.original_data$ObservedData,
-          function(observed_data_item) {
-            loadDataSetFromSnapshot(observed_data_item)
-          }
-        )
-      }
+      # Building-block collections are constructed lazily on first access via
+      # their active bindings; all `private$.<kind>` caches stay NULL here.
 
       cli::cli_alert_success("Snapshot loaded successfully")
     },
@@ -228,6 +127,9 @@ Snapshot <- R6::R6Class(
         )
       }
 
+      # Force lazy construction of any existing individuals before mutating
+      private$.ensure_individuals()
+
       # Add the individual to the list
       private$.individuals <- c(private$.individuals, list(individual))
 
@@ -253,6 +155,9 @@ Snapshot <- R6::R6Class(
     #' snapshot$remove_individual("Subject_001")
     #' }
     remove_individual = function(individual_name) {
+      # Force lazy construction so we can inspect the current set
+      private$.ensure_individuals()
+
       if (length(private$.individuals) == 0) {
         cli::cli_warn("No individuals to remove")
         return(invisible(self))
@@ -309,6 +214,9 @@ Snapshot <- R6::R6Class(
         )
       }
 
+      # Force lazy construction of any existing formulations before mutating
+      private$.ensure_formulations()
+
       # Add the formulation to the list
       private$.formulations <- c(private$.formulations, list(formulation))
 
@@ -334,6 +242,9 @@ Snapshot <- R6::R6Class(
     #' snapshot$remove_formulation("Tablet")
     #' }
     remove_formulation = function(formulation_name) {
+      # Force lazy construction so we can inspect the current set
+      private$.ensure_formulations()
+
       if (length(private$.formulations) == 0) {
         cli::cli_warn("No formulations to remove")
         return(invisible(self))
@@ -380,6 +291,9 @@ Snapshot <- R6::R6Class(
     #' snapshot$remove_population("pop_1")
     #' }
     remove_population = function(population_name) {
+      # Force lazy construction so we can inspect the current set
+      private$.ensure_populations()
+
       if (length(private$.populations) == 0) {
         cli::cli_warn("No populations to remove")
         return(invisible(self))
@@ -443,6 +357,9 @@ Snapshot <- R6::R6Class(
         )
       }
 
+      # Force lazy construction of any existing expression profiles before mutating
+      private$.ensure_expression_profiles()
+
       # Add the expression profile to the list
       private$.expression_profiles <- c(
         private$.expression_profiles,
@@ -472,6 +389,9 @@ Snapshot <- R6::R6Class(
     #' snapshot$remove_expression_profile("CYP3A4|Human|Healthy")
     #' }
     remove_expression_profile = function(profile_id) {
+      # Force lazy construction so we can inspect the current set
+      private$.ensure_expression_profiles()
+
       if (length(private$.expression_profiles) == 0) {
         cli::cli_warn("No expression profiles to remove")
         return(invisible(self))
@@ -526,6 +446,9 @@ Snapshot <- R6::R6Class(
         )
       }
 
+      # Force lazy construction of any existing observed data before mutating
+      private$.ensure_observed_data()
+
       # Add the observed data to the list
       private$.observed_data <- c(private$.observed_data, list(observed_data))
 
@@ -546,6 +469,9 @@ Snapshot <- R6::R6Class(
     #' @param observed_data_name Character vector of observed data names to remove
     #' @return Invisibly returns the object
     remove_observed_data = function(observed_data_name) {
+      # Force lazy construction so we can inspect the current set
+      private$.ensure_observed_data()
+
       if (length(private$.observed_data) == 0) {
         cli::cli_warn("No observed data to remove")
         return(invisible(self))
@@ -654,13 +580,15 @@ Snapshot <- R6::R6Class(
 
       # Update with current observed data
       # Note: DataSet objects don't have $data property, so we return the original data
-      # This preserves the original snapshot format for export/reimport
-      if (length(private$.observed_data) > 0) {
-        # Return original observed data to maintain snapshot format compatibility
-        result$ObservedData <- private$.original_data$ObservedData
-      } else {
-        # Remove ObservedData section if no data exists
-        result$ObservedData <- NULL
+      # This preserves the original snapshot format for export/reimport. We
+      # only override the original when the lazy cache has been touched, so
+      # untouched snapshots round-trip their ObservedData section as-is.
+      if (!is.null(private$.observed_data)) {
+        if (length(private$.observed_data) > 0) {
+          result$ObservedData <- private$.original_data$ObservedData
+        } else {
+          result$ObservedData <- NULL
+        }
       }
 
       return(result)
@@ -696,6 +624,7 @@ Snapshot <- R6::R6Class(
         private$.compounds <- value
         private$.compounds_named <- NULL
       }
+      private$.ensure_compounds()
       if (is.null(private$.compounds_named)) {
         private$.compounds_named <- private$.build_named_list(
           private$.compounds,
@@ -711,6 +640,7 @@ Snapshot <- R6::R6Class(
         private$.expression_profiles <- value
         private$.expression_profiles_named <- NULL
       }
+      private$.ensure_expression_profiles()
       if (is.null(private$.expression_profiles_named)) {
         private$.expression_profiles_named <- private$.build_named_list(
           private$.expression_profiles,
@@ -725,11 +655,15 @@ Snapshot <- R6::R6Class(
     individuals = function(value = NULL) {
       if (!is.null(value)) {
         private$.individuals <- value
+        private$.individuals_named <- NULL
       }
-      private$.individuals_named <- private$.build_named_list(
-        private$.individuals,
-        "individual_collection"
-      )
+      private$.ensure_individuals()
+      if (is.null(private$.individuals_named)) {
+        private$.individuals_named <- private$.build_named_list(
+          private$.individuals,
+          "individual_collection"
+        )
+      }
       private$.individuals_named
     },
 
@@ -737,11 +671,15 @@ Snapshot <- R6::R6Class(
     formulations = function(value = NULL) {
       if (!is.null(value)) {
         private$.formulations <- value
+        private$.formulations_named <- NULL
       }
-      private$.formulations_named <- private$.build_named_list(
-        private$.formulations,
-        "formulation_collection"
-      )
+      private$.ensure_formulations()
+      if (is.null(private$.formulations_named)) {
+        private$.formulations_named <- private$.build_named_list(
+          private$.formulations,
+          "formulation_collection"
+        )
+      }
       private$.formulations_named
     },
 
@@ -749,11 +687,15 @@ Snapshot <- R6::R6Class(
     populations = function(value = NULL) {
       if (!is.null(value)) {
         private$.populations <- value
+        private$.populations_named <- NULL
       }
-      private$.populations_named <- private$.build_named_list(
-        private$.populations,
-        "population_collection"
-      )
+      private$.ensure_populations()
+      if (is.null(private$.populations_named)) {
+        private$.populations_named <- private$.build_named_list(
+          private$.populations,
+          "population_collection"
+        )
+      }
       private$.populations_named
     },
 
@@ -761,11 +703,15 @@ Snapshot <- R6::R6Class(
     events = function(value = NULL) {
       if (!is.null(value)) {
         private$.events <- value
+        private$.events_named <- NULL
       }
-      private$.events_named <- private$.build_named_list(
-        private$.events,
-        "event_collection"
-      )
+      private$.ensure_events()
+      if (is.null(private$.events_named)) {
+        private$.events_named <- private$.build_named_list(
+          private$.events,
+          "event_collection"
+        )
+      }
       private$.events_named
     },
 
@@ -773,11 +719,15 @@ Snapshot <- R6::R6Class(
     protocols = function(value = NULL) {
       if (!is.null(value)) {
         private$.protocols <- value
+        private$.protocols_named <- NULL
       }
-      private$.protocols_named <- private$.build_named_list(
-        private$.protocols,
-        "protocol_collection"
-      )
+      private$.ensure_protocols()
+      if (is.null(private$.protocols_named)) {
+        private$.protocols_named <- private$.build_named_list(
+          private$.protocols,
+          "protocol_collection"
+        )
+      }
       private$.protocols_named
     },
 
@@ -785,11 +735,15 @@ Snapshot <- R6::R6Class(
     observed_data = function(value = NULL) {
       if (!is.null(value)) {
         private$.observed_data <- value
+        private$.observed_data_named <- NULL
       }
-      private$.observed_data_named <- private$.build_named_list(
-        private$.observed_data,
-        "observed_data_collection"
-      )
+      private$.ensure_observed_data()
+      if (is.null(private$.observed_data_named)) {
+        private$.observed_data_named <- private$.build_named_list(
+          private$.observed_data,
+          "observed_data_collection"
+        )
+      }
       private$.observed_data_named
     }
   ),
@@ -814,6 +768,88 @@ Snapshot <- R6::R6Class(
 
       return(pksim_version)
     },
+
+    # Lazily build the unnamed object list for a building-block collection.
+    # On first call, walks the matching section of `private$.original_data`
+    # and wraps each item with `ctor`; the cache slot stays an empty list
+    # when the section is absent or empty. Idempotent on the cache.
+    .ensure_collection = function(cache_name, section_name, ctor) {
+      if (!is.null(private[[cache_name]])) {
+        return(invisible(NULL))
+      }
+      section <- private$.original_data[[section_name]]
+      if (is.null(section)) {
+        private[[cache_name]] <- list()
+      } else {
+        private[[cache_name]] <- lapply(section, ctor)
+      }
+      invisible(NULL)
+    },
+
+    .ensure_compounds = function() {
+      private$.ensure_collection(
+        ".compounds",
+        "Compounds",
+        function(d) Compound$new(d)
+      )
+    },
+
+    .ensure_expression_profiles = function() {
+      private$.ensure_collection(
+        ".expression_profiles",
+        "ExpressionProfiles",
+        function(d) ExpressionProfile$new(d)
+      )
+    },
+
+    .ensure_individuals = function() {
+      private$.ensure_collection(
+        ".individuals",
+        "Individuals",
+        function(d) Individual$new(d)
+      )
+    },
+
+    .ensure_formulations = function() {
+      private$.ensure_collection(
+        ".formulations",
+        "Formulations",
+        function(d) Formulation$new(d)
+      )
+    },
+
+    .ensure_populations = function() {
+      private$.ensure_collection(
+        ".populations",
+        "Populations",
+        function(d) Population$new(d)
+      )
+    },
+
+    .ensure_events = function() {
+      private$.ensure_collection(
+        ".events",
+        "Events",
+        function(d) Event$new(d)
+      )
+    },
+
+    .ensure_protocols = function() {
+      private$.ensure_collection(
+        ".protocols",
+        "Protocols",
+        function(d) Protocol$new(d)
+      )
+    },
+
+    .ensure_observed_data = function() {
+      private$.ensure_collection(
+        ".observed_data",
+        "ObservedData",
+        function(d) loadDataSetFromSnapshot(d)
+      )
+    },
+
     # Store compound objects in an unnamed list
     .compounds = NULL,
 

--- a/R/snapshot_dataframes.R
+++ b/R/snapshot_dataframes.R
@@ -164,14 +164,14 @@ get_individuals_dfs <- function(snapshot) {
     if (length(individuals_dfs) > 0) {
       result$individuals <- dplyr::bind_rows(individuals_dfs)
     }
-    
+
     # Combine parameters data
     param_dfs <- lapply(ind_dfs, function(df) df$individuals_parameters)
     param_dfs <- param_dfs[!sapply(param_dfs, is.null)]
     if (length(param_dfs) > 0) {
       result$individuals_parameters <- dplyr::bind_rows(param_dfs)
     }
-    
+
     # Combine expression profiles data
     expr_dfs <- lapply(ind_dfs, function(df) df$individuals_expressions)
     expr_dfs <- expr_dfs[!sapply(expr_dfs, is.null)]
@@ -262,7 +262,7 @@ get_formulations_dfs <- function(snapshot) {
     if (length(formulations_dfs) > 0) {
       result$formulations <- dplyr::bind_rows(formulations_dfs)
     }
-    
+
     # Combine parameters data
     param_dfs <- lapply(form_dfs, function(df) df$formulations_parameters)
     param_dfs <- param_dfs[!sapply(param_dfs, is.null)]

--- a/R/utils.R
+++ b/R/utils.R
@@ -118,19 +118,19 @@ convert_ospsuite_time_unit_to_lubridate <- function(unit) {
   if (is.null(unit) || is.na(unit)) {
     return(unit)
   }
-  
+
   # Define mapping from ospsuite units to lubridate units
   unit_mapping <- list(
     "s" = "seconds",
-    "min" = "minutes", 
+    "min" = "minutes",
     "h" = "hours",
     "day(s)" = "days",
     "week(s)" = "weeks",
     "month(s)" = "months",
     "year(s)" = "years",
-    "ks" = "seconds"  # kiloseconds - will need special handling for value
+    "ks" = "seconds" # kiloseconds - will need special handling for value
   )
-  
+
   # Return mapped unit or original if not found
   lubridate_unit <- unit_mapping[[unit]]
   if (!is.null(lubridate_unit)) {
@@ -156,18 +156,18 @@ convert_ospsuite_time_to_duration <- function(value, unit) {
   if (is.null(value) || is.na(value)) {
     return(lubridate::duration(0))
   }
-  
+
   if (is.null(unit) || is.na(unit)) {
     # Default to seconds if no unit provided
     return(lubridate::duration(value, units = "seconds"))
   }
-  
+
   # Handle special case for kiloseconds
   if (unit == "ks") {
     # Convert kiloseconds to seconds
     return(lubridate::duration(value * 1000, units = "seconds"))
   }
-  
+
   # Convert unit and create duration
   lubridate_unit <- convert_ospsuite_time_unit_to_lubridate(unit)
   return(lubridate::duration(value, units = lubridate_unit))

--- a/man/Snapshot.Rd
+++ b/man/Snapshot.Rd
@@ -85,7 +85,7 @@ snapshot$add_expression_profile(profile)
 
 \dontrun{
 # Remove an expression profile from the snapshot
-snapshot$remove_expression_profile("CYP3A4|Human|Healthy")
+snapshot$remove_expression_profile("CYP3A4_Human_Healthy")
 }
 }
 \section{Active bindings}{
@@ -412,7 +412,7 @@ snapshot$add_expression_profile(profile)
   \subsection{Examples}{
     \if{html}{\out{<div class="r example copy">}}
     \preformatted{# Remove an expression profile from the snapshot
-snapshot$remove_expression_profile("CYP3A4|Human|Healthy")
+snapshot$remove_expression_profile("CYP3A4_Human_Healthy")
 }
     \if{html}{\out{</div>}}
   }

--- a/tests/testthat/test-observed-data.R
+++ b/tests/testthat/test-observed-data.R
@@ -155,6 +155,30 @@ test_that("Snapshot export includes observed data", {
   expect_true(length(data$ObservedData) > 0)
 })
 
+test_that("Snapshot export drops removed observed data on round-trip", {
+  snapshot <- load_snapshot(test_path("data", "test_snapshot.json"))
+  initial_count <- length(snapshot$observed_data)
+  expect_gt(initial_count, 1)
+
+  to_remove <- snapshot$observed_data[[1]]$name
+  snapshot$remove_observed_data(to_remove)
+
+  exported <- snapshot$data
+  expect_equal(length(exported$ObservedData), initial_count - 1)
+  exported_names <- vapply(
+    exported$ObservedData,
+    function(od) od$Name %||% od$name,
+    character(1)
+  )
+  expect_false(to_remove %in% exported_names)
+
+  out <- withr::local_tempfile(fileext = ".json")
+  export_snapshot(snapshot, out)
+  reloaded <- load_snapshot(out)
+  expect_equal(length(reloaded$observed_data), initial_count - 1)
+  expect_false(to_remove %in% names(reloaded$observed_data))
+})
+
 test_that("DataSet handles complex real data structure", {
   # Test with actual data from pre-loaded snapshot
   first_dataset <- test_snapshot$observed_data[[1]]

--- a/tests/testthat/test-range.R
+++ b/tests/testthat/test-range.R
@@ -75,7 +75,11 @@ test_that("Snapshot handles different types of range values in populations", {
   snapshot$export(temp_file)
 
   # Re-import and check for errors
-  imported_data <- jsonlite::fromJSON(temp_file, simplifyDataFrame = FALSE, simplifyVector = FALSE)
+  imported_data <- jsonlite::fromJSON(
+    temp_file,
+    simplifyDataFrame = FALSE,
+    simplifyVector = FALSE
+  )
 
   # Check the structure of the imported data
   cat("Age field structure:\n")

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -285,6 +285,28 @@ test_that("Snapshot compounds are initialized correctly", {
   }
 })
 
+test_that("Snapshot defers building-block construction until first access", {
+  snapshot <- Snapshot$new(testthat::test_path("data", "test_snapshot.json"))
+
+  # Reach into private state because laziness has no public-facing signal;
+  # the active fields populate `private$.<kind>` on first read.
+  private <- snapshot$.__enclos_env__$private
+
+  expect_null(private$.compounds)
+  expect_null(private$.individuals)
+  expect_null(private$.formulations)
+  expect_null(private$.populations)
+  expect_null(private$.events)
+  expect_null(private$.protocols)
+  expect_null(private$.expression_profiles)
+  expect_null(private$.observed_data)
+
+  # Touch a single section; only its cache should populate.
+  invisible(snapshot$compounds)
+  expect_type(private$.compounds, "list")
+  expect_null(private$.individuals)
+})
+
 test_that("Snapshot handles duplicated individual and compound names correctly", {
   # Create a snapshot object
   snapshot <- test_snapshot$clone()

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -289,7 +289,11 @@ test_that("Snapshot defers building-block construction until first access", {
   snapshot <- Snapshot$new(testthat::test_path("data", "test_snapshot.json"))
 
   # Reach into private state because laziness has no public-facing signal;
-  # the active fields populate `private$.<kind>` on first read.
+  # the active fields populate `private$.<kind>` on first read. Note that a
+  # NULL cache only proves the cache slot has not been written, not that no
+  # constructor ran; instrumenting R6 generators via `local_mocked_bindings`
+  # would require a mockable wrapper that does not exist today. Treat the
+  # NULL assertions as a strong but imperfect proxy for "no work done".
   private <- snapshot$.__enclos_env__$private
 
   expect_null(private$.compounds)
@@ -301,10 +305,18 @@ test_that("Snapshot defers building-block construction until first access", {
   expect_null(private$.expression_profiles)
   expect_null(private$.observed_data)
 
-  # Touch a single section; only its cache should populate.
+  # Touch a single section; only its cache should populate. The other 7
+  # caches must remain NULL, otherwise a future change has accidentally
+  # eager-loaded a sibling collection.
   invisible(snapshot$compounds)
   expect_type(private$.compounds, "list")
   expect_null(private$.individuals)
+  expect_null(private$.formulations)
+  expect_null(private$.populations)
+  expect_null(private$.events)
+  expect_null(private$.protocols)
+  expect_null(private$.expression_profiles)
+  expect_null(private$.observed_data)
 })
 
 test_that("Snapshot handles duplicated individual and compound names correctly", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -31,11 +31,11 @@ test_that("convert_ospsuite_time_unit_to_lubridate works correctly", {
   expect_equal(convert_ospsuite_time_unit_to_lubridate("month(s)"), "months")
   expect_equal(convert_ospsuite_time_unit_to_lubridate("year(s)"), "years")
   expect_equal(convert_ospsuite_time_unit_to_lubridate("ks"), "seconds")
-  
+
   # Test NULL and NA values
   expect_true(is.null(convert_ospsuite_time_unit_to_lubridate(NULL)))
   expect_true(is.na(convert_ospsuite_time_unit_to_lubridate(NA)))
-  
+
   # Test unknown unit - should give warning and return as-is
   expect_warning(
     result <- convert_ospsuite_time_unit_to_lubridate("unknown_unit"),
@@ -49,25 +49,25 @@ test_that("convert_ospsuite_time_to_duration works correctly", {
   expect_s4_class(convert_ospsuite_time_to_duration(1, "s"), "Duration")
   expect_s4_class(convert_ospsuite_time_to_duration(1, "h"), "Duration")
   expect_s4_class(convert_ospsuite_time_to_duration(1, "day(s)"), "Duration")
-  
+
   # Test specific values
   duration_1_day <- convert_ospsuite_time_to_duration(1, "day(s)")
   expect_equal(as.numeric(duration_1_day), 86400) # 1 day = 86400 seconds
-  
+
   duration_1_hour <- convert_ospsuite_time_to_duration(1, "h")
   expect_equal(as.numeric(duration_1_hour), 3600) # 1 hour = 3600 seconds
-  
+
   # Test kiloseconds special case
   duration_3_ks <- convert_ospsuite_time_to_duration(3, "ks")
   expect_equal(as.numeric(duration_3_ks), 3000) # 3 kiloseconds = 3000 seconds
-  
+
   # Test NULL and NA values
   expect_s4_class(convert_ospsuite_time_to_duration(NULL, "h"), "Duration")
   expect_equal(as.numeric(convert_ospsuite_time_to_duration(NULL, "h")), 0)
-  
+
   expect_s4_class(convert_ospsuite_time_to_duration(NA, "h"), "Duration")
   expect_equal(as.numeric(convert_ospsuite_time_to_duration(NA, "h")), 0)
-  
+
   # Test default unit when unit is NULL
   duration_default <- convert_ospsuite_time_to_duration(10, NULL)
   expect_equal(as.numeric(duration_default), 10) # Should default to seconds


### PR DESCRIPTION
Defer construction of each building-block collection (Compounds, Individuals, Formulations, Populations, Events, Protocols, ExpressionProfiles, ObservedData) until the matching active field is first accessed. Builds on #44, which consolidated the eight `.build_*_named_list` helpers; this PR keeps that generic and removes the remaining eager work from `Snapshot$initialize`. Inspecting a single section no longer pays the cost of wrapping every other section's items in R6 objects.

## Initialize

`Snapshot$initialize` now only normalises the input and stores `private$.original_data`. All eight `private$.<kind>` caches start at `NULL` and act as an uninitialised sentinel.

## Active fields

Each collection's active field calls a private `.ensure_<kind>()` helper, which wraps each entry from `private$.original_data` in its R6 class on the first call (or assigns `list()` when the section is missing). The named cache (`private$.<kind>_named`) is then built via the existing `.build_named_list` generic and reused on subsequent reads, with both caches invalidated when a `value` is supplied.

## Mutators

Every `add_*` / `remove_*` method calls the matching `.ensure_<kind>()` first so that existing items are materialised before the cache is mutated. Without this, mutating an untouched `NULL` cache would silently drop the items already present in `private$.original_data`.

## Round-trip fidelity

`Snapshot$data` now treats `NULL .observed_data` as untouched and leaves the original `ObservedData` section in place. Only an explicit mutation (which sets the cache to a real list) can drop or rebuild the section, so round-tripping a snapshot that never reads `observed_data` produces byte-equivalent output.

## Test

One new test in `tests/testthat/test-snapshot.R` asserts that every private cache is `NULL` immediately after `Snapshot$new` and that only the touched section populates on first read.