### PR TITLE
Test Observer setter-backed fields survive a load-mutate-export-reload cycle

### DIFF
--- a/tests/testthat/helper-Observer.R
+++ b/tests/testthat/helper-Observer.R
@@ -1,0 +1,33 @@
+# Test helpers for Observer round-trip checks --------------------------------
+
+#' Mutate one Observer field, export and reload the snapshot, then check
+#' that the new value survived the round-trip.
+#'
+#' Loads `test_snapshot.json` fresh so each call has independent state,
+#' mutates the first observer of the first observer set, exports to a
+#' temporary file (registered with `withr` against the caller's frame),
+#' reloads, and asserts that the field equals `new_value`.
+#'
+#' @param field Name of the active binding on `Observer` to mutate
+#'   (e.g. `"name"`, `"type"`, `"dimension"`, `"formula"`).
+#' @param new_value Replacement value to write into the field.
+#' @param env Environment used by `withr::local_tempfile()` for cleanup.
+expect_observer_field_roundtrip <- function(
+  field,
+  new_value,
+  env = parent.frame()
+) {
+  snapshot <- Snapshot$new(testthat::test_path("data", "test_snapshot.json"))
+  observer <- snapshot$observer_sets[[1]]$observers[[1]]
+
+  observer[[field]] <- new_value
+
+  tmp <- withr::local_tempfile(fileext = ".json", .local_envir = env)
+  snapshot$export(tmp)
+  reloaded <- Snapshot$new(tmp)
+
+  testthat::expect_equal(
+    reloaded$observer_sets[[1]]$observers[[1]][[field]],
+    new_value
+  )
+}

--- a/tests/testthat/test-ObserverSet.R
+++ b/tests/testthat/test-ObserverSet.R
@@ -118,71 +118,19 @@ test_that("ObserverSets round-trip byte-equivalently through export", {
 })
 
 test_that("Observer name mutation survives a load-mutate-export-reload cycle", {
-  snapshot <- Snapshot$new(test_path("data", "test_snapshot.json"))
-  os_id <- names(snapshot$observer_sets)[[1]]
-  observer <- snapshot$observer_sets[[os_id]]$observers[[1]]
-
-  observer$name <- "renamed_observer"
-
-  tmp <- withr::local_tempfile(fileext = ".json")
-  snapshot$export(tmp)
-  reloaded <- Snapshot$new(tmp)
-
-  expect_equal(
-    reloaded$observer_sets[[os_id]]$observers[[1]]$name,
-    "renamed_observer"
-  )
+  expect_observer_field_roundtrip("name", "renamed_observer")
 })
 
 test_that("Observer type mutation survives a load-mutate-export-reload cycle", {
-  snapshot <- Snapshot$new(test_path("data", "test_snapshot.json"))
-  os_id <- names(snapshot$observer_sets)[[1]]
-  observer <- snapshot$observer_sets[[os_id]]$observers[[1]]
-
-  observer$type <- "Amount"
-
-  tmp <- withr::local_tempfile(fileext = ".json")
-  snapshot$export(tmp)
-  reloaded <- Snapshot$new(tmp)
-
-  expect_equal(
-    reloaded$observer_sets[[os_id]]$observers[[1]]$type,
-    "Amount"
-  )
+  expect_observer_field_roundtrip("type", "Amount")
 })
 
 test_that("Observer dimension mutation survives a load-mutate-export-reload cycle", {
-  snapshot <- Snapshot$new(test_path("data", "test_snapshot.json"))
-  os_id <- names(snapshot$observer_sets)[[1]]
-  observer <- snapshot$observer_sets[[os_id]]$observers[[1]]
-
-  observer$dimension <- "Concentration (molar)"
-
-  tmp <- withr::local_tempfile(fileext = ".json")
-  snapshot$export(tmp)
-  reloaded <- Snapshot$new(tmp)
-
-  expect_equal(
-    reloaded$observer_sets[[os_id]]$observers[[1]]$dimension,
-    "Concentration (molar)"
-  )
+  expect_observer_field_roundtrip("dimension", "Concentration (molar)")
 })
 
 test_that("Observer formula mutation survives a load-mutate-export-reload cycle", {
-  snapshot <- Snapshot$new(test_path("data", "test_snapshot.json"))
-  os_id <- names(snapshot$observer_sets)[[1]]
-  observer <- snapshot$observer_sets[[os_id]]$observers[[1]]
-
-  observer$formula <- "3*Conc_Br"
-
-  tmp <- withr::local_tempfile(fileext = ".json")
-  snapshot$export(tmp)
-  reloaded <- Snapshot$new(tmp)
-
-  expect_equal(
-    reloaded$observer_sets[[os_id]]$observers[[1]]$formula,
-    "3*Conc_Br"
-  )
+  expect_observer_field_roundtrip("formula", "3*Conc_Br")
 })
 
 # ---- Mutators ----

--- a/tests/testthat/test-ObserverSet.R
+++ b/tests/testthat/test-ObserverSet.R
@@ -117,22 +117,72 @@ test_that("ObserverSets round-trip byte-equivalently through export", {
   expect_equal(reloaded$ObserverSets, snapshot$data$ObserverSets)
 })
 
-test_that("Observer mutations survive export and reload", {
-  snapshot <- test_snapshot$clone(deep = TRUE)
+test_that("Observer name mutation survives a load-mutate-export-reload cycle", {
+  snapshot <- Snapshot$new(test_path("data", "test_snapshot.json"))
   os_id <- names(snapshot$observer_sets)[[1]]
-  observer_id <- names(snapshot$observer_sets[[os_id]]$observers)[[1]]
-  observer <- snapshot$observer_sets[[os_id]]$observers[[observer_id]]
+  observer <- snapshot$observer_sets[[os_id]]$observers[[1]]
 
-  observer$dimension <- "Time"
-  observer$formula <- "2*Conc"
+  observer$name <- "renamed_observer"
 
   tmp <- withr::local_tempfile(fileext = ".json")
   snapshot$export(tmp)
   reloaded <- Snapshot$new(tmp)
 
-  reloaded_observer <- reloaded$observer_sets[[os_id]]$observers[[observer_id]]
-  expect_equal(reloaded_observer$dimension, "Time")
-  expect_equal(reloaded_observer$formula, "2*Conc")
+  expect_equal(
+    reloaded$observer_sets[[os_id]]$observers[[1]]$name,
+    "renamed_observer"
+  )
+})
+
+test_that("Observer type mutation survives a load-mutate-export-reload cycle", {
+  snapshot <- Snapshot$new(test_path("data", "test_snapshot.json"))
+  os_id <- names(snapshot$observer_sets)[[1]]
+  observer <- snapshot$observer_sets[[os_id]]$observers[[1]]
+
+  observer$type <- "Amount"
+
+  tmp <- withr::local_tempfile(fileext = ".json")
+  snapshot$export(tmp)
+  reloaded <- Snapshot$new(tmp)
+
+  expect_equal(
+    reloaded$observer_sets[[os_id]]$observers[[1]]$type,
+    "Amount"
+  )
+})
+
+test_that("Observer dimension mutation survives a load-mutate-export-reload cycle", {
+  snapshot <- Snapshot$new(test_path("data", "test_snapshot.json"))
+  os_id <- names(snapshot$observer_sets)[[1]]
+  observer <- snapshot$observer_sets[[os_id]]$observers[[1]]
+
+  observer$dimension <- "Concentration (molar)"
+
+  tmp <- withr::local_tempfile(fileext = ".json")
+  snapshot$export(tmp)
+  reloaded <- Snapshot$new(tmp)
+
+  expect_equal(
+    reloaded$observer_sets[[os_id]]$observers[[1]]$dimension,
+    "Concentration (molar)"
+  )
+})
+
+test_that("Observer formula mutation survives a load-mutate-export-reload cycle", {
+  snapshot <- Snapshot$new(test_path("data", "test_snapshot.json"))
+  os_id <- names(snapshot$observer_sets)[[1]]
+  observer <- snapshot$observer_sets[[os_id]]$observers[[1]]
+
+  observer$formula <- "3*Conc_Br"
+
+  tmp <- withr::local_tempfile(fileext = ".json")
+  snapshot$export(tmp)
+  reloaded <- Snapshot$new(tmp)
+
+  expect_equal(
+    reloaded$observer_sets[[os_id]]$observers[[1]]$formula,
+    "3*Conc_Br"
+  )
 })
 
 # ---- Mutators ----


### PR DESCRIPTION
PR #73 added a round-trip test for ObserverSet that exports and reloads without mutating any field. This PR fills the testing gap flagged by the reviewer by exercising each Observer setter (name, type, dimension, formula) through the full load, mutate, export, reload cycle, so any future regression in the `Observer$data` rebuild path is caught.

## Tests

The previous `Observer mutations survive export and reload` test bundled `dimension` and `formula` together and reused the package-level `test_snapshot` helper. It has been replaced with four focused tests, one per setter-backed field, each loading the fixture fresh inside its own `test_that()` block so the tests are fully self-sufficient.

Closes #78