### PR TITLE
Use specific expectations in add_observed_data round-trip test

### DIFF
--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -1019,10 +1019,10 @@ test_that("add_observed_data exported wrapper round-trips", {
 
   empty <- load_snapshot(test_path("data", "empty_snapshot.json"))
   empty <- add_observed_data(empty, dataset)
-  expect_true(dataset$name %in% names(empty$observed_data))
+  expect_named(empty$observed_data, dataset$name)
 
   empty <- remove_observed_data(empty, dataset$name)
-  expect_false(dataset$name %in% names(empty$observed_data))
+  expect_length(empty$observed_data, 0)
 })
 
 test_that("add_observed_data exported wrapper errors on wrong class", {


### PR DESCRIPTION
Replace `expect_true()` / `expect_false()` membership checks in the `add_observed_data` round-trip test with `expect_named()` and `expect_length()`, so failures report what the collection actually contained instead of `Expected TRUE, got FALSE`.

Closes #95