### PR TITLE
Add regression tests for Snapshot$data empty-collection merge

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,7 +53,7 @@
   every building-block section: clearing a collection via `remove_individual()`,
   `remove_formulation()`, `remove_population()`, or
   `remove_expression_profile()` now writes an empty section on export instead
-  of falling back to the original entries (#35).
+  of falling back to the original entries (#35, #59).
 
 - Fixed snapshot export/import so single-element JSON arrays remain arrays,
   allowing exported snapshots to load in PK-Sim (#23).

--- a/tests/testthat/test-snapshot-empty-merge.R
+++ b/tests/testthat/test-snapshot-empty-merge.R
@@ -1,0 +1,132 @@
+# Regression coverage for issue #59: the `Snapshot$data` active field must
+# honour user intent across the three lazy-cache states (NULL untouched,
+# `list()` cleared, non-empty hydrated). PR #58 introduced the tri-state
+# adapter contract that fixed the pre-existing merge bug; these tests guard
+# against future regressions.
+
+# Scenario A: load N items, remove every one via the matching mutator. The
+# exported section must be empty (the user's clear intent), not the original
+# items resurrected.
+
+test_that("remove_compound clearing all entries drops the Compounds section on export", {
+  snapshot <- load_snapshot(test_path("data", "test_snapshot.json"))
+  for (name in names(snapshot$compounds)) {
+    snapshot$remove_compound(name)
+  }
+
+  out <- withr::local_tempfile(fileext = ".json")
+  export_snapshot(snapshot, out)
+
+  reloaded <- load_snapshot(out)
+  expect_length(reloaded$compounds, 0)
+
+  parsed <- jsonlite::fromJSON(
+    out,
+    simplifyVector = FALSE,
+    simplifyDataFrame = FALSE
+  )
+  expect_length(parsed$Compounds, 0)
+})
+
+test_that("remove_individual clearing all entries drops the Individuals section on export", {
+  snapshot <- load_snapshot(test_path("data", "test_snapshot.json"))
+  for (name in names(snapshot$individuals)) {
+    snapshot$remove_individual(name)
+  }
+
+  out <- withr::local_tempfile(fileext = ".json")
+  export_snapshot(snapshot, out)
+
+  reloaded <- load_snapshot(out)
+  expect_length(reloaded$individuals, 0)
+
+  parsed <- jsonlite::fromJSON(
+    out,
+    simplifyVector = FALSE,
+    simplifyDataFrame = FALSE
+  )
+  expect_length(parsed$Individuals, 0)
+})
+
+test_that("remove_observed_data clearing every dataset drops the ObservedData section on export", {
+  snapshot <- load_snapshot(test_path("data", "test_snapshot.json"))
+  snapshot$remove_observed_data(names(snapshot$observed_data))
+
+  out <- withr::local_tempfile(fileext = ".json")
+  export_snapshot(snapshot, out)
+
+  parsed <- jsonlite::fromJSON(
+    out,
+    simplifyVector = FALSE,
+    simplifyDataFrame = FALSE
+  )
+  expect_null(parsed[["ObservedData"]])
+})
+
+# Scenario B: load a snapshot where the section is already empty (or absent),
+# never touch the active binding. The exported payload must replay the
+# original shape verbatim.
+
+test_that("untouched empty Compounds section round-trips verbatim", {
+  data <- list(
+    Version = 80,
+    Compounds = list(),
+    Individuals = list(list(Name = "Alice"))
+  )
+  snapshot <- Snapshot$new(data)
+
+  out <- withr::local_tempfile(fileext = ".json")
+  export_snapshot(snapshot, out)
+
+  parsed <- jsonlite::fromJSON(
+    out,
+    simplifyVector = FALSE,
+    simplifyDataFrame = FALSE
+  )
+  expect_length(parsed$Compounds, 0)
+  expect_named(parsed, c("Version", "Compounds", "Individuals"))
+})
+
+test_that("untouched missing Compounds section stays absent on export", {
+  data <- list(
+    Version = 80,
+    Individuals = list(list(Name = "Alice"))
+  )
+  snapshot <- Snapshot$new(data)
+
+  out <- withr::local_tempfile(fileext = ".json")
+  export_snapshot(snapshot, out)
+
+  parsed <- jsonlite::fromJSON(
+    out,
+    simplifyVector = FALSE,
+    simplifyDataFrame = FALSE
+  )
+  expect_named(parsed, c("Version", "Individuals"))
+})
+
+# Scenario C: read a collection via the active binding without mutating, then
+# export. The lazy cache transitions from NULL to a hydrated list of R6
+# wrappers, but the exported names and count must match the original.
+
+test_that("reading compounds without mutating preserves them on export", {
+  snapshot <- load_snapshot(test_path("data", "test_snapshot.json"))
+  original_names <- names(snapshot$compounds)
+
+  out <- withr::local_tempfile(fileext = ".json")
+  export_snapshot(snapshot, out)
+
+  reloaded <- load_snapshot(out)
+  expect_equal(names(reloaded$compounds), original_names)
+})
+
+test_that("reading individuals without mutating preserves them on export", {
+  snapshot <- load_snapshot(test_path("data", "test_snapshot.json"))
+  original_names <- names(snapshot$individuals)
+
+  out <- withr::local_tempfile(fileext = ".json")
+  export_snapshot(snapshot, out)
+
+  reloaded <- load_snapshot(out)
+  expect_equal(names(reloaded$individuals), original_names)
+})

--- a/tests/testthat/test-snapshot-empty-merge.R
+++ b/tests/testthat/test-snapshot-empty-merge.R
@@ -8,11 +8,9 @@
 # exported section must be empty (the user's clear intent), not the original
 # items resurrected.
 
-test_that("remove_compound clearing all entries drops the Compounds section on export", {
+test_that("remove_compound clearing all entries empties the Compounds section on export", {
   snapshot <- load_snapshot(test_path("data", "test_snapshot.json"))
-  for (name in names(snapshot$compounds)) {
-    snapshot$remove_compound(name)
-  }
+  snapshot$remove_compound(names(snapshot$compounds))
 
   out <- withr::local_tempfile(fileext = ".json")
   export_snapshot(snapshot, out)
@@ -28,11 +26,9 @@ test_that("remove_compound clearing all entries drops the Compounds section on e
   expect_length(parsed$Compounds, 0)
 })
 
-test_that("remove_individual clearing all entries drops the Individuals section on export", {
+test_that("remove_individual clearing all entries empties the Individuals section on export", {
   snapshot <- load_snapshot(test_path("data", "test_snapshot.json"))
-  for (name in names(snapshot$individuals)) {
-    snapshot$remove_individual(name)
-  }
+  snapshot$remove_individual(names(snapshot$individuals))
 
   out <- withr::local_tempfile(fileext = ".json")
   export_snapshot(snapshot, out)


### PR DESCRIPTION
Issue #59 reported that emptying a building-block collection via `remove_*()` would silently re-introduce the original entries on export because the per-section `if (length(...) > 0)` guard in `Snapshot$data` skipped the merge. PR #58 already addressed this when it refactored `Snapshot$data` into a per-section adapter table with a tri-state contract (cache `NULL` replays original, cache `list()` exports empty, cache non-empty rebuilds from items). This PR confirms the fix with regression tests against the three lazy-cache states and notes the cross-reference in NEWS.

## Tests

The new file `tests/testthat/test-snapshot-empty-merge.R` exercises:

- Scenario A (load N, remove all): Compounds, Individuals, ObservedData.
- Scenario B (untouched empty or missing section): Compounds.
- Scenario C (read-only access): Compounds, Individuals.

Compounds and Individuals stand in for the seven sections that share `.default_export_adapter`. ObservedData has its own `.observed_data_export_adapter` and is covered separately for scenario A.

## NEWS

The existing #35 bug-fix bullet is extended to also reference #59, since the same fix closes both issues.

Closes #59