### PR TITLE
Serialize runtime-added DataSets on export

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,7 +47,7 @@ Several previously list-shaped fields are now first-class R6 objects:
 ## Minor improvements
 
 - Building-block collections now share a `snapshot_collection` S3 class with a single generic `print()` method. The existing per-kind classes (`compound_collection`, `individual_collection`, ...) are preserved as marker classes (#34).
-- `export_snapshot()` now documents that mutations to a `DataSet` after load (e.g. changing `xUnit` on an entry in `snapshot$observed_data`) are not preserved on export. The exported `ObservedData` section is replayed from the original snapshot JSON, filtered to entries still present after `remove_observed_data()` (#35).
+- `export_snapshot()` now serializes `DataSet` objects attached at runtime via `add_observed_data()`, so a snapshot built from `create_observed_data()` and `add_observed_data()` round-trips through `export_snapshot()` and `load_snapshot()`. Entries that were already present in the loaded snapshot are still replayed from the original JSON slice, which means post-load mutations to a `DataSet` (e.g. changing `xUnit` on an entry in `snapshot$observed_data`) are not reflected on export (#35, #96).
 
 ## Bug fixes
 

--- a/R/ObservedData.R
+++ b/R/ObservedData.R
@@ -220,8 +220,8 @@ ObservedData <- loadDataSetFromSnapshot
       AuxiliaryType = "Undefined"
     ),
     Values = values_as_list(dataset$xValues),
-    Dimension = dataset$xDimension,
-    Unit = dataset$xUnit
+    Dimension = dataset$xDimension %||% "Time",
+    Unit = dataset$xUnit %||% "h"
   )
 
   data_info <- list(
@@ -235,10 +235,12 @@ ObservedData <- loadDataSetFromSnapshot
     data_info$LLOQ <- dataset$LLOQ
   }
 
+  base_path <- paste0(dataset$name, "|ObservedData|", dataset$name)
+
   column <- list(
     Name = "Avg",
     QuantityInfo = list(
-      Path = paste0(dataset$name, "|ObservedData|", dataset$name)
+      Path = paste0(base_path, "|ArithmeticMean")
     ),
     DataInfo = data_info,
     Values = values_as_list(dataset$yValues),
@@ -247,9 +249,10 @@ ObservedData <- loadDataSetFromSnapshot
   )
 
   if (length(dataset$yErrorValues) > 0) {
+    error_type <- dataset$yErrorType %||% "ArithmeticStdDev"
     related_data_info <- list(
       Origin = "ObservationAuxiliary",
-      AuxiliaryType = dataset$yErrorType %||% "ArithmeticStdDev"
+      AuxiliaryType = error_type
     )
     if (!is.null(dataset$molWeight) && !is.na(dataset$molWeight)) {
       related_data_info$MolWeight <- dataset$molWeight
@@ -257,7 +260,7 @@ ObservedData <- loadDataSetFromSnapshot
     column$RelatedColumns <- list(list(
       Name = "Var",
       QuantityInfo = list(
-        Path = paste0(dataset$name, "|ObservedData|", dataset$name)
+        Path = paste0(base_path, "|", error_type)
       ),
       DataInfo = related_data_info,
       Values = values_as_list(dataset$yErrorValues),

--- a/R/ObservedData.R
+++ b/R/ObservedData.R
@@ -190,18 +190,106 @@ loadDataSetFromSnapshot <- function(observedDataStructure) {
 #' @export
 ObservedData <- loadDataSetFromSnapshot
 
+# Serialize a runtime `ospsuite::DataSet` back into the list shape used by the
+# snapshot JSON `ObservedData[[i]]`. This is the inverse of
+# `loadDataSetFromSnapshot()` and is, like the loader, lossy: it can only emit
+# fields the public `DataSet` API exposes. In particular `QuantityInfo$Path`
+# is synthesized from `dataset$name` (the original PK-Sim hierarchical path is
+# not preserved on load), `ExtendedProperties[[i]]$Type` is always "String"
+# (the loader coerces values via `as.character` and drops the type tag), and
+# only one y-column is emitted ("Avg"); multi-column observed-data entries
+# are not representable through a single `DataSet`. The synthesized payload
+# is sufficient for round-trip through `osp.snapshots`; round-trip through
+# PK-Sim has not been validated and may require additional fields.
+.dataset_to_snapshot_list <- function(dataset) {
+  values_as_list <- function(x) {
+    if (length(x) == 0) {
+      return(list())
+    }
+    lapply(x, identity)
+  }
+
+  base_grid <- list(
+    Name = "Time",
+    QuantityInfo = list(
+      Path = paste0(dataset$name, "|Time"),
+      Type = "Time"
+    ),
+    DataInfo = list(
+      Origin = "BaseGrid",
+      AuxiliaryType = "Undefined"
+    ),
+    Values = values_as_list(dataset$xValues),
+    Dimension = dataset$xDimension,
+    Unit = dataset$xUnit
+  )
+
+  data_info <- list(
+    Origin = "Observation",
+    AuxiliaryType = "Undefined"
+  )
+  if (!is.null(dataset$molWeight) && !is.na(dataset$molWeight)) {
+    data_info$MolWeight <- dataset$molWeight
+  }
+  if (!is.null(dataset$LLOQ) && !is.na(dataset$LLOQ)) {
+    data_info$LLOQ <- dataset$LLOQ
+  }
+
+  column <- list(
+    Name = "Avg",
+    QuantityInfo = list(
+      Path = paste0(dataset$name, "|ObservedData|", dataset$name)
+    ),
+    DataInfo = data_info,
+    Values = values_as_list(dataset$yValues),
+    Dimension = dataset$yDimension,
+    Unit = dataset$yUnit
+  )
+
+  if (length(dataset$yErrorValues) > 0) {
+    related_data_info <- list(
+      Origin = "ObservationAuxiliary",
+      AuxiliaryType = dataset$yErrorType %||% "ArithmeticStdDev"
+    )
+    if (!is.null(dataset$molWeight) && !is.na(dataset$molWeight)) {
+      related_data_info$MolWeight <- dataset$molWeight
+    }
+    column$RelatedColumns <- list(list(
+      Name = "Var",
+      QuantityInfo = list(
+        Path = paste0(dataset$name, "|ObservedData|", dataset$name)
+      ),
+      DataInfo = related_data_info,
+      Values = values_as_list(dataset$yErrorValues),
+      Dimension = dataset$yDimension,
+      Unit = dataset$yErrorUnit %||% dataset$yUnit
+    ))
+  }
+
+  extended_properties <- list()
+  meta <- dataset$metaData
+  if (length(meta) > 0) {
+    extended_properties <- lapply(names(meta), function(k) {
+      list(Name = k, Value = as.character(meta[[k]]), Type = "String")
+    })
+  }
+
+  list(
+    Name = dataset$name,
+    ExtendedProperties = extended_properties,
+    Columns = list(column),
+    BaseGrid = base_grid
+  )
+}
+
 # Export adapter for the ObservedData section of a Snapshot.
 #
-# `ospsuite::DataSet` does not round-trip back to the snapshot list shape, so
-# the export payload for `ObservedData` is always replayed from the raw JSON
-# slice that was parsed at load time. Mutations to a `DataSet` after load
-# (e.g. `dataset$xUnit <- "min"`) are silently lost on export; only
-# removals (via `remove_observed_data()`) and reorderings of surviving names
-# are honoured. Items added at runtime through `add_observed_data()` cannot be
-# serialized either: their backing JSON is not in `.original_data`, so they
-# are dropped silently here. `Snapshot$add_observed_data()` warns at the time
-# of addition so the user is informed once, rather than on every `$data`
-# access (which includes `print()`).
+# Entries that are still present in the raw JSON slice (matched by name) are
+# replayed byte-for-byte from `.original_data`, so post-load mutations to a
+# loaded `DataSet` (e.g. `dataset$xUnit <- "min"`) are NOT reflected on
+# export. Entries added at runtime via `add_observed_data()` are serialized
+# through `.dataset_to_snapshot_list()`; that path is lossy (see the comment
+# on the helper) but round-trips through `osp.snapshots` itself.
 #
 # Contract:
 #   items     cache slot value: `NULL` (untouched), `list()` (cleared by
@@ -215,14 +303,21 @@ ObservedData <- loadDataSetFromSnapshot
   if (length(items) == 0) {
     return(NULL)
   }
-  surviving_names <- vapply(items, function(od) od$name, character(1))
-  original_names <- vapply(
-    original,
-    function(od) od$Name %||% od$name,
-    character(1)
-  )
-  # Use match() so the export order tracks the user's current ordering of
-  # `items` rather than the order of the original snapshot slice.
-  indices <- match(surviving_names, original_names)
-  original[indices[!is.na(indices)]]
+  original_names <- if (length(original) == 0) {
+    character()
+  } else {
+    vapply(
+      original,
+      function(od) od$Name %||% od$name,
+      character(1)
+    )
+  }
+  lapply(items, function(item) {
+    idx <- match(item$name, original_names)
+    if (!is.na(idx)) {
+      original[[idx]]
+    } else {
+      .dataset_to_snapshot_list(item)
+    }
+  })
 }

--- a/R/Snapshot.R
+++ b/R/Snapshot.R
@@ -392,12 +392,13 @@ Snapshot <- R6::R6Class(
         ensure = private$.ensure_observed_data,
         collection_class = "observed_data_collection",
         label_count = "observed data item(s)",
-        pre_add = function(obj) {
-          # Warn once at add time if the new DataSet has no backing JSON slice
-          # in `.original_data`; `ospsuite::DataSet` does not round-trip back
-          # to the snapshot list shape, so such entries are dropped on export.
-          # Warning here (rather than inside the export adapter) keeps
-          # `print()` and other `$data` accesses quiet.
+        pre_add = function(objs) {
+          # Warn once at add time for any new DataSet without a backing JSON
+          # slice in `.original_data`; `ospsuite::DataSet` does not round-trip
+          # back to the snapshot list shape, so such entries are dropped on
+          # export. Warning here (rather than inside the export adapter) keeps
+          # `print()` and other `$data` accesses quiet. Aggregated into a
+          # single message so batched adds do not produce N warning blocks.
           original <- private$.original_data$ObservedData
           original_names <- if (is.null(original)) {
             character()
@@ -408,9 +409,14 @@ Snapshot <- R6::R6Class(
               character(1)
             )
           }
-          if (!(obj$name %in% original_names)) {
+          non_backed_names <- vapply(
+            Filter(\(obj) !(obj$name %in% original_names), objs),
+            \(obj) obj$name,
+            character(1)
+          )
+          if (length(non_backed_names) > 0) {
             cli::cli_warn(c(
-              "Observed data {.val {obj$name}} cannot be serialized on export.",
+              "{length(non_backed_names)} observed data item{?s} cannot be serialized on export: {.val {non_backed_names}}",
               i = "{.cls DataSet} objects have no {.code $data} accessor; only entries present in the original snapshot are exported."
             ))
           }
@@ -957,8 +963,9 @@ Snapshot <- R6::R6Class(
     # `ensure()`, appends the validated objects to the unnamed cache slot in
     # one shot, rebuilds the named cache via `.build_named_list`, and emits a
     # success message counting the entries added. `pre_add`, when supplied,
-    # runs once per element before any mutation; it is used by
-    # `add_observed_data` to warn about un-serializable DataSets.
+    # runs once with the full validated list before any mutation; it is used
+    # by `add_observed_data` to warn about un-serializable DataSets in a
+    # single aggregated message.
     .add_block = function(
       obj,
       expected_class,
@@ -1001,9 +1008,7 @@ Snapshot <- R6::R6Class(
       }
 
       if (!is.null(pre_add)) {
-        for (el in objs) {
-          pre_add(el)
-        }
+        pre_add(objs)
       }
 
       ensure()

--- a/R/Snapshot.R
+++ b/R/Snapshot.R
@@ -391,36 +391,7 @@ Snapshot <- R6::R6Class(
         named_slot = ".observed_data_named",
         ensure = private$.ensure_observed_data,
         collection_class = "observed_data_collection",
-        label_count = "observed data item(s)",
-        pre_add = function(objs) {
-          # Warn once at add time for any new DataSet without a backing JSON
-          # slice in `.original_data`; `ospsuite::DataSet` does not round-trip
-          # back to the snapshot list shape, so such entries are dropped on
-          # export. Warning here (rather than inside the export adapter) keeps
-          # `print()` and other `$data` accesses quiet. Aggregated into a
-          # single message so batched adds do not produce N warning blocks.
-          original <- private$.original_data$ObservedData
-          original_names <- if (is.null(original)) {
-            character()
-          } else {
-            vapply(
-              original,
-              function(od) od$Name %||% od$name,
-              character(1)
-            )
-          }
-          non_backed_names <- vapply(
-            Filter(\(obj) !(obj$name %in% original_names), objs),
-            \(obj) obj$name,
-            character(1)
-          )
-          if (length(non_backed_names) > 0) {
-            cli::cli_warn(c(
-              "{length(non_backed_names)} observed data item{?s} cannot be serialized on export: {.val {non_backed_names}}",
-              i = "{.cls DataSet} objects have no {.code $data} accessor; only entries present in the original snapshot are exported."
-            ))
-          }
-        }
+        label_count = "observed data item(s)"
       )
     },
 
@@ -962,10 +933,7 @@ Snapshot <- R6::R6Class(
     # rejects mixed-type lists and empty lists. Forces lazy construction via
     # `ensure()`, appends the validated objects to the unnamed cache slot in
     # one shot, rebuilds the named cache via `.build_named_list`, and emits a
-    # success message counting the entries added. `pre_add`, when supplied,
-    # runs once with the full validated list before any mutation; it is used
-    # by `add_observed_data` to warn about un-serializable DataSets in a
-    # single aggregated message.
+    # success message counting the entries added.
     .add_block = function(
       obj,
       expected_class,
@@ -975,8 +943,7 @@ Snapshot <- R6::R6Class(
       collection_class,
       label_count,
       key_fn = \(x) x$name,
-      class_article = "a",
-      pre_add = NULL
+      class_article = "a"
     ) {
       if (inherits(obj, expected_class)) {
         objs <- list(obj)
@@ -1005,10 +972,6 @@ Snapshot <- R6::R6Class(
           "Must supply at least one {.cls {expected_class}}.",
           call = rlang::caller_env()
         )
-      }
-
-      if (!is.null(pre_add)) {
-        pre_add(objs)
       }
 
       ensure()

--- a/tests/testthat/_snaps/observed-data.md
+++ b/tests/testthat/_snaps/observed-data.md
@@ -33,25 +33,3 @@
       #   xDimension <chr>, xUnit <chr>, yDimension <chr>, yUnit <chr>,
       #   yErrorType <chr>, yErrorUnit <chr>, molWeight <dbl>, lloq <dbl>
 
-# add_observed_data warns when the dataset has no backing snapshot slice
-
-    Code
-      snapshot$add_observed_data(dataset)
-    Condition
-      Warning:
-      1 observed data item cannot be serialized on export: "Backman 1996 - Control (Perpetrator Placebo) - Midazolam - PO - 15 mg - Plasma - agg. (n=10)"
-      i <DataSet> objects have no `$data` accessor; only entries present in the original snapshot are exported.
-    Message
-      v Added 1 observed data item(s)
-
-# add_observed_data aggregates the warning when adding several non-backed DataSets at once
-
-    Code
-      snapshot$add_observed_data(datasets)
-    Condition
-      Warning:
-      3 observed data items cannot be serialized on export: "Backman 1996 - Control (Perpetrator Placebo) - Midazolam - PO - 15 mg - Plasma - agg. (n=10)", "Backman 1996 - with Perpetrator (Rifampicin) - Midazolam - PO - 15 mg - Plasma - agg. (n=10)", and "Backman 1998 - Phase I (Control (Perpetrator Placebo)) - Midazolam - PO - 15 mg - Plasma - agg. (n=9)"
-      i <DataSet> objects have no `$data` accessor; only entries present in the original snapshot are exported.
-    Message
-      v Added 3 observed data item(s)
-

--- a/tests/testthat/_snaps/observed-data.md
+++ b/tests/testthat/_snaps/observed-data.md
@@ -39,8 +39,19 @@
       snapshot$add_observed_data(dataset)
     Condition
       Warning:
-      Observed data "Backman 1996 - Control (Perpetrator Placebo) - Midazolam - PO - 15 mg - Plasma - agg. (n=10)" cannot be serialized on export.
+      1 observed data item cannot be serialized on export: "Backman 1996 - Control (Perpetrator Placebo) - Midazolam - PO - 15 mg - Plasma - agg. (n=10)"
       i <DataSet> objects have no `$data` accessor; only entries present in the original snapshot are exported.
     Message
       v Added 1 observed data item(s)
+
+# add_observed_data aggregates the warning when adding several non-backed DataSets at once
+
+    Code
+      snapshot$add_observed_data(datasets)
+    Condition
+      Warning:
+      3 observed data items cannot be serialized on export: "Backman 1996 - Control (Perpetrator Placebo) - Midazolam - PO - 15 mg - Plasma - agg. (n=10)", "Backman 1996 - with Perpetrator (Rifampicin) - Midazolam - PO - 15 mg - Plasma - agg. (n=10)", and "Backman 1998 - Phase I (Control (Perpetrator Placebo)) - Midazolam - PO - 15 mg - Plasma - agg. (n=9)"
+      i <DataSet> objects have no `$data` accessor; only entries present in the original snapshot are exported.
+    Message
+      v Added 3 observed data item(s)
 

--- a/tests/testthat/test-observed-data.R
+++ b/tests/testthat/test-observed-data.R
@@ -256,6 +256,7 @@ test_that("export_snapshot round-trips a runtime DataSet added to an empty snaps
   expect_equal(ds2$yErrorValues, dataset$yErrorValues)
   expect_equal(ds2$xUnit, dataset$xUnit)
   expect_equal(ds2$yUnit, dataset$yUnit)
+  expect_equal(ds2$xDimension, dataset$xDimension)
   expect_equal(ds2$yDimension, dataset$yDimension)
   expect_equal(ds2$yErrorType, dataset$yErrorType)
   expect_equal(ds2$yErrorUnit, dataset$yErrorUnit)

--- a/tests/testthat/test-observed-data.R
+++ b/tests/testthat/test-observed-data.R
@@ -99,12 +99,10 @@ test_that("get_observed_data_dfs function works", {
 })
 
 test_that("add_observed_data method works", {
-  # Use a DataSet from test snapshot
   dataset <- test_snapshot$observed_data[[1]]
 
-  # Add to empty snapshot (warning about runtime-only DataSet is expected)
   initial_count <- length(empty_snapshot$observed_data)
-  suppressWarnings(empty_snapshot$add_observed_data(dataset))
+  empty_snapshot$add_observed_data(dataset)
 
   expect_equal(length(empty_snapshot$observed_data), initial_count + 1)
   expect_true(dataset$name %in% names(empty_snapshot$observed_data))
@@ -114,13 +112,11 @@ test_that("add_observed_data method works", {
 })
 
 test_that("remove_observed_data method works", {
-  # First add a DataSet to test removal
   dataset <- test_snapshot$observed_data[[1]]
 
-  suppressWarnings(empty_snapshot$add_observed_data(dataset))
+  empty_snapshot$add_observed_data(dataset)
   initial_count <- length(empty_snapshot$observed_data)
 
-  # Remove the added observed data
   empty_snapshot$remove_observed_data(dataset$name)
 
   expect_equal(length(empty_snapshot$observed_data), initial_count - 1)
@@ -227,22 +223,68 @@ test_that("Snapshot export preserves the user's ordering of observed data", {
   expect_equal(exported_names, cache_names)
 })
 
-test_that("add_observed_data warns when the dataset has no backing snapshot slice", {
+test_that("add_observed_data does not warn for runtime DataSets", {
   snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
   dataset <- test_snapshot$observed_data[[1]]
-  expect_snapshot(snapshot$add_observed_data(dataset))
+  expect_no_warning(snapshot$add_observed_data(dataset))
 })
 
-test_that("add_observed_data aggregates the warning when adding several non-backed DataSets at once", {
+test_that("export_snapshot round-trips a runtime DataSet added to an empty snapshot", {
+  dataset <- create_observed_data(
+    name = "Round-trip Study",
+    time = c(0, 1, 2, 4),
+    values = c(0, 5, 8, 4),
+    value_dimension = "Concentration (mass)",
+    value_unit = "mg/l",
+    error = c(0.1, 0.5, 0.8, 0.4),
+    error_type = "ArithmeticStdDev",
+    error_unit = "mg/l",
+    metadata = list(Source = "Test", Note = "synthetic")
+  )
   snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
-  datasets <- test_snapshot$observed_data[1:3]
-  expect_snapshot(snapshot$add_observed_data(datasets))
+  snapshot <- add_observed_data(snapshot, dataset)
+
+  out_path <- withr::local_tempfile(fileext = ".json")
+  export_snapshot(snapshot, out_path)
+  reloaded <- load_snapshot(out_path)
+
+  expect_length(reloaded$observed_data, 1)
+  ds2 <- reloaded$observed_data[[1]]
+  expect_equal(ds2$name, dataset$name)
+  expect_equal(ds2$xValues, dataset$xValues)
+  expect_equal(ds2$yValues, dataset$yValues)
+  expect_equal(ds2$yErrorValues, dataset$yErrorValues)
+  expect_equal(ds2$xUnit, dataset$xUnit)
+  expect_equal(ds2$yUnit, dataset$yUnit)
+  expect_equal(ds2$yDimension, dataset$yDimension)
+  expect_equal(ds2$yErrorType, dataset$yErrorType)
+  expect_equal(ds2$yErrorUnit, dataset$yErrorUnit)
+  expect_equal(ds2$metaData, dataset$metaData)
+})
+
+test_that("export_snapshot replays the original JSON slice for backed entries even when new runtime entries are added", {
+  source_snapshot <- load_snapshot(test_path("data", "test_snapshot.json"))
+  original_slice <- source_snapshot$data$ObservedData[[1]]
+
+  extra <- create_observed_data(
+    name = "Extra Runtime",
+    time = c(0, 1),
+    values = c(0, 1),
+    value_dimension = "Concentration (mass)",
+    value_unit = "mg/l"
+  )
+  source_snapshot <- add_observed_data(source_snapshot, extra)
+
+  out_path <- withr::local_tempfile(fileext = ".json")
+  export_snapshot(source_snapshot, out_path)
+  raw <- jsonlite::fromJSON(out_path, simplifyVector = FALSE)
+  expect_equal(raw$ObservedData[[1]], original_slice)
 })
 
 test_that("Snapshot$print stays quiet when runtime DataSet entries are present", {
   snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
   dataset <- test_snapshot$observed_data[[1]]
-  suppressWarnings(suppressMessages(snapshot$add_observed_data(dataset)))
+  suppressMessages(snapshot$add_observed_data(dataset))
   expect_no_warning(snapshot$data)
   expect_no_warning(capture.output(print(snapshot)))
 })
@@ -312,8 +354,8 @@ test_that("DataSet handles duplicate names correctly", {
   dataset1 <- test_snapshot$observed_data[[1]]
   dataset2 <- test_snapshot$observed_data[[1]] # Same DataSet
 
-  suppressWarnings(temp_empty$add_observed_data(dataset1))
-  suppressWarnings(temp_empty$add_observed_data(dataset2))
+  temp_empty$add_observed_data(dataset1)
+  temp_empty$add_observed_data(dataset2)
 
   # Check that both are added with disambiguated names
   expect_equal(length(temp_empty$observed_data), 2)
@@ -375,7 +417,7 @@ test_that("add/remove observed data updates export data", {
 
   # Add a DataSet
   dataset <- test_snapshot$observed_data[[1]]
-  suppressWarnings(temp_empty$add_observed_data(dataset))
+  temp_empty$add_observed_data(dataset)
 
   # Check export data is updated (note: export functionality may be different now)
   updated_data <- temp_empty$data
@@ -399,7 +441,7 @@ test_that("Convenience functions work correctly", {
 
   # Use method calls directly
   initial_count <- length(temp_empty$observed_data)
-  suppressWarnings(temp_empty$add_observed_data(dataset))
+  temp_empty$add_observed_data(dataset)
   expect_equal(length(temp_empty$observed_data), initial_count + 1)
 
   # Test remove_observed_data method

--- a/tests/testthat/test-observed-data.R
+++ b/tests/testthat/test-observed-data.R
@@ -233,6 +233,12 @@ test_that("add_observed_data warns when the dataset has no backing snapshot slic
   expect_snapshot(snapshot$add_observed_data(dataset))
 })
 
+test_that("add_observed_data aggregates the warning when adding several non-backed DataSets at once", {
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+  datasets <- test_snapshot$observed_data[1:3]
+  expect_snapshot(snapshot$add_observed_data(datasets))
+})
+
 test_that("Snapshot$print stays quiet when runtime DataSet entries are present", {
   snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
   dataset <- test_snapshot$observed_data[[1]]

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -1157,9 +1157,7 @@ test_that("add_observed_data accepts a list of objects", {
   dataset <- source_snapshot$observed_data[[1]]
 
   snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
-  snapshot <- suppressWarnings(
-    add_observed_data(snapshot, list(dataset, dataset))
-  )
+  snapshot <- add_observed_data(snapshot, list(dataset, dataset))
   expect_length(snapshot$observed_data, 2)
 })
 

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -985,7 +985,7 @@ test_that("remove_observed_data warns when name is missing", {
   dataset <- source_snapshot$observed_data[[1]]
 
   snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
-  snapshot <- suppressWarnings(add_observed_data(snapshot, dataset))
+  snapshot <- add_observed_data(snapshot, dataset)
   expect_snapshot(remove_observed_data(snapshot, "Other"))
 })
 
@@ -999,7 +999,7 @@ test_that("remove_observed_data reports the actual count when some names are mis
   dataset <- source_snapshot$observed_data[[1]]
 
   snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
-  snapshot <- suppressWarnings(add_observed_data(snapshot, dataset))
+  snapshot <- add_observed_data(snapshot, dataset)
   expect_snapshot(remove_observed_data(snapshot, c(dataset$name, "Other")))
 })
 


### PR DESCRIPTION
Runtime-added `ospsuite::DataSet` objects used to be dropped on export (with a warning at add time) because `DataSet` doesn't round-trip back to the snapshot JSON shape natively. The `DataSet` API exposes enough state, though, that we can reconstruct the JSON ourselves. This PR adds that reconstruction and removes the warning.

## Serializer

`R/ObservedData.R` gains a private `.dataset_to_snapshot_list(dataset)` that inverts the existing `loadDataSetFromSnapshot()`: it emits `BaseGrid`, a single `Columns[[1]]` (with `RelatedColumns` when error values are present), and `ExtendedProperties` from `dataset$metaData`. Synthesized `QuantityInfo$Path` values follow PK-Sim's convention of distinguishing the primary column (suffix `|ArithmeticMean`) from the auxiliary column (suffix `|<errorType>`). The synthesis is lossy in the same places the loader is lossy (multi-column data, `ExtendedProperties$Type`, deep PK-Sim hierarchical paths); the comment block above the helper documents the loss surface.

`.observed_data_export_adapter()` now replays the original JSON slice byte-for-byte for entries still present in `.original_data`, and serializes the rest through the new helper. Order follows the user's current cache ordering.

## Warning removed

`Snapshot$add_observed_data()` no longer warns about runtime DataSets, and the `pre_add` plumbing on the private `.add_block()` helper (`add_observed_data` was its only caller) is gone too. `suppressWarnings()` wrappers around `add_observed_data()` calls in the test suite are unwrapped.

## Tests

`tests/testthat/test-observed-data.R` gains a round-trip test (build via `create_observed_data()`, add, export, reload, assert every field including error series and metaData) and a backed-replay test (verifies that adding a runtime entry alongside a backed one does not perturb the original slice on export). Two warning snapshots are deleted.

## Scope note

Round-trip through `osp.snapshots` itself is verified by the tests. Round-trip through PK-Sim (reloading the exported JSON in PK-Sim) has not been validated and may need additional fields the loader currently drops; that's a separate effort.

Closes #96