### PR TITLE
Consolidate PK-Sim application-type enum

### DIFF
--- a/R/Protocol.R
+++ b/R/Protocol.R
@@ -283,14 +283,7 @@ Protocol <- R6::R6Class(
       if (is.null(self$application_type)) {
         return(NA_character_)
       }
-
-      switch(
-        self$application_type,
-        "Oral" = "Oral",
-        "IntravenousBolus" = "Intravenous bolus",
-        "IntravenousInfusion" = "Intravenous infusion",
-        self$application_type
-      )
+      human_application_type(self$application_type)
     },
 
     #' @description
@@ -462,14 +455,7 @@ Protocol <- R6::R6Class(
       if (is.null(application_type)) {
         return(NA_character_)
       }
-
-      switch(
-        application_type,
-        "Oral" = "Oral",
-        "IntravenousBolus" = "Intravenous bolus",
-        "IntravenousInfusion" = "Intravenous infusion",
-        application_type
-      )
+      human_application_type(application_type)
     },
 
     get_dosing_interval_from_reps = function(rep_num_param, rep_time_param) {
@@ -509,6 +495,36 @@ Protocol <- R6::R6Class(
     }
   )
 )
+
+# Canonical PK-Sim application types accepted by `create_schema_item()` and
+# `Schema/SchemaItem` JSON, paired with their human-readable labels. PK-Sim
+# resolves the enum values via `ApplicationTypes.ByName()` (see
+# `snapshot-spec.md`). This is the single source of truth for the enum;
+# `schema_item_application_types()` (in `R/create_schema_item.R`) and
+# `human_application_type()` both read from it.
+#
+# Names are the enum values; values are the labels used by
+# `Protocol$get_human_application_type()`. Entries whose label matches the
+# name simply round-trip the enum value as its own label.
+PKSIM_APPLICATION_TYPES <- c(
+  Oral = "Oral",
+  IntravenousBolus = "Intravenous bolus",
+  IntravenousInfusion = "Intravenous infusion",
+  Intramuscular = "Intramuscular",
+  Subcutaneous = "Subcutaneous",
+  Dermal = "Dermal",
+  Rectal = "Rectal",
+  Inhalation = "Inhalation",
+  Intraperitoneal = "Intraperitoneal"
+)
+
+# Look up the human-readable label for a PK-Sim application type. Falls back
+# to the raw enum value when no entry exists, mirroring the previous
+# `switch()` default arm.
+human_application_type <- function(application_type) {
+  label <- PKSIM_APPLICATION_TYPES[application_type]
+  if (is.na(label)) application_type else unname(label)
+}
 
 # Shared empty tibble used by Protocol$to_df() and as_tibbles_protocols(), so
 # the empty-state and populated shapes cannot drift (#56).

--- a/R/Protocol.R
+++ b/R/Protocol.R
@@ -520,9 +520,14 @@ PKSIM_APPLICATION_TYPES <- c(
 
 # Look up the human-readable label for a PK-Sim application type. Falls back
 # to the raw enum value when no entry exists, mirroring the previous
-# `switch()` default arm.
+# `switch()` default arm. `unlist()` flattens length-1 lists from
+# `jsonlite::fromJSON(simplifyVector = FALSE)` so subsetting is robust.
 human_application_type <- function(application_type) {
+  application_type <- unlist(application_type)
   label <- PKSIM_APPLICATION_TYPES[application_type]
+  if (length(label) == 0) {
+    return(NA_character_)
+  }
   if (is.na(label)) application_type else unname(label)
 }
 

--- a/R/create_schema_item.R
+++ b/R/create_schema_item.R
@@ -94,19 +94,9 @@ create_schema_item <- function(
 }
 
 # Canonical PK-Sim application types accepted by `create_schema_item()` and
-# `Schema/SchemaItem` JSON. PK-Sim resolves these via `ApplicationTypes.ByName()`
-# (see `snapshot-spec.md`). This is the curated public list from PK-Sim; if
-# PK-Sim adds new application types this list must be updated in lockstep.
+# `Schema/SchemaItem` JSON. Reads from the single source of truth declared in
+# `R/Protocol.R` so the validator, `Protocol$get_human_application_type()`,
+# and the reverse lookup all stay in sync.
 schema_item_application_types <- function() {
-  c(
-    "Oral",
-    "IntravenousBolus",
-    "IntravenousInfusion",
-    "Intramuscular",
-    "Subcutaneous",
-    "Dermal",
-    "Rectal",
-    "Inhalation",
-    "Intraperitoneal"
-  )
+  names(PKSIM_APPLICATION_TYPES)
 }

--- a/tests/testthat/test-Protocol.R
+++ b/tests/testthat/test-Protocol.R
@@ -179,6 +179,22 @@ test_that("Protocol handles different types correctly", {
     "Intravenous infusion"
   )
 
+  # Application types without a dedicated label round-trip the enum value
+  # (locks in the fallback behavior of PKSIM_APPLICATION_TYPES).
+  sc_data <- simple_protocol_data
+  sc_data$ApplicationType <- "Subcutaneous"
+  sc_protocol <- Protocol$new(sc_data)
+  expect_equal(sc_protocol$get_human_application_type(), "Subcutaneous")
+
+  # Unknown application types fall back to the raw enum value.
+  unknown_data <- simple_protocol_data
+  unknown_data$ApplicationType <- "FutureRouteOfAdministration"
+  unknown_protocol <- Protocol$new(unknown_data)
+  expect_equal(
+    unknown_protocol$get_human_application_type(),
+    "FutureRouteOfAdministration"
+  )
+
   # Test different dosing intervals
   daily_data <- simple_protocol_data
   daily_data$DosingInterval <- "DI_24"

--- a/tests/testthat/test-Protocol.R
+++ b/tests/testthat/test-Protocol.R
@@ -195,6 +195,16 @@ test_that("Protocol handles different types correctly", {
     "FutureRouteOfAdministration"
   )
 
+  # `jsonlite::fromJSON(simplifyVector = FALSE)` returns length-1 lists for
+  # scalar JSON values; the helper must still resolve the label.
+  list_data <- simple_protocol_data
+  list_data$ApplicationType <- list("IntravenousBolus")
+  list_protocol <- Protocol$new(list_data)
+  expect_equal(
+    list_protocol$get_human_application_type(),
+    "Intravenous bolus"
+  )
+
   # Test different dosing intervals
   daily_data <- simple_protocol_data
   daily_data$DosingInterval <- "DI_24"


### PR DESCRIPTION
This PR replaces the three independent maintainability hotspots for the PK-Sim application-type enum with a single declared constant, so PK-Sim adding a new application type only requires one edit.

## Source of truth

A new named character vector `PKSIM_APPLICATION_TYPES` lives at the bottom of `R/Protocol.R` (names are the canonical PK-Sim enum values, values are the human-readable labels; enum values without a special label map to themselves so the prior fallback behaviour is preserved).

## Call sites

- `Protocol$get_human_application_type()` and the private `get_human_application_type_from_value()` now delegate to a small internal `human_application_type()` helper that does a lookup against `PKSIM_APPLICATION_TYPES` with fallback to the raw value.
- `schema_item_application_types()` is now `names(PKSIM_APPLICATION_TYPES)`; the public helper signature is unchanged so the validator and any error messages keep working.

Closes #80