### PR TITLE
Expose full ExplicitFormula on Observer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,7 +30,7 @@ You can now convert any building-block collection to a tibble through one entry 
 
 - `as_tibbles(snapshot, kind)` returns either a bare tibble (`"protocols"`, `"observed_data"`) or a named list of related tibbles (every other kind). The eight existing `get_*_dfs()` functions remain available as thin wrappers (#36).
 
-Observer sets are now fully supported. Each `ObserverSet` exposes its observers as a named list of `Observer` objects with `name`, `type`, `dimension`, `formula`, and `container_tags`. `get_observer_sets_dfs()` returns two tibbles (`observer_sets` for set-level rows, `observers` joinable back via `observer_set_id` / `observer_set_name`) (#38, #42, #76).
+Observer sets are now fully supported. Each `ObserverSet` exposes its observers as a named list of `Observer` objects with `name`, `type`, `dimension`, `formula` (the full `ExplicitFormula` list), `formula_expression`, `formula_dimension`, `formula_references`, and `container_tags`. `get_observer_sets_dfs()` returns two tibbles (`observer_sets` for set-level rows, `observers` joinable back via `observer_set_id` / `observer_set_name`); the `observers` tibble carries `formula_expression`, `formula_dimension`, and `formula_references` columns alongside `name`, `type`, `dimension`, and `container_tags` (#38, #42, #76, #79).
 
 Several previously list-shaped fields are now first-class R6 objects:
 

--- a/R/Observer.R
+++ b/R/Observer.R
@@ -19,11 +19,22 @@
 #'   Name = "brain_plasma_conc",
 #'   Type = "Container",
 #'   Dimension = "Concentration (molar)",
-#'   Formula = list(Formula = "Conc_Br")
+#'   Formula = list(
+#'     Name = "brain_plasma_conc_formula",
+#'     Formula = "Conc_Br",
+#'     Dimension = "Concentration (molar)",
+#'     References = list(list(
+#'       Alias = "Conc_Br",
+#'       Path = "Organism|Brain|Plasma|Drug|Concentration",
+#'       Dimension = "Concentration (molar)"
+#'     ))
+#'   )
 #' ))
 #' observer$name
 #' observer$type
-#' observer$dimension
+#' observer$formula_expression
+#' observer$formula_dimension
+#' observer$formula_references
 Observer <- R6::R6Class(
   classname = "Observer",
   public = list(
@@ -52,8 +63,11 @@ Observer <- R6::R6Class(
         if (!is.null(self$dimension)) {
           cli::cli_li("Dimension: {self$dimension}")
         }
-        if (!is.null(self$formula)) {
-          cli::cli_li("Formula: {self$formula}")
+        if (!is.null(self$formula_expression)) {
+          cli::cli_li("Formula expression: {self$formula_expression}")
+        }
+        if (!is.null(self$formula_dimension)) {
+          cli::cli_li("Formula dimension: {self$formula_dimension}")
         }
         if (!is.null(self$container_tags)) {
           cli::cli_li("Container tags: {self$container_tags}")
@@ -66,14 +80,22 @@ Observer <- R6::R6Class(
     #' @description
     #' Convert the observer to a single-row tibble suitable for the
     #' tibble-layer exporter. Columns are `name`, `type`, `dimension`,
-    #' `formula`, and `container_tags`.
+    #' `formula_expression`, `formula_dimension`, `formula_references`,
+    #' and `container_tags`. `formula_references` collapses each
+    #' `FormulaUsablePath` entry (`Alias`, `Path`, `Dimension`) to
+    #' `"alias=path"` and joins entries with `|`; `NA` when the observer
+    #' carries no references.
     #' @return A tibble with one row.
     to_df = function() {
       tibble::tibble(
         name = self$name %||% NA_character_,
         type = self$type %||% NA_character_,
         dimension = self$dimension %||% NA_character_,
-        formula = self$formula %||% NA_character_,
+        formula_expression = self$formula_expression %||% NA_character_,
+        formula_dimension = self$formula_dimension %||% NA_character_,
+        formula_references = format_formula_references(
+          self$formula_references
+        ),
         container_tags = self$container_tags %||% NA_character_
       )
     }
@@ -115,12 +137,28 @@ Observer <- R6::R6Class(
       private$.data$Dimension <- value
     },
 
-    #' @field formula The formula expression string. Read from the inner
-    #'   `Formula$Formula` field of the underlying `ExplicitFormula`
-    #'   object; this binding does not expose `References` or `Dimension`.
-    #'   Setting this field writes back to `Formula$Formula` only. To
-    #'   access the full `ExplicitFormula`, use `observer$data$Formula`.
+    #' @field formula The full `ExplicitFormula` object backing the
+    #'   observer, as a list with `Name`, `Formula` (the expression
+    #'   string), `Dimension`, and `References` (a list of
+    #'   `FormulaUsablePath` entries, each with `Alias`, `Path`, and
+    #'   `Dimension`). `NULL` when the observer carries no formula.
+    #'   Setting this field replaces the whole structure; pass `NULL` to
+    #'   drop it. For the inner expression string or dimension only, use
+    #'   `formula_expression` or `formula_dimension`.
     formula = function(value) {
+      if (missing(value)) {
+        return(private$.data$Formula)
+      }
+      private$.data$Formula <- value
+    },
+
+    #' @field formula_expression The expression string of the underlying
+    #'   `ExplicitFormula` (`Formula$Formula` in the snapshot JSON).
+    #'   Setting writes back to the inner `Formula$Formula` field and
+    #'   preserves the sibling `Name`, `Dimension`, and `References`
+    #'   entries. To build a complete `ExplicitFormula` (including
+    #'   `Name` and `References`), assign to `formula` instead.
+    formula_expression = function(value) {
       if (missing(value)) {
         return(private$.data$Formula$Formula)
       }
@@ -128,6 +166,33 @@ Observer <- R6::R6Class(
         private$.data$Formula <- list()
       }
       private$.data$Formula$Formula <- value
+    },
+
+    #' @field formula_dimension The output dimension of the underlying
+    #'   `ExplicitFormula` (`Formula$Dimension` in the snapshot JSON),
+    #'   resolved in PK-Sim via `IDimensionRepository.DimensionByName()`.
+    #'   Setting writes back to the inner `Formula$Dimension` field.
+    formula_dimension = function(value) {
+      if (missing(value)) {
+        return(private$.data$Formula$Dimension)
+      }
+      if (is.null(private$.data$Formula)) {
+        private$.data$Formula <- list()
+      }
+      private$.data$Formula$Dimension <- value
+    },
+
+    #' @field formula_references The `References` list of the underlying
+    #'   `ExplicitFormula`, where each entry is a named list with
+    #'   `Alias`, `Path`, and `Dimension`. Read-only; mutate the whole
+    #'   structure through `formula`.
+    formula_references = function(value) {
+      if (!missing(value)) {
+        cli::cli_abort(
+          "{.field formula_references} is read-only; assign through {.field formula} instead"
+        )
+      }
+      private$.data$Formula$References
     },
 
     #' @field container_tags The `Tag` values from the observer's
@@ -159,6 +224,26 @@ Observer <- R6::R6Class(
     .data = NULL
   )
 )
+
+# Internal: collapse a `References` list (each entry an `Alias`/`Path`
+# /`Dimension` triple) into a single string of `"alias=path"` pairs joined
+# with `|`. Returns `NA_character_` for empty or `NULL` input so the
+# Observer tibble layer can use it as a column value.
+format_formula_references <- function(references) {
+  if (is.null(references) || length(references) == 0) {
+    return(NA_character_)
+  }
+  parts <- vapply(
+    references,
+    function(ref) {
+      alias <- ref$Alias %||% ""
+      path <- ref$Path %||% ""
+      paste0(alias, "=", path)
+    },
+    character(1)
+  )
+  paste(parts, collapse = "|")
+}
 
 # Internal: build a flat named list of `Observer` objects from a raw
 # `Observer[]` list. Duplicate names are disambiguated with the standard

--- a/R/snapshot_dataframes.R
+++ b/R/snapshot_dataframes.R
@@ -440,7 +440,9 @@ empty_observers_tibble <- function() {
     name = character(0),
     type = character(0),
     dimension = character(0),
-    formula = character(0),
+    formula_expression = character(0),
+    formula_dimension = character(0),
+    formula_references = character(0),
     container_tags = character(0)
   )
 }
@@ -631,8 +633,11 @@ get_protocols_dfs <- function(snapshot) {
 #'   `ObserverSet` with columns `observer_set_id`, `name`,
 #'   `n_observers`. `observers` has one row per `Observer` with columns
 #'   `observer_set_id`, `observer_set_name`, `name`, `type`,
-#'   `dimension`, `formula`, `container_tags`; rows join back to their
+#'   `dimension`, `formula_expression`, `formula_dimension`,
+#'   `formula_references`, `container_tags`; rows join back to their
 #'   parent `ObserverSet` by `observer_set_id` or `observer_set_name`.
+#'   `formula_references` flattens the underlying `ExplicitFormula`
+#'   references to `"alias=path"` pairs joined with `|`.
 #'
 #' @export
 #'

--- a/man/Observer.Rd
+++ b/man/Observer.Rd
@@ -19,11 +19,22 @@ observer <- Observer$new(list(
   Name = "brain_plasma_conc",
   Type = "Container",
   Dimension = "Concentration (molar)",
-  Formula = list(Formula = "Conc_Br")
+  Formula = list(
+    Name = "brain_plasma_conc_formula",
+    Formula = "Conc_Br",
+    Dimension = "Concentration (molar)",
+    References = list(list(
+      Alias = "Conc_Br",
+      Path = "Organism|Brain|Plasma|Drug|Concentration",
+      Dimension = "Concentration (molar)"
+    ))
+  )
 ))
 observer$name
 observer$type
-observer$dimension
+observer$formula_expression
+observer$formula_dimension
+observer$formula_references
 }
 \section{Active bindings}{
   \if{html}{\out{<div class="r6-active-bindings">}}
@@ -40,11 +51,31 @@ JSON (read-only).}
     \item{\code{dimension}}{The dimension of the observed quantity, resolved
 in PK-Sim via \code{IDimensionRepository.DimensionByName()}.}
 
-    \item{\code{formula}}{The formula expression string. Read from the inner
-\code{Formula$Formula} field of the underlying \code{ExplicitFormula}
-object; this binding does not expose \code{References} or \code{Dimension}.
-Setting this field writes back to \code{Formula$Formula} only. To
-access the full \code{ExplicitFormula}, use \code{observer$data$Formula}.}
+    \item{\code{formula}}{The full \code{ExplicitFormula} object backing the
+observer, as a list with \code{Name}, \code{Formula} (the expression
+string), \code{Dimension}, and \code{References} (a list of
+\code{FormulaUsablePath} entries, each with \code{Alias}, \code{Path}, and
+\code{Dimension}). \code{NULL} when the observer carries no formula.
+Setting this field replaces the whole structure; pass \code{NULL} to
+drop it. For the inner expression string or dimension only, use
+\code{formula_expression} or \code{formula_dimension}.}
+
+    \item{\code{formula_expression}}{The expression string of the underlying
+\code{ExplicitFormula} (\code{Formula$Formula} in the snapshot JSON).
+Setting writes back to the inner \code{Formula$Formula} field and
+preserves the sibling \code{Name}, \code{Dimension}, and \code{References}
+entries. To build a complete \code{ExplicitFormula} (including
+\code{Name} and \code{References}), assign to \code{formula} instead.}
+
+    \item{\code{formula_dimension}}{The output dimension of the underlying
+\code{ExplicitFormula} (\code{Formula$Dimension} in the snapshot JSON),
+resolved in PK-Sim via \code{IDimensionRepository.DimensionByName()}.
+Setting writes back to the inner \code{Formula$Dimension} field.}
+
+    \item{\code{formula_references}}{The \code{References} list of the underlying
+\code{ExplicitFormula}, where each entry is a named list with
+\code{Alias}, \code{Path}, and \code{Dimension}. Read-only; mutate the whole
+structure through \code{formula}.}
 
     \item{\code{container_tags}}{The \code{Tag} values from the observer's
 \code{ContainerCriteria}, joined with \code{|}. There is no \code{ContainerPath}
@@ -114,7 +145,11 @@ an empty list, both of which create an empty observer.}
 \subsection{\code{Observer$to_df()}}{
   Convert the observer to a single-row tibble suitable for the
 tibble-layer exporter. Columns are \code{name}, \code{type}, \code{dimension},
-\code{formula}, and \code{container_tags}.
+\code{formula_expression}, \code{formula_dimension}, \code{formula_references},
+and \code{container_tags}. \code{formula_references} collapses each
+\code{FormulaUsablePath} entry (\code{Alias}, \code{Path}, \code{Dimension}) to
+\code{"alias=path"} and joins entries with \code{|}; \code{NA} when the observer
+carries no references.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Observer$to_df()}

--- a/man/get_observer_sets_dfs.Rd
+++ b/man/get_observer_sets_dfs.Rd
@@ -14,8 +14,11 @@ A list with two tibbles. \code{observer_sets} has one row per
 \code{ObserverSet} with columns \code{observer_set_id}, \code{name},
 \code{n_observers}. \code{observers} has one row per \code{Observer} with columns
 \code{observer_set_id}, \code{observer_set_name}, \code{name}, \code{type},
-\code{dimension}, \code{formula}, \code{container_tags}; rows join back to their
+\code{dimension}, \code{formula_expression}, \code{formula_dimension},
+\code{formula_references}, \code{container_tags}; rows join back to their
 parent \code{ObserverSet} by \code{observer_set_id} or \code{observer_set_name}.
+\code{formula_references} flattens the underlying \code{ExplicitFormula}
+references to \code{"alias=path"} pairs joined with \code{|}.
 }
 \description{
 Thin wrapper around \code{\link[=as_tibbles]{as_tibbles()}} with \code{kind = "observer_sets"}.

--- a/tests/testthat/_snaps/Observer.md
+++ b/tests/testthat/_snaps/Observer.md
@@ -1,3 +1,11 @@
+# Observer formula_references is read-only
+
+    Code
+      observer$formula_references <- list()
+    Condition
+      Error:
+      ! formula_references is read-only; assign through formula instead
+
 # Observer container_tags is read-only
 
     Code
@@ -23,6 +31,6 @@
       -- Observer: brain_plasma 
       * Type: Container
       * Dimension: Concentration (molar)
-      * Formula: Conc_Br
+      * Formula expression: Conc_Br
       * Container tags: Brain
 

--- a/tests/testthat/test-Observer.R
+++ b/tests/testthat/test-Observer.R
@@ -14,7 +14,8 @@ test_that("Observer class initialization works", {
   expect_equal(observer$name, "brain_plasma")
   expect_equal(observer$type, "Container")
   expect_equal(observer$dimension, "Concentration (molar)")
-  expect_equal(observer$formula, "Conc_Br")
+  expect_equal(observer$formula, list(Formula = "Conc_Br"))
+  expect_equal(observer$formula_expression, "Conc_Br")
   expect_equal(observer$container_tags, "Brain")
   expect_equal(observer$data, data)
 })
@@ -25,6 +26,9 @@ test_that("Observer handles empty and NULL data", {
   expect_null(empty$type)
   expect_null(empty$dimension)
   expect_null(empty$formula)
+  expect_null(empty$formula_expression)
+  expect_null(empty$formula_dimension)
+  expect_null(empty$formula_references)
   expect_null(empty$container_tags)
 
   null_data <- Observer$new(NULL)
@@ -58,26 +62,109 @@ test_that("Observer dimension setter round-trips through data", {
   expect_equal(observer$data$Dimension, "Time")
 })
 
-test_that("Observer formula setter writes into nested Formula", {
+test_that("Observer formula returns the full ExplicitFormula list", {
+  observer <- Observer$new(list(
+    Name = "x",
+    Formula = list(
+      Name = "f",
+      Formula = "Conc",
+      Dimension = "D",
+      References = list(list(Alias = "Conc", Path = "p", Dimension = "D"))
+    )
+  ))
+
+  expect_equal(
+    observer$formula,
+    list(
+      Name = "f",
+      Formula = "Conc",
+      Dimension = "D",
+      References = list(list(Alias = "Conc", Path = "p", Dimension = "D"))
+    )
+  )
+})
+
+test_that("Observer formula setter replaces the whole structure", {
+  observer <- Observer$new(list(
+    Name = "x",
+    Formula = list(Name = "old", Formula = "Conc", Dimension = "D")
+  ))
+
+  observer$formula <- list(Name = "new", Formula = "2*Conc")
+
+  expect_equal(observer$data$Formula, list(Name = "new", Formula = "2*Conc"))
+})
+
+test_that("Observer formula setter accepts NULL to drop the formula", {
+  observer <- Observer$new(list(
+    Name = "x",
+    Formula = list(Formula = "Conc")
+  ))
+
+  observer$formula <- NULL
+
+  expect_null(observer$formula)
+  expect_null(observer$data$Formula)
+})
+
+test_that("Observer formula_expression setter writes into nested Formula", {
   observer <- Observer$new(list(Name = "x"))
 
-  observer$formula <- "2*Conc"
+  observer$formula_expression <- "2*Conc"
 
-  expect_equal(observer$formula, "2*Conc")
+  expect_equal(observer$formula_expression, "2*Conc")
   expect_equal(observer$data$Formula$Formula, "2*Conc")
 })
 
-test_that("Observer formula setter preserves existing Formula fields", {
+test_that("Observer formula_expression setter preserves sibling fields", {
   observer <- Observer$new(list(
     Name = "x",
     Formula = list(Name = "f", Formula = "Conc", Dimension = "D")
   ))
 
-  observer$formula <- "2*Conc"
+  observer$formula_expression <- "2*Conc"
 
   expect_equal(observer$data$Formula$Formula, "2*Conc")
   expect_equal(observer$data$Formula$Name, "f")
   expect_equal(observer$data$Formula$Dimension, "D")
+})
+
+test_that("Observer formula_dimension round-trips through nested Formula", {
+  observer <- Observer$new(list(
+    Name = "x",
+    Formula = list(Formula = "Conc", Dimension = "Concentration (molar)")
+  ))
+
+  expect_equal(observer$formula_dimension, "Concentration (molar)")
+
+  observer$formula_dimension <- "Time"
+
+  expect_equal(observer$formula_dimension, "Time")
+  expect_equal(observer$data$Formula$Dimension, "Time")
+  expect_equal(observer$data$Formula$Formula, "Conc")
+})
+
+test_that("Observer formula_references reads References from Formula", {
+  refs <- list(
+    list(Alias = "Conc_Br", Path = "Brain|Conc", Dimension = "C"),
+    list(Alias = "Vol_Br", Path = "Brain|Vol", Dimension = "V")
+  )
+  observer <- Observer$new(list(
+    Name = "x",
+    Formula = list(Formula = "Conc_Br/Vol_Br", References = refs)
+  ))
+
+  expect_equal(observer$formula_references, refs)
+})
+
+test_that("Observer formula_references is NULL when no formula present", {
+  observer <- Observer$new(list(Name = "x"))
+  expect_null(observer$formula_references)
+})
+
+test_that("Observer formula_references is read-only", {
+  observer <- Observer$new(list(Name = "x"))
+  expect_snapshot(observer$formula_references <- list(), error = TRUE)
 })
 
 test_that("Observer container_tags joins multiple tags", {
@@ -107,7 +194,11 @@ test_that("Observer to_df returns a single-row tibble", {
     Name = "obs",
     Type = "Amount",
     Dimension = "Time",
-    Formula = list(Formula = "t"),
+    Formula = list(
+      Formula = "t",
+      Dimension = "Time",
+      References = list(list(Alias = "t", Path = "Time", Dimension = "Time"))
+    ),
     ContainerCriteria = list(list(Tag = "Brain", Type = "MatchTag"))
   ))
 
@@ -117,10 +208,21 @@ test_that("Observer to_df returns a single-row tibble", {
   expect_equal(nrow(df), 1)
   expect_named(
     df,
-    c("name", "type", "dimension", "formula", "container_tags")
+    c(
+      "name",
+      "type",
+      "dimension",
+      "formula_expression",
+      "formula_dimension",
+      "formula_references",
+      "container_tags"
+    )
   )
   expect_equal(df$name, "obs")
   expect_equal(df$type, "Amount")
+  expect_equal(df$formula_expression, "t")
+  expect_equal(df$formula_dimension, "Time")
+  expect_equal(df$formula_references, "t=Time")
   expect_equal(df$container_tags, "Brain")
 })
 
@@ -132,8 +234,27 @@ test_that("Observer to_df fills NA for missing fields", {
   expect_equal(df$name, "obs")
   expect_equal(df$type, NA_character_)
   expect_equal(df$dimension, NA_character_)
-  expect_equal(df$formula, NA_character_)
+  expect_equal(df$formula_expression, NA_character_)
+  expect_equal(df$formula_dimension, NA_character_)
+  expect_equal(df$formula_references, NA_character_)
   expect_equal(df$container_tags, NA_character_)
+})
+
+test_that("Observer to_df joins multiple formula references", {
+  observer <- Observer$new(list(
+    Name = "obs",
+    Formula = list(
+      Formula = "a+b",
+      References = list(
+        list(Alias = "a", Path = "p1", Dimension = "D"),
+        list(Alias = "b", Path = "p2", Dimension = "D")
+      )
+    )
+  ))
+
+  df <- observer$to_df()
+
+  expect_equal(df$formula_references, "a=p1|b=p2")
 })
 
 test_that("Observer round-trips raw data verbatim", {

--- a/tests/testthat/test-ObserverSet.R
+++ b/tests/testthat/test-ObserverSet.R
@@ -129,8 +129,31 @@ test_that("Observer dimension mutation survives a load-mutate-export-reload cycl
   expect_observer_field_roundtrip("dimension", "Concentration (molar)")
 })
 
+test_that("Observer formula_expression mutation survives a load-mutate-export-reload cycle", {
+  expect_observer_field_roundtrip("formula_expression", "3*Conc_Br")
+})
+
+test_that("Observer formula_dimension mutation survives a load-mutate-export-reload cycle", {
+  expect_observer_field_roundtrip(
+    "formula_dimension",
+    "Concentration (molar)"
+  )
+})
+
 test_that("Observer formula mutation survives a load-mutate-export-reload cycle", {
-  expect_observer_field_roundtrip("formula", "3*Conc_Br")
+  expect_observer_field_roundtrip(
+    "formula",
+    list(
+      Name = "renamed_formula",
+      Formula = "2*Conc_Br",
+      Dimension = "Concentration (molar)",
+      References = list(list(
+        Alias = "Conc_Br",
+        Path = "Organism|Brain|Plasma|Drug|Concentration",
+        Dimension = "Concentration (molar)"
+      ))
+    )
+  )
 })
 
 # ---- Mutators ----
@@ -235,7 +258,9 @@ test_that("get_observer_sets_dfs() returns observer_sets and observers", {
       "name",
       "type",
       "dimension",
-      "formula",
+      "formula_expression",
+      "formula_dimension",
+      "formula_references",
       "container_tags"
     )
   )
@@ -282,7 +307,9 @@ test_that("get_observer_sets_dfs() returns empty tibbles for empty snapshot", {
       "name",
       "type",
       "dimension",
-      "formula",
+      "formula_expression",
+      "formula_dimension",
+      "formula_references",
       "container_tags"
     )
   )

--- a/vignettes/creating-building-blocks.Rmd
+++ b/vignettes/creating-building-blocks.Rmd
@@ -286,7 +286,7 @@ breakfast
 
 An *Observer* is a simulation-time formula that exposes a derived quantity (for example a tissue concentration) that is not a natural model output. Observers travel in groups called *Observer sets*. `create_observer_set()` builds a set from a name and a list of observers.
 
-Build each observer with `Observer$new()` (which validates the input and gives you typed accessors `$name`, `$type`, `$dimension`, `$formula`, `$container_tags`), then bundle them into a set and attach the set to a snapshot:
+Build each observer with `Observer$new()` (which validates the input and gives you typed accessors `$name`, `$type`, `$dimension`, `$formula` (the full `ExplicitFormula` list), `$formula_expression`, `$formula_dimension`, `$formula_references`, `$container_tags`), then bundle them into a set and attach the set to a snapshot:
 
 ```{r}
 brain_obs <- Observer$new(list(

--- a/vignettes/exporting-snapshots-to-dataframes.Rmd
+++ b/vignettes/exporting-snapshots-to-dataframes.Rmd
@@ -129,7 +129,7 @@ head(protocols_df)
 `as_tibbles(snapshot, "observer_sets")` returns a list of two tibbles joinable on `observer_set_id` (or `observer_set_name`):
 
 * `$observer_sets` has one row per *ObserverSet* with its name and the count of observers it contains.
-* `$observers` has one row per *Observer* with its name, type, dimension, formula, and `container_tags` (the `|`-joined `Tag` values from the underlying `ContainerCriteria`).
+* `$observers` has one row per *Observer* with its name, type, dimension, `formula_expression`, `formula_dimension`, `formula_references` (the underlying `ExplicitFormula` references collapsed to `"alias=path"` pairs joined with `|`), and `container_tags` (the `|`-joined `Tag` values from the underlying `ContainerCriteria`).
 
 ```{r, eval=FALSE}
 observer_dfs <- as_tibbles(snapshot, "observer_sets")


### PR DESCRIPTION
`Observer$formula` previously returned only the inner `Formula$Formula` expression string, hiding the rest of the underlying `ExplicitFormula` object (`Name`, `Dimension`, `References`). Users had to drop down to `observer$data$Formula`, which is read-only on `Observer`. This PR repurposes `$formula` to expose the full structure and adds dedicated convenience accessors for the inner pieces.

## Observer surface

- `$formula` now returns the full `ExplicitFormula` list (`Name`, `Formula`, `Dimension`, `References`). The setter replaces the whole sub-list; passing `NULL` drops it.
- `$formula_expression` is the new home of the inner expression string. Writing preserves the sibling `Name`, `Dimension`, and `References` entries.
- `$formula_dimension` reads and writes the inner output dimension.
- `$formula_references` is read-only; assign through `$formula` to mutate.

## Tibble layer

- `Observer$to_df()` and `empty_observers_tibble()` swap the single `formula` column for `formula_expression`, `formula_dimension`, and `formula_references`. The references column collapses each `FormulaUsablePath` entry to `"alias=path"` and joins entries with `|`, returning `NA` when no references are present.

## Docs and tests

- `print(observer)` now lists `Formula expression` and `Formula dimension`.
- New tests cover the four formula accessors (including `NULL` setter on `$formula`), the new tibble columns, and round-tripping through export and reload.
- Two vignettes (`creating-building-blocks.Rmd`, `exporting-snapshots-to-dataframes.Rmd`) and the existing `NEWS.md` entry are updated to reflect the new surface.

Closes #79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Observers now expose detailed formula components: `formula_expression`, `formula_dimension`, and `formula_references` as distinct, accessible fields.
  * Observer dataframes include expanded formula-related columns, with references displayed as flattened `alias=path` pairs.

* **Documentation**
  * Updated guides and API documentation to reflect new formula field structure and access patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/esqLABS/osp.snapshots/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->