### PR TITLE
Vectorize add_*() mutators on Snapshot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@ This release widens the building-block coverage of `osp.snapshots` and consolida
 
 ## New features
 
+- `add_*()` mutators now accept either a single building block or a list of building blocks, mirroring `remove_*()` which has accepted a character vector of names since #66. Success messages on both sides now uniformly report `Added N kind(s)` / `Removed N kind(s)` (#92).
+
 You can now create every kind of building block from a `create_*()` function and attach it with the matching `add_*()` mutator:
 
 - `create_compound()` builds a compound from named arguments, with validation on `molecular_weight_unit` against `ospsuite::ospUnits$"Molecular weight"` (#27, #48). Attach with `add_compound()`, remove by name with `remove_compound()` (#39).

--- a/R/Snapshot.R
+++ b/R/Snapshot.R
@@ -160,8 +160,9 @@ Snapshot <- R6::R6Class(
     },
 
     #' @description
-    #' Add an Individual object to the snapshot
-    #' @param individual An Individual object created with create_individual()
+    #' Add one or more Individual objects to the snapshot.
+    #' @param individual An Individual object created with create_individual(),
+    #'   or a list of such objects.
     #' @return Invisibly returns the object
     #' @examples
     #' \dontrun{
@@ -170,6 +171,13 @@ Snapshot <- R6::R6Class(
     #'
     #' # Add the individual to a snapshot
     #' snapshot$add_individual(ind)
+    #'
+    #' # Add several at once
+    #' patients <- list(
+    #'   create_individual("Patient_A", age = 25),
+    #'   create_individual("Patient_B", age = 45)
+    #' )
+    #' snapshot$add_individual(patients)
     #' }
     add_individual = function(individual) {
       private$.add_block(
@@ -180,7 +188,7 @@ Snapshot <- R6::R6Class(
         named_slot = ".individuals_named",
         ensure = private$.ensure_individuals,
         collection_class = "individual_collection",
-        label = "individual"
+        label_count = "individual(s)"
       )
     },
 
@@ -207,8 +215,9 @@ Snapshot <- R6::R6Class(
     },
 
     #' @description
-    #' Add a Formulation object to the snapshot
-    #' @param formulation A Formulation object created with create_formulation()
+    #' Add one or more Formulation objects to the snapshot.
+    #' @param formulation A Formulation object created with
+    #'   create_formulation(), or a list of such objects.
     #' @return Invisibly returns the object
     #' @examples
     #' \dontrun{
@@ -217,6 +226,13 @@ Snapshot <- R6::R6Class(
     #'
     #' # Add the formulation to a snapshot
     #' snapshot$add_formulation(form)
+    #'
+    #' # Add several at once
+    #' forms <- list(
+    #'   create_formulation("Tablet", type = "Weibull"),
+    #'   create_formulation("Oral solution", type = "First Order")
+    #' )
+    #' snapshot$add_formulation(forms)
     #' }
     add_formulation = function(formulation) {
       private$.add_block(
@@ -227,7 +243,7 @@ Snapshot <- R6::R6Class(
         named_slot = ".formulations_named",
         ensure = private$.ensure_formulations,
         collection_class = "formulation_collection",
-        label = "formulation"
+        label_count = "formulation(s)"
       )
     },
 
@@ -276,8 +292,9 @@ Snapshot <- R6::R6Class(
     },
 
     #' @description
-    #' Add an ExpressionProfile object to the snapshot
-    #' @param expression_profile An ExpressionProfile object
+    #' Add one or more ExpressionProfile objects to the snapshot.
+    #' @param expression_profile An ExpressionProfile object, or a list of
+    #'   such objects.
     #' @return Invisibly returns the object
     #' @examples
     #' \dontrun{
@@ -293,6 +310,9 @@ Snapshot <- R6::R6Class(
     #'
     #' # Add the expression profile to a snapshot
     #' snapshot$add_expression_profile(profile)
+    #'
+    #' # Add several at once
+    #' snapshot$add_expression_profile(list(profile, profile))
     #' }
     add_expression_profile = function(expression_profile) {
       private$.add_block(
@@ -304,8 +324,7 @@ Snapshot <- R6::R6Class(
         ensure = private$.ensure_expression_profiles,
         collection_class = "expression_profile_collection",
         key_fn = \(x) x$id,
-        label = "expression profile",
-        display_fn = \(x) x$molecule
+        label_count = "expression profile(s)"
       )
     },
 
@@ -341,7 +360,7 @@ Snapshot <- R6::R6Class(
         named_slot = ".observer_sets_named",
         ensure = private$.ensure_observer_sets,
         collection_class = "observer_set_collection",
-        label = "observer set"
+        label_count = "observer set(s)"
       )
     },
 
@@ -359,8 +378,9 @@ Snapshot <- R6::R6Class(
     },
 
     #' @description
-    #' Add a DataSet object (observed data) to the snapshot
-    #' @param observed_data A DataSet object created from snapshot observed data
+    #' Add one or more DataSet objects (observed data) to the snapshot.
+    #' @param observed_data A DataSet object created from snapshot observed
+    #'   data, or a list of such objects.
     #' @return Invisibly returns the object
     add_observed_data = function(observed_data) {
       private$.add_block(
@@ -371,7 +391,7 @@ Snapshot <- R6::R6Class(
         named_slot = ".observed_data_named",
         ensure = private$.ensure_observed_data,
         collection_class = "observed_data_collection",
-        label = "observed data",
+        label_count = "observed data item(s)",
         pre_add = function(obj) {
           # Warn once at add time if the new DataSet has no backing JSON slice
           # in `.original_data`; `ospsuite::DataSet` does not round-trip back
@@ -424,7 +444,7 @@ Snapshot <- R6::R6Class(
         named_slot = ".compounds_named",
         ensure = private$.ensure_compounds,
         collection_class = "compound_collection",
-        label = "compound"
+        label_count = "compound(s)"
       )
     },
 
@@ -450,7 +470,7 @@ Snapshot <- R6::R6Class(
         named_slot = ".populations_named",
         ensure = private$.ensure_populations,
         collection_class = "population_collection",
-        label = "population"
+        label_count = "population(s)"
       )
     },
 
@@ -463,7 +483,7 @@ Snapshot <- R6::R6Class(
         named_slot = ".protocols_named",
         ensure = private$.ensure_protocols,
         collection_class = "protocol_collection",
-        label = "protocol"
+        label_count = "protocol(s)"
       )
     },
 
@@ -489,7 +509,7 @@ Snapshot <- R6::R6Class(
         named_slot = ".events_named",
         ensure = private$.ensure_events,
         collection_class = "event_collection",
-        label = "event"
+        label_count = "event(s)"
       )
     },
 
@@ -931,12 +951,14 @@ Snapshot <- R6::R6Class(
     # Cache for the named observed data list with disambiguated names
     .observed_data_named = NULL,
 
-    # Shared append routine for `add_<kind>` methods. Validates `obj` against
-    # `expected_class`, forces lazy construction of the cache via `ensure()`,
-    # appends the new object to the unnamed cache slot, rebuilds the named
-    # cache via `.build_named_list`, and emits a success message. `pre_add`,
-    # when supplied, is run after the class check but before mutation; it is
-    # used by `add_observed_data` to warn about un-serializable DataSets.
+    # Shared append routine for `add_<kind>` methods. Accepts either a single
+    # building block of class `expected_class` or a list of such objects;
+    # rejects mixed-type lists and empty lists. Forces lazy construction via
+    # `ensure()`, appends the validated objects to the unnamed cache slot in
+    # one shot, rebuilds the named cache via `.build_named_list`, and emits a
+    # success message counting the entries added. `pre_add`, when supplied,
+    # runs once per element before any mutation; it is used by
+    # `add_observed_data` to warn about un-serializable DataSets.
     .add_block = function(
       obj,
       expected_class,
@@ -944,26 +966,49 @@ Snapshot <- R6::R6Class(
       named_slot,
       ensure,
       collection_class,
-      label,
+      label_count,
       key_fn = \(x) x$name,
-      display_fn = \(x) x$name,
       class_article = "a",
       pre_add = NULL
     ) {
-      if (!inherits(obj, expected_class)) {
+      if (inherits(obj, expected_class)) {
+        objs <- list(obj)
+      } else if (is.list(obj)) {
+        objs <- obj
+        bad <- which(!vapply(objs, inherits, logical(1), expected_class))
+        if (length(bad) > 0) {
+          first <- bad[[1]]
+          cli::cli_abort(
+            c(
+              "Every element must be {class_article} {.cls {expected_class}} object.",
+              x = "Element {first} is {.cls {class(objs[[first]])[1]}}."
+            ),
+            call = rlang::caller_env()
+          )
+        }
+      } else {
         cli::cli_abort(
-          "Expected {class_article} {expected_class} object, but got {.cls {class(obj)[1]}}",
+          "Expected {class_article} {expected_class} object or a list of them, but got {.cls {class(obj)[1]}}",
+          call = rlang::caller_env()
+        )
+      }
+
+      if (length(objs) == 0) {
+        cli::cli_abort(
+          "Must supply at least one {.cls {expected_class}}.",
           call = rlang::caller_env()
         )
       }
 
       if (!is.null(pre_add)) {
-        pre_add(obj)
+        for (el in objs) {
+          pre_add(el)
+        }
       }
 
       ensure()
 
-      private[[slot]] <- c(private[[slot]], list(obj))
+      private[[slot]] <- c(private[[slot]], objs)
 
       private[[named_slot]] <- private$.build_named_list(
         private[[slot]],
@@ -972,7 +1017,7 @@ Snapshot <- R6::R6Class(
       )
 
       cli::cli_alert_success(
-        "Added {label} '{display_fn(obj)}' to the snapshot"
+        "Added {length(objs)} {label_count}"
       )
       invisible(self)
     },
@@ -1162,15 +1207,15 @@ load_snapshot <- function(source) {
   return(templates$Templates)
 }
 
-#' Add an individual to a snapshot
+#' Add one or more individuals to a snapshot
 #'
 #' @description
-#' Add an Individual object to a Snapshot. This is a convenience function
-#' that calls the add_individual method of the Snapshot class.
+#' Add one or more [Individual] objects to a [Snapshot].
 #'
 #' @param snapshot A Snapshot object
-#' @param individual An Individual object created with create_individual()
-#' @return The updated Snapshot object
+#' @param individual An Individual object created with [create_individual()],
+#'   or a list of such objects.
+#' @return The updated [Snapshot] object, returned invisibly.
 #' @export
 #'
 #' @examples
@@ -1178,11 +1223,16 @@ load_snapshot <- function(source) {
 #' # Load a snapshot
 #' snapshot <- load_snapshot("Midazolam")
 #'
-#' # Create a new individual
+#' # Add a single individual
 #' ind <- create_individual(name = "New Patient", age = 35, weight = 70)
-#'
-#' # Add the individual to the snapshot
 #' snapshot <- add_individual(snapshot, ind)
+#'
+#' # Add several at once
+#' patients <- list(
+#'   create_individual("Patient_A", age = 25),
+#'   create_individual("Patient_B", age = 45)
+#' )
+#' snapshot <- add_individual(snapshot, patients)
 #' }
 add_individual <- function(snapshot, individual) {
   # Validate that the snapshot is a Snapshot object
@@ -1202,7 +1252,7 @@ add_individual <- function(snapshot, individual) {
 #'
 #' @param snapshot A Snapshot object
 #' @param individual_name Character vector of individual names to remove
-#' @return The updated Snapshot object
+#' @return The updated [Snapshot] object, returned invisibly.
 #' @export
 #'
 #' @examples
@@ -1230,15 +1280,15 @@ remove_individual <- function(snapshot, individual_name) {
   invisible(snapshot)
 }
 
-#' Add a formulation to a snapshot
+#' Add one or more formulations to a snapshot
 #'
 #' @description
-#' Add a Formulation object to a Snapshot. This is a convenience function
-#' that calls the add_formulation method of the Snapshot class.
+#' Add one or more [Formulation] objects to a [Snapshot].
 #'
 #' @param snapshot A Snapshot object
-#' @param formulation A Formulation object created with create_formulation()
-#' @return The updated Snapshot object
+#' @param formulation A Formulation object created with
+#'   [create_formulation()], or a list of such objects.
+#' @return The updated [Snapshot] object, returned invisibly.
 #' @export
 #'
 #' @examples
@@ -1246,11 +1296,16 @@ remove_individual <- function(snapshot, individual_name) {
 #' # Load a snapshot
 #' snapshot <- load_snapshot("Midazolam")
 #'
-#' # Create a new formulation
+#' # Add a single formulation
 #' form <- create_formulation(name = "Tablet", type = "Weibull")
-#'
-#' # Add the formulation to the snapshot
 #' snapshot <- add_formulation(snapshot, form)
+#'
+#' # Add several at once
+#' forms <- list(
+#'   create_formulation("Tablet", type = "Weibull"),
+#'   create_formulation("Oral solution", type = "First Order")
+#' )
+#' snapshot <- add_formulation(snapshot, forms)
 #' }
 add_formulation <- function(snapshot, formulation) {
   # Validate that the snapshot is a Snapshot object
@@ -1270,7 +1325,7 @@ add_formulation <- function(snapshot, formulation) {
 #'
 #' @param snapshot A Snapshot object
 #' @param formulation_name Character vector of formulation names to remove
-#' @return The updated Snapshot object
+#' @return The updated [Snapshot] object, returned invisibly.
 #' @export
 #'
 #' @examples
@@ -1305,7 +1360,7 @@ remove_formulation <- function(snapshot, formulation_name) {
 #'
 #' @param snapshot A Snapshot object
 #' @param population_name Character vector of population names to remove
-#' @return The updated Snapshot object
+#' @return The updated [Snapshot] object, returned invisibly.
 #' @export
 #'
 #' @examples
@@ -1333,15 +1388,15 @@ remove_population <- function(snapshot, population_name) {
   invisible(snapshot)
 }
 
-#' Add an expression profile to a snapshot
+#' Add one or more expression profiles to a snapshot
 #'
 #' @description
-#' Add an ExpressionProfile object to a Snapshot. This is a convenience function
-#' that calls the add_expression_profile method of the Snapshot class.
+#' Add one or more [ExpressionProfile] objects to a [Snapshot].
 #'
 #' @param snapshot A Snapshot object
-#' @param expression_profile An ExpressionProfile object
-#' @return The updated Snapshot object
+#' @param expression_profile An ExpressionProfile object, or a list of such
+#'   objects.
+#' @return The updated [Snapshot] object, returned invisibly.
 #' @export
 #'
 #' @examples
@@ -1359,8 +1414,11 @@ remove_population <- function(snapshot, population_name) {
 #' )
 #' profile <- ExpressionProfile$new(profile_data)
 #'
-#' # Add the expression profile to the snapshot
+#' # Add a single expression profile
 #' snapshot <- add_expression_profile(snapshot, profile)
+#'
+#' # Add several at once
+#' snapshot <- add_expression_profile(snapshot, list(profile, profile))
 #' }
 add_expression_profile <- function(snapshot, expression_profile) {
   # Validate that the snapshot is a Snapshot object
@@ -1381,7 +1439,7 @@ add_expression_profile <- function(snapshot, expression_profile) {
 #'
 #' @param snapshot A Snapshot object
 #' @param profile_id Character vector of expression profile IDs to remove
-#' @return The updated Snapshot object
+#' @return The updated [Snapshot] object, returned invisibly.
 #' @export
 #'
 #' @examples
@@ -1409,15 +1467,15 @@ remove_expression_profile <- function(snapshot, profile_id) {
   invisible(snapshot)
 }
 
-#' Add an observer set to a snapshot
+#' Add one or more observer sets to a snapshot
 #'
 #' @description
-#' Add an `ObserverSet` building block to a `Snapshot`. The exported function
-#' is the canonical, pipeable surface for the mutation; it validates the
-#' snapshot before delegating to the underlying R6 method.
+#' Add one or more `ObserverSet` building blocks to a `Snapshot`. The
+#' exported function is the canonical, pipeable surface for the mutation; it
+#' validates the snapshot before delegating to the underlying R6 method.
 #'
 #' @param snapshot A `Snapshot` object.
-#' @param observer_set An `ObserverSet` object.
+#' @param observer_set An `ObserverSet` object, or a list of such objects.
 #'
 #' @return The updated `Snapshot` object, invisibly.
 #' @export
@@ -1432,6 +1490,8 @@ remove_expression_profile <- function(snapshot, profile_id) {
 #' ))
 #'
 #' snapshot |> add_observer_set(observer_set)
+#'
+#' snapshot |> add_observer_set(list(observer_set, observer_set))
 #' }
 add_observer_set <- function(snapshot, observer_set) {
   validate_snapshot(snapshot)
@@ -1535,13 +1595,14 @@ osp_models <- function(pattern = NULL) {
   )
 }
 
-#' Add a compound to a snapshot
+#' Add one or more compounds to a snapshot
 #'
 #' @description
-#' Add a [Compound] object to a [Snapshot].
+#' Add one or more [Compound] objects to a [Snapshot].
 #'
 #' @param snapshot A [Snapshot] object.
-#' @param compound A [Compound] object created with [create_compound()].
+#' @param compound A [Compound] object created with [create_compound()], or a
+#'   list of such objects.
 #' @return The updated [Snapshot] object, returned invisibly.
 #' @export
 #'
@@ -1549,6 +1610,12 @@ osp_models <- function(pattern = NULL) {
 #' \dontrun{
 #' snapshot <- load_snapshot("Midazolam") |>
 #'   add_compound(create_compound(name = "Drug X"))
+#'
+#' snapshot <- load_snapshot("Midazolam") |>
+#'   add_compound(list(
+#'     create_compound(name = "Drug X"),
+#'     create_compound(name = "Drug Y")
+#'   ))
 #' }
 add_compound <- function(snapshot, compound) {
   validate_snapshot(snapshot)
@@ -1577,13 +1644,14 @@ remove_compound <- function(snapshot, compound_name) {
   invisible(snapshot)
 }
 
-#' Add a population to a snapshot
+#' Add one or more populations to a snapshot
 #'
 #' @description
-#' Add a [Population] object to a [Snapshot].
+#' Add one or more [Population] objects to a [Snapshot].
 #'
 #' @param snapshot A [Snapshot] object.
-#' @param population A [Population] object created with [create_population()].
+#' @param population A [Population] object created with [create_population()],
+#'   or a list of such objects.
 #' @return The updated [Snapshot] object, returned invisibly.
 #' @export
 #'
@@ -1592,6 +1660,12 @@ remove_compound <- function(snapshot, compound_name) {
 #' pop <- create_population(name = "Adults", number_of_individuals = 100)
 #' snapshot <- load_snapshot("Midazolam") |>
 #'   add_population(pop)
+#'
+#' snapshot <- load_snapshot("Midazolam") |>
+#'   add_population(list(
+#'     create_population(name = "Adults", number_of_individuals = 100),
+#'     create_population(name = "Children", number_of_individuals = 50)
+#'   ))
 #' }
 add_population <- function(snapshot, population) {
   validate_snapshot(snapshot)
@@ -1599,13 +1673,14 @@ add_population <- function(snapshot, population) {
   invisible(snapshot)
 }
 
-#' Add a protocol to a snapshot
+#' Add one or more protocols to a snapshot
 #'
 #' @description
-#' Add a [Protocol] object to a [Snapshot].
+#' Add one or more [Protocol] objects to a [Snapshot].
 #'
 #' @param snapshot A [Snapshot] object.
-#' @param protocol A [Protocol] object created with [create_protocol()].
+#' @param protocol A [Protocol] object created with [create_protocol()], or a
+#'   list of such objects.
 #' @return The updated [Snapshot] object, returned invisibly.
 #' @export
 #'
@@ -1618,6 +1693,9 @@ add_population <- function(snapshot, population) {
 #' )
 #' snapshot <- load_snapshot("Midazolam") |>
 #'   add_protocol(prot)
+#'
+#' snapshot <- load_snapshot("Midazolam") |>
+#'   add_protocol(list(prot, prot))
 #' }
 add_protocol <- function(snapshot, protocol) {
   validate_snapshot(snapshot)
@@ -1646,13 +1724,14 @@ remove_protocol <- function(snapshot, protocol_name) {
   invisible(snapshot)
 }
 
-#' Add an event to a snapshot
+#' Add one or more events to a snapshot
 #'
 #' @description
-#' Add an [Event] object to a [Snapshot].
+#' Add one or more [Event] objects to a [Snapshot].
 #'
 #' @param snapshot A [Snapshot] object.
-#' @param event An [Event] object created with [create_event()].
+#' @param event An [Event] object created with [create_event()], or a list of
+#'   such objects.
 #' @return The updated [Snapshot] object, returned invisibly.
 #' @export
 #'
@@ -1664,6 +1743,9 @@ remove_protocol <- function(snapshot, protocol_name) {
 #' )
 #' snapshot <- load_snapshot("Midazolam") |>
 #'   add_event(evt)
+#'
+#' snapshot <- load_snapshot("Midazolam") |>
+#'   add_event(list(evt, evt))
 #' }
 add_event <- function(snapshot, event) {
   validate_snapshot(snapshot)
@@ -1692,14 +1774,16 @@ remove_event <- function(snapshot, event_name) {
   invisible(snapshot)
 }
 
-#' Add observed data to a snapshot
+#' Add one or more observed-data entries to a snapshot
 #'
 #' @description
-#' Add an `ospsuite::DataSet` (observed data) to a [Snapshot].
+#' Add one or more `ospsuite::DataSet` (observed data) objects to a
+#' [Snapshot].
 #'
 #' @param snapshot A [Snapshot] object.
 #' @param observed_data A `DataSet` object, typically created with
-#'   [create_observed_data()] or [loadDataSetFromSnapshot()].
+#'   [create_observed_data()] or [loadDataSetFromSnapshot()], or a list of
+#'   such objects.
 #' @return The updated [Snapshot] object, returned invisibly.
 #' @export
 #'
@@ -1713,6 +1797,9 @@ remove_event <- function(snapshot, event_name) {
 #' )
 #' snapshot <- load_snapshot("Midazolam") |>
 #'   add_observed_data(dataset)
+#'
+#' snapshot <- load_snapshot("Midazolam") |>
+#'   add_observed_data(list(dataset, dataset))
 #' }
 add_observed_data <- function(snapshot, observed_data) {
   validate_snapshot(snapshot)

--- a/man/Snapshot.Rd
+++ b/man/Snapshot.Rd
@@ -29,6 +29,13 @@ ind <- create_individual(name = "New Patient", age = 35, weight = 70)
 
 # Add the individual to a snapshot
 snapshot$add_individual(ind)
+
+# Add several at once
+patients <- list(
+  create_individual("Patient_A", age = 25),
+  create_individual("Patient_B", age = 45)
+)
+snapshot$add_individual(patients)
 }
 
 ## ------------------------------------------------
@@ -50,6 +57,13 @@ form <- create_formulation(name = "Tablet", type = "Weibull")
 
 # Add the formulation to a snapshot
 snapshot$add_formulation(form)
+
+# Add several at once
+forms <- list(
+  create_formulation("Tablet", type = "Weibull"),
+  create_formulation("Oral solution", type = "First Order")
+)
+snapshot$add_formulation(forms)
 }
 
 ## ------------------------------------------------
@@ -87,6 +101,9 @@ profile <- ExpressionProfile$new(profile_data)
 
 # Add the expression profile to a snapshot
 snapshot$add_expression_profile(profile)
+
+# Add several at once
+snapshot$add_expression_profile(list(profile, profile))
 }
 
 ## ------------------------------------------------
@@ -227,7 +244,7 @@ versions abort.}
 \if{html}{\out{<a id="method-Snapshot-add_individual"></a>}}
 \if{latex}{\out{\hypertarget{method-Snapshot-add_individual}{}}}
 \subsection{\code{Snapshot$add_individual()}}{
-  Add an Individual object to the snapshot
+  Add one or more Individual objects to the snapshot.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Snapshot$add_individual(individual)}
@@ -236,7 +253,8 @@ versions abort.}
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{individual}}{An Individual object created with create_individual()}
+      \item{\code{individual}}{An Individual object created with create_individual(),
+or a list of such objects.}
     }
     \if{html}{\out{</div>}}
   }
@@ -250,6 +268,13 @@ ind <- create_individual(name = "New Patient", age = 35, weight = 70)
 
 # Add the individual to a snapshot
 snapshot$add_individual(ind)
+
+# Add several at once
+patients <- list(
+  create_individual("Patient_A", age = 25),
+  create_individual("Patient_B", age = 45)
+)
+snapshot$add_individual(patients)
 }
     \if{html}{\out{</div>}}
   }
@@ -288,7 +313,7 @@ snapshot$remove_individual("Subject_001")
 \if{html}{\out{<a id="method-Snapshot-add_formulation"></a>}}
 \if{latex}{\out{\hypertarget{method-Snapshot-add_formulation}{}}}
 \subsection{\code{Snapshot$add_formulation()}}{
-  Add a Formulation object to the snapshot
+  Add one or more Formulation objects to the snapshot.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Snapshot$add_formulation(formulation)}
@@ -297,7 +322,8 @@ snapshot$remove_individual("Subject_001")
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{formulation}}{A Formulation object created with create_formulation()}
+      \item{\code{formulation}}{A Formulation object created with
+create_formulation(), or a list of such objects.}
     }
     \if{html}{\out{</div>}}
   }
@@ -311,6 +337,13 @@ form <- create_formulation(name = "Tablet", type = "Weibull")
 
 # Add the formulation to a snapshot
 snapshot$add_formulation(form)
+
+# Add several at once
+forms <- list(
+  create_formulation("Tablet", type = "Weibull"),
+  create_formulation("Oral solution", type = "First Order")
+)
+snapshot$add_formulation(forms)
 }
     \if{html}{\out{</div>}}
   }
@@ -378,7 +411,7 @@ snapshot$remove_population("pop_1")
 \if{html}{\out{<a id="method-Snapshot-add_expression_profile"></a>}}
 \if{latex}{\out{\hypertarget{method-Snapshot-add_expression_profile}{}}}
 \subsection{\code{Snapshot$add_expression_profile()}}{
-  Add an ExpressionProfile object to the snapshot
+  Add one or more ExpressionProfile objects to the snapshot.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Snapshot$add_expression_profile(expression_profile)}
@@ -387,7 +420,8 @@ snapshot$remove_population("pop_1")
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{expression_profile}}{An ExpressionProfile object}
+      \item{\code{expression_profile}}{An ExpressionProfile object, or a list of
+such objects.}
     }
     \if{html}{\out{</div>}}
   }
@@ -408,6 +442,9 @@ profile <- ExpressionProfile$new(profile_data)
 
 # Add the expression profile to a snapshot
 snapshot$add_expression_profile(profile)
+
+# Add several at once
+snapshot$add_expression_profile(list(profile, profile))
 }
     \if{html}{\out{</div>}}
   }
@@ -468,7 +505,7 @@ snapshot$remove_expression_profile("CYP3A4_Human_Healthy")
 \if{html}{\out{<a id="method-Snapshot-add_observed_data"></a>}}
 \if{latex}{\out{\hypertarget{method-Snapshot-add_observed_data}{}}}
 \subsection{\code{Snapshot$add_observed_data()}}{
-  Add a DataSet object (observed data) to the snapshot
+  Add one or more DataSet objects (observed data) to the snapshot.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Snapshot$add_observed_data(observed_data)}
@@ -477,7 +514,8 @@ snapshot$remove_expression_profile("CYP3A4_Human_Healthy")
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{observed_data}}{A DataSet object created from snapshot observed data}
+      \item{\code{observed_data}}{A DataSet object created from snapshot observed
+data, or a list of such objects.}
     }
     \if{html}{\out{</div>}}
   }

--- a/man/add_compound.Rd
+++ b/man/add_compound.Rd
@@ -2,24 +2,31 @@
 % Please edit documentation in R/Snapshot.R
 \name{add_compound}
 \alias{add_compound}
-\title{Add a compound to a snapshot}
+\title{Add one or more compounds to a snapshot}
 \usage{
 add_compound(snapshot, compound)
 }
 \arguments{
 \item{snapshot}{A \link{Snapshot} object.}
 
-\item{compound}{A \link{Compound} object created with \code{\link[=create_compound]{create_compound()}}.}
+\item{compound}{A \link{Compound} object created with \code{\link[=create_compound]{create_compound()}}, or a
+list of such objects.}
 }
 \value{
 The updated \link{Snapshot} object, returned invisibly.
 }
 \description{
-Add a \link{Compound} object to a \link{Snapshot}.
+Add one or more \link{Compound} objects to a \link{Snapshot}.
 }
 \examples{
 \dontrun{
 snapshot <- load_snapshot("Midazolam") |>
   add_compound(create_compound(name = "Drug X"))
+
+snapshot <- load_snapshot("Midazolam") |>
+  add_compound(list(
+    create_compound(name = "Drug X"),
+    create_compound(name = "Drug Y")
+  ))
 }
 }

--- a/man/add_event.Rd
+++ b/man/add_event.Rd
@@ -2,20 +2,21 @@
 % Please edit documentation in R/Snapshot.R
 \name{add_event}
 \alias{add_event}
-\title{Add an event to a snapshot}
+\title{Add one or more events to a snapshot}
 \usage{
 add_event(snapshot, event)
 }
 \arguments{
 \item{snapshot}{A \link{Snapshot} object.}
 
-\item{event}{An \link{Event} object created with \code{\link[=create_event]{create_event()}}.}
+\item{event}{An \link{Event} object created with \code{\link[=create_event]{create_event()}}, or a list of
+such objects.}
 }
 \value{
 The updated \link{Snapshot} object, returned invisibly.
 }
 \description{
-Add an \link{Event} object to a \link{Snapshot}.
+Add one or more \link{Event} objects to a \link{Snapshot}.
 }
 \examples{
 \dontrun{
@@ -25,5 +26,8 @@ evt <- create_event(
 )
 snapshot <- load_snapshot("Midazolam") |>
   add_event(evt)
+
+snapshot <- load_snapshot("Midazolam") |>
+  add_event(list(evt, evt))
 }
 }

--- a/man/add_expression_profile.Rd
+++ b/man/add_expression_profile.Rd
@@ -2,21 +2,21 @@
 % Please edit documentation in R/Snapshot.R
 \name{add_expression_profile}
 \alias{add_expression_profile}
-\title{Add an expression profile to a snapshot}
+\title{Add one or more expression profiles to a snapshot}
 \usage{
 add_expression_profile(snapshot, expression_profile)
 }
 \arguments{
 \item{snapshot}{A Snapshot object}
 
-\item{expression_profile}{An ExpressionProfile object}
+\item{expression_profile}{An ExpressionProfile object, or a list of such
+objects.}
 }
 \value{
-The updated Snapshot object
+The updated \link{Snapshot} object, returned invisibly.
 }
 \description{
-Add an ExpressionProfile object to a Snapshot. This is a convenience function
-that calls the add_expression_profile method of the Snapshot class.
+Add one or more \link{ExpressionProfile} objects to a \link{Snapshot}.
 }
 \examples{
 \dontrun{
@@ -33,7 +33,10 @@ profile_data <- list(
 )
 profile <- ExpressionProfile$new(profile_data)
 
-# Add the expression profile to the snapshot
+# Add a single expression profile
 snapshot <- add_expression_profile(snapshot, profile)
+
+# Add several at once
+snapshot <- add_expression_profile(snapshot, list(profile, profile))
 }
 }

--- a/man/add_formulation.Rd
+++ b/man/add_formulation.Rd
@@ -2,31 +2,36 @@
 % Please edit documentation in R/Snapshot.R
 \name{add_formulation}
 \alias{add_formulation}
-\title{Add a formulation to a snapshot}
+\title{Add one or more formulations to a snapshot}
 \usage{
 add_formulation(snapshot, formulation)
 }
 \arguments{
 \item{snapshot}{A Snapshot object}
 
-\item{formulation}{A Formulation object created with create_formulation()}
+\item{formulation}{A Formulation object created with
+\code{\link[=create_formulation]{create_formulation()}}, or a list of such objects.}
 }
 \value{
-The updated Snapshot object
+The updated \link{Snapshot} object, returned invisibly.
 }
 \description{
-Add a Formulation object to a Snapshot. This is a convenience function
-that calls the add_formulation method of the Snapshot class.
+Add one or more \link{Formulation} objects to a \link{Snapshot}.
 }
 \examples{
 \dontrun{
 # Load a snapshot
 snapshot <- load_snapshot("Midazolam")
 
-# Create a new formulation
+# Add a single formulation
 form <- create_formulation(name = "Tablet", type = "Weibull")
-
-# Add the formulation to the snapshot
 snapshot <- add_formulation(snapshot, form)
+
+# Add several at once
+forms <- list(
+  create_formulation("Tablet", type = "Weibull"),
+  create_formulation("Oral solution", type = "First Order")
+)
+snapshot <- add_formulation(snapshot, forms)
 }
 }

--- a/man/add_individual.Rd
+++ b/man/add_individual.Rd
@@ -2,31 +2,36 @@
 % Please edit documentation in R/Snapshot.R
 \name{add_individual}
 \alias{add_individual}
-\title{Add an individual to a snapshot}
+\title{Add one or more individuals to a snapshot}
 \usage{
 add_individual(snapshot, individual)
 }
 \arguments{
 \item{snapshot}{A Snapshot object}
 
-\item{individual}{An Individual object created with create_individual()}
+\item{individual}{An Individual object created with \code{\link[=create_individual]{create_individual()}},
+or a list of such objects.}
 }
 \value{
-The updated Snapshot object
+The updated \link{Snapshot} object, returned invisibly.
 }
 \description{
-Add an Individual object to a Snapshot. This is a convenience function
-that calls the add_individual method of the Snapshot class.
+Add one or more \link{Individual} objects to a \link{Snapshot}.
 }
 \examples{
 \dontrun{
 # Load a snapshot
 snapshot <- load_snapshot("Midazolam")
 
-# Create a new individual
+# Add a single individual
 ind <- create_individual(name = "New Patient", age = 35, weight = 70)
-
-# Add the individual to the snapshot
 snapshot <- add_individual(snapshot, ind)
+
+# Add several at once
+patients <- list(
+  create_individual("Patient_A", age = 25),
+  create_individual("Patient_B", age = 45)
+)
+snapshot <- add_individual(snapshot, patients)
 }
 }

--- a/man/add_observed_data.Rd
+++ b/man/add_observed_data.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Snapshot.R
 \name{add_observed_data}
 \alias{add_observed_data}
-\title{Add observed data to a snapshot}
+\title{Add one or more observed-data entries to a snapshot}
 \usage{
 add_observed_data(snapshot, observed_data)
 }
@@ -10,13 +10,15 @@ add_observed_data(snapshot, observed_data)
 \item{snapshot}{A \link{Snapshot} object.}
 
 \item{observed_data}{A \code{DataSet} object, typically created with
-\code{\link[=create_observed_data]{create_observed_data()}} or \code{\link[=loadDataSetFromSnapshot]{loadDataSetFromSnapshot()}}.}
+\code{\link[=create_observed_data]{create_observed_data()}} or \code{\link[=loadDataSetFromSnapshot]{loadDataSetFromSnapshot()}}, or a list of
+such objects.}
 }
 \value{
 The updated \link{Snapshot} object, returned invisibly.
 }
 \description{
-Add an \code{ospsuite::DataSet} (observed data) to a \link{Snapshot}.
+Add one or more \code{ospsuite::DataSet} (observed data) objects to a
+\link{Snapshot}.
 }
 \examples{
 \dontrun{
@@ -28,5 +30,8 @@ dataset <- create_observed_data(
 )
 snapshot <- load_snapshot("Midazolam") |>
   add_observed_data(dataset)
+
+snapshot <- load_snapshot("Midazolam") |>
+  add_observed_data(list(dataset, dataset))
 }
 }

--- a/man/add_observer_set.Rd
+++ b/man/add_observer_set.Rd
@@ -2,22 +2,22 @@
 % Please edit documentation in R/Snapshot.R
 \name{add_observer_set}
 \alias{add_observer_set}
-\title{Add an observer set to a snapshot}
+\title{Add one or more observer sets to a snapshot}
 \usage{
 add_observer_set(snapshot, observer_set)
 }
 \arguments{
 \item{snapshot}{A \code{Snapshot} object.}
 
-\item{observer_set}{An \code{ObserverSet} object.}
+\item{observer_set}{An \code{ObserverSet} object, or a list of such objects.}
 }
 \value{
 The updated \code{Snapshot} object, invisibly.
 }
 \description{
-Add an \code{ObserverSet} building block to a \code{Snapshot}. The exported function
-is the canonical, pipeable surface for the mutation; it validates the
-snapshot before delegating to the underlying R6 method.
+Add one or more \code{ObserverSet} building blocks to a \code{Snapshot}. The
+exported function is the canonical, pipeable surface for the mutation; it
+validates the snapshot before delegating to the underlying R6 method.
 }
 \examples{
 \dontrun{
@@ -29,5 +29,7 @@ observer_set <- ObserverSet$new(list(
 ))
 
 snapshot |> add_observer_set(observer_set)
+
+snapshot |> add_observer_set(list(observer_set, observer_set))
 }
 }

--- a/man/add_population.Rd
+++ b/man/add_population.Rd
@@ -2,25 +2,32 @@
 % Please edit documentation in R/Snapshot.R
 \name{add_population}
 \alias{add_population}
-\title{Add a population to a snapshot}
+\title{Add one or more populations to a snapshot}
 \usage{
 add_population(snapshot, population)
 }
 \arguments{
 \item{snapshot}{A \link{Snapshot} object.}
 
-\item{population}{A \link{Population} object created with \code{\link[=create_population]{create_population()}}.}
+\item{population}{A \link{Population} object created with \code{\link[=create_population]{create_population()}},
+or a list of such objects.}
 }
 \value{
 The updated \link{Snapshot} object, returned invisibly.
 }
 \description{
-Add a \link{Population} object to a \link{Snapshot}.
+Add one or more \link{Population} objects to a \link{Snapshot}.
 }
 \examples{
 \dontrun{
 pop <- create_population(name = "Adults", number_of_individuals = 100)
 snapshot <- load_snapshot("Midazolam") |>
   add_population(pop)
+
+snapshot <- load_snapshot("Midazolam") |>
+  add_population(list(
+    create_population(name = "Adults", number_of_individuals = 100),
+    create_population(name = "Children", number_of_individuals = 50)
+  ))
 }
 }

--- a/man/add_protocol.Rd
+++ b/man/add_protocol.Rd
@@ -2,20 +2,21 @@
 % Please edit documentation in R/Snapshot.R
 \name{add_protocol}
 \alias{add_protocol}
-\title{Add a protocol to a snapshot}
+\title{Add one or more protocols to a snapshot}
 \usage{
 add_protocol(snapshot, protocol)
 }
 \arguments{
 \item{snapshot}{A \link{Snapshot} object.}
 
-\item{protocol}{A \link{Protocol} object created with \code{\link[=create_protocol]{create_protocol()}}.}
+\item{protocol}{A \link{Protocol} object created with \code{\link[=create_protocol]{create_protocol()}}, or a
+list of such objects.}
 }
 \value{
 The updated \link{Snapshot} object, returned invisibly.
 }
 \description{
-Add a \link{Protocol} object to a \link{Snapshot}.
+Add one or more \link{Protocol} objects to a \link{Snapshot}.
 }
 \examples{
 \dontrun{
@@ -26,5 +27,8 @@ prot <- create_protocol(
 )
 snapshot <- load_snapshot("Midazolam") |>
   add_protocol(prot)
+
+snapshot <- load_snapshot("Midazolam") |>
+  add_protocol(list(prot, prot))
 }
 }

--- a/man/remove_expression_profile.Rd
+++ b/man/remove_expression_profile.Rd
@@ -12,7 +12,7 @@ remove_expression_profile(snapshot, profile_id)
 \item{profile_id}{Character vector of expression profile IDs to remove}
 }
 \value{
-The updated Snapshot object
+The updated \link{Snapshot} object, returned invisibly.
 }
 \description{
 Remove one or more expression profiles from a Snapshot by ID

--- a/man/remove_formulation.Rd
+++ b/man/remove_formulation.Rd
@@ -12,7 +12,7 @@ remove_formulation(snapshot, formulation_name)
 \item{formulation_name}{Character vector of formulation names to remove}
 }
 \value{
-The updated Snapshot object
+The updated \link{Snapshot} object, returned invisibly.
 }
 \description{
 Remove one or more formulations from a Snapshot by name.

--- a/man/remove_individual.Rd
+++ b/man/remove_individual.Rd
@@ -12,7 +12,7 @@ remove_individual(snapshot, individual_name)
 \item{individual_name}{Character vector of individual names to remove}
 }
 \value{
-The updated Snapshot object
+The updated \link{Snapshot} object, returned invisibly.
 }
 \description{
 Remove one or more individuals from a Snapshot by name.

--- a/man/remove_population.Rd
+++ b/man/remove_population.Rd
@@ -12,7 +12,7 @@ remove_population(snapshot, population_name)
 \item{population_name}{Character vector of population names to remove}
 }
 \value{
-The updated Snapshot object
+The updated \link{Snapshot} object, returned invisibly.
 }
 \description{
 Remove one or more populations from a Snapshot by name.

--- a/tests/testthat/_snaps/ObserverSet.md
+++ b/tests/testthat/_snaps/ObserverSet.md
@@ -12,7 +12,7 @@
       add_observer_set(snapshot, list())
     Condition
       Error in `snapshot$add_observer_set()`:
-      ! Expected an ObserverSet object, but got <list>
+      ! Must supply at least one <ObserverSet>.
 
 # add_observer_set() rejects non-Snapshot inputs
 

--- a/tests/testthat/_snaps/observed-data.md
+++ b/tests/testthat/_snaps/observed-data.md
@@ -42,5 +42,5 @@
       Observed data "Backman 1996 - Control (Perpetrator Placebo) - Midazolam - PO - 15 mg - Plasma - agg. (n=10)" cannot be serialized on export.
       i <DataSet> objects have no `$data` accessor; only entries present in the original snapshot are exported.
     Message
-      v Added observed data 'Backman 1996 - Control (Perpetrator Placebo) - Midazolam - PO - 15 mg - Plasma - agg. (n=10)' to the snapshot
+      v Added 1 observed data item(s)
 

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -84,7 +84,7 @@
       add_compound(snapshot, "not a compound")
     Condition
       Error in `snapshot$add_compound()`:
-      ! Expected a Compound object, but got <character>
+      ! Expected a Compound object or a list of them, but got <character>
 
 # remove_compound warns when name is missing
 
@@ -110,7 +110,7 @@
       add_population(snapshot, "not a population")
     Condition
       Error in `snapshot$add_population()`:
-      ! Expected a Population object, but got <character>
+      ! Expected a Population object or a list of them, but got <character>
 
 # add_protocol errors on wrong class
 
@@ -118,7 +118,7 @@
       add_protocol(snapshot, "not a protocol")
     Condition
       Error in `snapshot$add_protocol()`:
-      ! Expected a Protocol object, but got <character>
+      ! Expected a Protocol object or a list of them, but got <character>
 
 # remove_protocol warns when name is missing
 
@@ -144,7 +144,7 @@
       add_event(snapshot, "not an event")
     Condition
       Error in `snapshot$add_event()`:
-      ! Expected an Event object, but got <character>
+      ! Expected an Event object or a list of them, but got <character>
 
 # remove_event warns when name is missing
 
@@ -280,7 +280,7 @@
       add_observed_data(snapshot, "not a dataset")
     Condition
       Error in `snapshot$add_observed_data()`:
-      ! Expected a DataSet object, but got <character>
+      ! Expected a DataSet object or a list of them, but got <character>
 
 # mutators reject non-Snapshot inputs
 
@@ -337,4 +337,59 @@
     Condition
       Error in `validate_snapshot()`:
       ! Expected a Snapshot object, but got <character>
+
+# add_compound errors on an empty list
+
+    Code
+      add_compound(snapshot, list())
+    Condition
+      Error in `snapshot$add_compound()`:
+      ! Must supply at least one <Compound>.
+
+# add_individual errors on an empty list
+
+    Code
+      add_individual(snapshot, list())
+    Condition
+      Error in `snapshot$add_individual()`:
+      ! Must supply at least one <Individual>.
+
+# add_compound rejects a list with a wrong-class element
+
+    Code
+      add_compound(snapshot, bad)
+    Condition
+      Error in `snapshot$add_compound()`:
+      ! Every element must be a <Compound> object.
+      x Element 2 is <character>.
+
+# add_individual rejects a list with a wrong-class element
+
+    Code
+      add_individual(snapshot, bad)
+    Condition
+      Error in `snapshot$add_individual()`:
+      ! Every element must be an <Individual> object.
+      x Element 2 is <character>.
+
+# add_expression_profile rejects a list with a wrong-class element
+
+    Code
+      add_expression_profile(snapshot, bad)
+    Condition
+      Error in `snapshot$add_expression_profile()`:
+      ! Every element must be an <ExpressionProfile> object.
+      x Element 2 is <character>.
+
+# add_*() reports the count of added entries
+
+    Code
+      snapshot <- add_compound(snapshot, create_compound(name = "X"))
+    Message
+      v Added 1 compound(s)
+    Code
+      snapshot <- add_compound(snapshot, list(create_compound(name = "Y"),
+      create_compound(name = "Z")))
+    Message
+      v Added 2 compound(s)
 

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -1048,3 +1048,176 @@ test_that("mutators reject non-Snapshot inputs", {
   expect_snapshot(add_event("nope", event), error = TRUE)
   expect_snapshot(remove_event("nope", "E"), error = TRUE)
 })
+
+# add_*() accepts a list of objects -----------------------------------------
+
+test_that("add_compound accepts a list of objects", {
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+  objs <- list(
+    create_compound(name = "A"),
+    create_compound(name = "B")
+  )
+  snapshot <- add_compound(snapshot, objs)
+  expect_named(snapshot$compounds, c("A", "B"))
+})
+
+test_that("add_individual accepts a list of objects", {
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+  objs <- list(
+    create_individual(name = "A", age = 25),
+    create_individual(name = "B", age = 45)
+  )
+  snapshot <- add_individual(snapshot, objs)
+  expect_named(snapshot$individuals, c("A", "B"))
+})
+
+test_that("add_formulation accepts a list of objects", {
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+  objs <- list(
+    create_formulation(name = "A", type = "Weibull"),
+    create_formulation(name = "B", type = "First Order")
+  )
+  snapshot <- add_formulation(snapshot, objs)
+  expect_named(snapshot$formulations, c("A", "B"))
+})
+
+test_that("add_population accepts a list of objects", {
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+  objs <- list(
+    create_population(name = "A", number_of_individuals = 10),
+    create_population(name = "B", number_of_individuals = 20)
+  )
+  snapshot <- add_population(snapshot, objs)
+  expect_named(snapshot$populations, c("A", "B"))
+})
+
+test_that("add_protocol accepts a list of objects", {
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+  objs <- list(
+    create_protocol(
+      name = "A",
+      application_type = "Oral",
+      dosing_interval = "Single"
+    ),
+    create_protocol(
+      name = "B",
+      application_type = "Oral",
+      dosing_interval = "Single"
+    )
+  )
+  snapshot <- add_protocol(snapshot, objs)
+  expect_named(snapshot$protocols, c("A", "B"))
+})
+
+test_that("add_event accepts a list of objects", {
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+  objs <- list(
+    create_event(name = "A", template = "Meal: Standard (Human)"),
+    create_event(name = "B", template = "Meal: Standard (Human)")
+  )
+  snapshot <- add_event(snapshot, objs)
+  expect_named(snapshot$events, c("A", "B"))
+})
+
+test_that("add_expression_profile accepts a list of objects", {
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+  objs <- list(
+    create_expression_profile(
+      molecule = "CYP3A4",
+      species = "Human",
+      category = "Healthy",
+      type = "Enzyme"
+    ),
+    create_expression_profile(
+      molecule = "CYP2D6",
+      species = "Human",
+      category = "Healthy",
+      type = "Enzyme"
+    )
+  )
+  snapshot <- add_expression_profile(snapshot, objs)
+  expect_named(
+    snapshot$expression_profiles,
+    c("CYP3A4_Human_Healthy", "CYP2D6_Human_Healthy")
+  )
+})
+
+test_that("add_observer_set accepts a list of objects", {
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+  objs <- list(
+    create_observer_set(name = "A"),
+    create_observer_set(name = "B")
+  )
+  snapshot <- add_observer_set(snapshot, objs)
+  expect_named(snapshot$observer_sets, c("A", "B"))
+})
+
+test_that("add_observed_data accepts a list of objects", {
+  source_snapshot <- load_snapshot(test_path("data", "test_snapshot.json"))
+  dataset <- source_snapshot$observed_data[[1]]
+
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+  snapshot <- suppressWarnings(
+    add_observed_data(snapshot, list(dataset, dataset))
+  )
+  expect_length(snapshot$observed_data, 2)
+})
+
+# add_*() rejects an empty list ---------------------------------------------
+
+test_that("add_compound errors on an empty list", {
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+  expect_snapshot(add_compound(snapshot, list()), error = TRUE)
+})
+
+test_that("add_individual errors on an empty list", {
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+  expect_snapshot(add_individual(snapshot, list()), error = TRUE)
+})
+
+# add_*() rejects a mixed-type list -----------------------------------------
+
+test_that("add_compound rejects a list with a wrong-class element", {
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+  bad <- list(create_compound(name = "A"), "not a compound")
+  expect_snapshot(add_compound(snapshot, bad), error = TRUE)
+})
+
+test_that("add_individual rejects a list with a wrong-class element", {
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+  bad <- list(create_individual(name = "A", age = 25), "nope")
+  expect_snapshot(add_individual(snapshot, bad), error = TRUE)
+})
+
+test_that("add_expression_profile rejects a list with a wrong-class element", {
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+  bad <- list(
+    create_expression_profile(
+      molecule = "CYP3A4",
+      species = "Human",
+      category = "Healthy",
+      type = "Enzyme"
+    ),
+    "nope"
+  )
+  expect_snapshot(add_expression_profile(snapshot, bad), error = TRUE)
+})
+
+# add_*() success message format --------------------------------------------
+
+test_that("add_*() reports the count of added entries", {
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+  expect_snapshot({
+    snapshot <- add_compound(
+      snapshot,
+      create_compound(name = "X")
+    )
+    snapshot <- add_compound(
+      snapshot,
+      list(
+        create_compound(name = "Y"),
+        create_compound(name = "Z")
+      )
+    )
+  })
+})

--- a/vignettes/creating-building-blocks.Rmd
+++ b/vignettes/creating-building-blocks.Rmd
@@ -341,7 +341,7 @@ remove_expression_profile(snapshot, "CYP3A4|Human|Healthy")
 
 ### Adding several building blocks at once
 
-`add_*()` currently takes one building block at a time, so loop over your list to add many:
+`add_*()` accepts either a single building block or a list of them, so you can attach many in one call. Each `add_*()` reports how many entries were added.
 
 ```{r}
 patients <- list(
@@ -350,9 +350,7 @@ patients <- list(
   create_individual("Patient_C", age = 65, gender = "MALE")
 )
 
-for (patient in patients) {
-  add_individual(snapshot, patient)
-}
+add_individual(snapshot, patients)
 
 snapshot$individuals
 ```


### PR DESCRIPTION
This PR vectorizes the nine `add_*()` mutators on `Snapshot` so each accepts either a single building block or a list of building blocks, matching the shape that `remove_*()` already had via character vectors since #66. The friction it removes is concrete: the "Adding several building blocks at once" vignette section no longer has to instruct readers to write a `for (patient in patients) add_individual(snapshot, patient)` loop; one call now suffices.

## Helper

`private$.add_block()` in `R/Snapshot.R` is the only place that grew vectorization logic. It normalises a single R6 object or a list into a validated list, errors on empty and mixed-class lists (with the offending index and class), runs each per-element `pre_add` hook before any mutation, appends in one shot, and emits a uniform success message. All nine R6 `add_*` methods are unchanged in shape, they just pass `label_count` instead of `label`; the exported wrappers stay thin and gain only roxygen updates.

## Message format

Both `add_*()` and `remove_*()` now emit `v Added N kind(s)` / `v Removed N kind(s)`. The previous `Added <kind> '<name>' to the snapshot` form is gone. `_snaps/{snapshot, observed-data, ObserverSet}.md` were regenerated.

## Tests

`tests/testthat/test-snapshot.R` gains per-kind batch round-trip tests for the nine kinds, empty-list and mixed-list rejection tests on a representative subset (the helper is shared, so per-kind coverage is redundant), and one consolidated success-message snapshot. Full suite: 1954 tests passing, 0 failing.

## Documentation

The "Adding several building blocks at once" section in `creating-building-blocks.Rmd` now shows the single-call form. Every `add_*()` roxygen block advertises the list shape and includes a batch example. `NEWS.md` gained one bullet at the top of "New features" describing both the new shape and the unified message format.

## Follow-up issues

Three findings from the independent code review were filed as separate issues rather than rolled in: replacing `expect_true`/`expect_false` in a pre-existing test (#95), aggregating per-element warnings in `add_observed_data()` (#96), and harmonising the mutation-by-reference pattern in `creating-building-blocks.Rmd` (#97).

Closes #92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `add_*()` functions now accept either a single building block or a list of building blocks
  * Success messages now consistently display the count of added items

* **Documentation**
  * Updated `add_*()` function documentation to reflect multi-object support and clarified return values

* **Tests**
  * Added comprehensive coverage for list-based building block additions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/esqLABS/osp.snapshots/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->