### PR TITLE
Fix remove_*() count reporting (#66)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,8 @@
 
 ## Bug fixes
 
+- `remove_expression_profile()` and `remove_observed_data()` now report the actual number of entries removed instead of the length of the input vector, so the success message reads correctly when a requested name is not present in the snapshot (#66).
+
 - Fixed `Snapshot$data` so observed data removed via `remove_observed_data()`
   is also dropped from the exported snapshot. Previously the export reused the
   full original `ObservedData` list whenever the lazy cache had been touched,

--- a/NEWS.md
+++ b/NEWS.md
@@ -49,7 +49,7 @@
 
 ## Bug fixes
 
-- `remove_expression_profile()` and `remove_observed_data()` now report the actual number of entries removed instead of the length of the input vector, so the success message reads correctly when a requested name is not present in the snapshot (#66).
+- `remove_expression_profile()`, `remove_formulation()`, `remove_individual()`, `remove_observed_data()`, and `remove_population()` now report the actual number of entries removed instead of the length of the input vector, so the success message reads correctly when a requested name is not present in the snapshot (#66).
 
 - Fixed `Snapshot$data` so observed data removed via `remove_observed_data()`
   is also dropped from the exported snapshot. Previously the export reused the

--- a/R/Snapshot.R
+++ b/R/Snapshot.R
@@ -227,12 +227,8 @@ Snapshot <- R6::R6Class(
 
       # Remove the requested individuals
       keep_indices <- which(!(current_names %in% individual_name))
-
-      if (length(keep_indices) == 0) {
-        private$.individuals <- list()
-      } else {
-        private$.individuals <- private$.individuals[keep_indices]
-      }
+      num_removed <- length(private$.individuals) - length(keep_indices)
+      private$.individuals <- private$.individuals[keep_indices]
 
       # Reset the named list
       private$.individuals_named <- private$.build_named_list(
@@ -241,7 +237,7 @@ Snapshot <- R6::R6Class(
       )
 
       cli::cli_alert_success(
-        "Removed {length(individual_name)} individual(s)"
+        "Removed {num_removed} individual(s)"
       )
       invisible(self)
     },
@@ -314,12 +310,8 @@ Snapshot <- R6::R6Class(
 
       # Remove the requested formulations
       keep_indices <- which(!(current_names %in% formulation_name))
-
-      if (length(keep_indices) == 0) {
-        private$.formulations <- list()
-      } else {
-        private$.formulations <- private$.formulations[keep_indices]
-      }
+      num_removed <- length(private$.formulations) - length(keep_indices)
+      private$.formulations <- private$.formulations[keep_indices]
 
       # Reset the named list
       private$.formulations_named <- private$.build_named_list(
@@ -328,7 +320,7 @@ Snapshot <- R6::R6Class(
       )
 
       cli::cli_alert_success(
-        "Removed {length(formulation_name)} formulation(s)"
+        "Removed {num_removed} formulation(s)"
       )
       invisible(self)
     },
@@ -363,12 +355,8 @@ Snapshot <- R6::R6Class(
 
       # Remove the requested populations
       keep_indices <- which(!(current_names %in% population_name))
-
-      if (length(keep_indices) == 0) {
-        private$.populations <- list()
-      } else {
-        private$.populations <- private$.populations[keep_indices]
-      }
+      num_removed <- length(private$.populations) - length(keep_indices)
+      private$.populations <- private$.populations[keep_indices]
 
       # Reset the named list
       private$.populations_named <- private$.build_named_list(
@@ -377,7 +365,7 @@ Snapshot <- R6::R6Class(
       )
 
       cli::cli_alert_success(
-        "Removed {length(population_name)} population(s)"
+        "Removed {num_removed} population(s)"
       )
       invisible(self)
     },

--- a/R/Snapshot.R
+++ b/R/Snapshot.R
@@ -464,14 +464,11 @@ Snapshot <- R6::R6Class(
 
       # Remove the requested expression profiles
       keep_indices <- which(!(current_ids %in% profile_id))
-
-      if (length(keep_indices) == 0) {
-        private$.expression_profiles <- list()
-      } else {
-        private$.expression_profiles <- private$.expression_profiles[
-          keep_indices
-        ]
-      }
+      num_removed <- length(private$.expression_profiles) -
+        length(keep_indices)
+      private$.expression_profiles <- private$.expression_profiles[
+        keep_indices
+      ]
 
       # Reset the named list
       private$.expression_profiles_named <- private$.build_named_list(
@@ -481,7 +478,7 @@ Snapshot <- R6::R6Class(
       )
 
       cli::cli_alert_success(
-        "Removed {length(profile_id)} expression profile(s)"
+        "Removed {num_removed} expression profile(s)"
       )
       invisible(self)
     },
@@ -621,12 +618,8 @@ Snapshot <- R6::R6Class(
 
       # Remove the requested observed data
       keep_indices <- which(!(current_names %in% observed_data_name))
-
-      if (length(keep_indices) == 0) {
-        private$.observed_data <- list()
-      } else {
-        private$.observed_data <- private$.observed_data[keep_indices]
-      }
+      num_removed <- length(private$.observed_data) - length(keep_indices)
+      private$.observed_data <- private$.observed_data[keep_indices]
 
       # Reset the named list
       private$.observed_data_named <- private$.build_named_list(
@@ -635,7 +628,7 @@ Snapshot <- R6::R6Class(
       )
 
       cli::cli_alert_success(
-        "Removed {length(observed_data_name)} observed data item(s)"
+        "Removed {num_removed} observed data item(s)"
       )
       invisible(self)
     },

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -164,6 +164,42 @@
       Warning:
       No events to remove
 
+# remove_observed_data warns when name is missing
+
+    Code
+      remove_observed_data(snapshot, "Other")
+    Condition
+      Warning:
+      Observed data 'Other' not found in snapshot
+    Message
+      v Removed 0 observed data item(s)
+
+# remove_observed_data warns on empty collection
+
+    Code
+      remove_observed_data(snapshot, "Study A")
+    Condition
+      Warning:
+      No observed data to remove
+
+# remove_expression_profile warns when id is missing
+
+    Code
+      remove_expression_profile(snapshot, "Other|Human|Healthy")
+    Condition
+      Warning:
+      Expression profile 'Other|Human|Healthy' not found in snapshot
+    Message
+      v Removed 0 expression profile(s)
+
+# remove_expression_profile warns on empty collection
+
+    Code
+      remove_expression_profile(snapshot, "CYP3A4|Human|Healthy")
+    Condition
+      Warning:
+      No expression profiles to remove
+
 # add_observed_data exported wrapper errors on wrong class
 
     Code

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -164,6 +164,70 @@
       Warning:
       No events to remove
 
+# remove_individual warns when name is missing
+
+    Code
+      remove_individual(snapshot, "Other")
+    Condition
+      Warning:
+      Individual 'Other' not found in snapshot
+    Message
+      v Removed 0 individual(s)
+
+# remove_individual warns on empty collection
+
+    Code
+      remove_individual(snapshot, "Subject_001")
+    Condition
+      Warning:
+      No individuals to remove
+
+# remove_individual reports the actual count when some names are missing
+
+    Code
+      remove_individual(snapshot, c(existing, "Other"))
+    Condition
+      Warning:
+      Individual 'Other' not found in snapshot
+    Message
+      v Removed 1 individual(s)
+
+# remove_formulation warns when name is missing
+
+    Code
+      remove_formulation(snapshot, "Other")
+    Condition
+      Warning:
+      Formulation 'Other' not found in snapshot
+    Message
+      v Removed 0 formulation(s)
+
+# remove_formulation warns on empty collection
+
+    Code
+      remove_formulation(snapshot, "Tablet")
+    Condition
+      Warning:
+      No formulations to remove
+
+# remove_population warns when name is missing
+
+    Code
+      remove_population(snapshot, "Other")
+    Condition
+      Warning:
+      Population 'Other' not found in snapshot
+    Message
+      v Removed 0 population(s)
+
+# remove_population warns on empty collection
+
+    Code
+      remove_population(snapshot, "pop_1")
+    Condition
+      Warning:
+      No populations to remove
+
 # remove_observed_data warns when name is missing
 
     Code
@@ -181,6 +245,16 @@
     Condition
       Warning:
       No observed data to remove
+
+# remove_observed_data reports the actual count when some names are missing
+
+    Code
+      remove_observed_data(snapshot, c(dataset$name, "Other"))
+    Condition
+      Warning:
+      Observed data 'Other' not found in snapshot
+    Message
+      v Removed 1 observed data item(s)
 
 # remove_expression_profile warns when id is missing
 

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -944,6 +944,30 @@ test_that("remove_event warns on empty collection", {
   expect_snapshot(remove_event(snapshot, "Breakfast"))
 })
 
+test_that("remove_observed_data warns when name is missing", {
+  source_snapshot <- load_snapshot(test_path("data", "test_snapshot.json"))
+  dataset <- source_snapshot$observed_data[[1]]
+
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+  snapshot <- suppressWarnings(add_observed_data(snapshot, dataset))
+  expect_snapshot(remove_observed_data(snapshot, "Other"))
+})
+
+test_that("remove_observed_data warns on empty collection", {
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+  expect_snapshot(remove_observed_data(snapshot, "Study A"))
+})
+
+test_that("remove_expression_profile warns when id is missing", {
+  snapshot <- load_snapshot(test_path("data", "test_snapshot.json"))
+  expect_snapshot(remove_expression_profile(snapshot, "Other|Human|Healthy"))
+})
+
+test_that("remove_expression_profile warns on empty collection", {
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+  expect_snapshot(remove_expression_profile(snapshot, "CYP3A4|Human|Healthy"))
+})
+
 test_that("add_observed_data exported wrapper round-trips", {
   source_snapshot <- load_snapshot(test_path("data", "test_snapshot.json"))
   dataset <- source_snapshot$observed_data[[1]]

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -944,6 +944,42 @@ test_that("remove_event warns on empty collection", {
   expect_snapshot(remove_event(snapshot, "Breakfast"))
 })
 
+test_that("remove_individual warns when name is missing", {
+  snapshot <- load_snapshot(test_path("data", "test_snapshot.json"))
+  expect_snapshot(remove_individual(snapshot, "Other"))
+})
+
+test_that("remove_individual warns on empty collection", {
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+  expect_snapshot(remove_individual(snapshot, "Subject_001"))
+})
+
+test_that("remove_individual reports the actual count when some names are missing", {
+  snapshot <- load_snapshot(test_path("data", "test_snapshot.json"))
+  existing <- names(snapshot$individuals)[[1]]
+  expect_snapshot(remove_individual(snapshot, c(existing, "Other")))
+})
+
+test_that("remove_formulation warns when name is missing", {
+  snapshot <- load_snapshot(test_path("data", "test_snapshot.json"))
+  expect_snapshot(remove_formulation(snapshot, "Other"))
+})
+
+test_that("remove_formulation warns on empty collection", {
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+  expect_snapshot(remove_formulation(snapshot, "Tablet"))
+})
+
+test_that("remove_population warns when name is missing", {
+  snapshot <- load_snapshot(test_path("data", "test_snapshot.json"))
+  expect_snapshot(remove_population(snapshot, "Other"))
+})
+
+test_that("remove_population warns on empty collection", {
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+  expect_snapshot(remove_population(snapshot, "pop_1"))
+})
+
 test_that("remove_observed_data warns when name is missing", {
   source_snapshot <- load_snapshot(test_path("data", "test_snapshot.json"))
   dataset <- source_snapshot$observed_data[[1]]
@@ -956,6 +992,15 @@ test_that("remove_observed_data warns when name is missing", {
 test_that("remove_observed_data warns on empty collection", {
   snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
   expect_snapshot(remove_observed_data(snapshot, "Study A"))
+})
+
+test_that("remove_observed_data reports the actual count when some names are missing", {
+  source_snapshot <- load_snapshot(test_path("data", "test_snapshot.json"))
+  dataset <- source_snapshot$observed_data[[1]]
+
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+  snapshot <- suppressWarnings(add_observed_data(snapshot, dataset))
+  expect_snapshot(remove_observed_data(snapshot, c(dataset$name, "Other")))
 })
 
 test_that("remove_expression_profile warns when id is missing", {


### PR DESCRIPTION
Aligns the success messages emitted by `remove_observed_data()` and `remove_expression_profile()` with the number of entries actually removed. Previously these methods reported the length of the input vector, which overstated the count when a requested name or id was absent from the snapshot.

## Fix

Both methods now compute the removed count from the change in the underlying collection length, and the empty-collection branch was dropped since standard list subsetting already handles that case. The corresponding `cli_alert_success()` calls now interpolate `num_removed` instead of `length(...)` of the input.

## Tests

Added four tests covering the missing-name, missing-id, and empty-collection paths for both methods, with matching snapshots.

Closes #66