### PR TITLE
Add first-class compound physicochemical properties and processes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# osp.snapshots 1.0.0.9000
+
+- `create_compound()` gains arguments to set lipophilicity, fraction unbound, solubility (including `reference_pH`, `solubility_gain_per_charge`, and `solubility_table`), intestinal permeability, permeability, and `pKa`, and to attach `processes`; the matching `Compound` fields (`$lipophilicity`, `$fraction_unbound`, `$solubility`, `$intestinal_permeability`, the new `$permeability`, `$pka_types`, `$processes`) are now writable (#115).
+
 # osp.snapshots 1.0.0
 
 ## Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,3 @@
-# osp.snapshots 1.0.0.9000
-
-- `create_compound()` gains arguments to set lipophilicity, fraction unbound, solubility (including `reference_pH`, `solubility_gain_per_charge`, and `solubility_table`), intestinal permeability, permeability, and `pKa`, and to attach `processes`; the matching `Compound` fields (`$lipophilicity`, `$fraction_unbound`, `$solubility`, `$intestinal_permeability`, the new `$permeability`, `$pka_types`, `$processes`) are now writable (#115).
-
 # osp.snapshots 1.0.0
 
 ## Breaking changes
@@ -19,7 +15,7 @@
 - `as_tibbles(snapshot, kind)` converts any building-block collection to a tibble through one entry point, returning either a bare tibble (`"protocols"`, `"observed_data"`) or a named list of related tibbles (every other kind). The eight existing `get_*_dfs()` functions remain available as thin wrappers (#36).
 - `compound$calculation_methods` and `individual$origin_data$calculation_methods` return a `CalculationMethods` object you can inspect (`$names`, `$length`) and mutate (`$add()`, `$remove()`) (#30).
 - `compound$processes` returns a named list of `Process` objects, each exposing `internal_name`, `data_source`, `molecule`, `metabolite`, `species`, `parameters`, and a derived `category` (#40).
-- `create_compound()` builds a compound from named arguments, with validation on `molecular_weight_unit` against `ospsuite::ospUnits$"Molecular weight"` (#27, #48). Attach with `add_compound()`, remove by name with `remove_compound()` (#39).
+- `create_compound()` builds a compound from named arguments, with validation on `molecular_weight_unit` against `ospsuite::ospUnits$"Molecular weight"` (#27, #48). It also sets the physicochemical properties directly: `lipophilicity`, `fraction_unbound`, `solubility` (with `reference_pH`, `solubility_gain_per_charge`, and `solubility_table`), `intestinal_permeability`, `permeability`, and `pKa`, and attaches `processes`; the matching `Compound` fields (`$lipophilicity`, `$fraction_unbound`, `$solubility`, `$intestinal_permeability`, `$permeability`, `$pka_types`, `$processes`) are writable so a loaded compound can be mutated. Attach with `add_compound()`, remove by name with `remove_compound()` (#39, #115).
 - `create_compound_group_selection()`, `create_compound_process_selection()`, `create_compound_properties()`, `create_event_selection()`, `create_formulation_selection()`, `create_observer_set_selection()`, `create_output_interval()`, `create_output_mapping()`, `create_output_schema()`, `create_protocol_selection()`, `create_simulation()`, and `create_solver_settings()` build a `Simulation` and its supporting structures from named arguments (#94).
 - `create_event()` builds an event from a template name and an optional list of parameter overrides (#27). Attach with `add_event()`, remove with `remove_event()` (#39).
 - `create_expression_profile()` builds an expression profile, requiring molecule, species, category, and type (#27).
@@ -40,6 +36,7 @@
 ## Minor improvements and fixes
 
 - `as_tibbles(snapshot, "protocols")` (and the legacy `get_protocols_dfs()` wrapper) now returns the same 13 columns whether the snapshot has any protocols or not. Previously the empty-state path returned an 18-column tibble that disagreed with the populated path, breaking `bind_rows()` across mixed snapshots (#56).
+- `create_compound()` output can now be printed when `is_small_molecule` is left unset. Previously printing such a compound aborted with "missing value where TRUE/FALSE needed"; the type line is now omitted instead (#115).
 - `export_snapshot()` now serializes `DataSet` objects attached at runtime via `add_observed_data()`, so a snapshot built from `create_observed_data()` and `add_observed_data()` round-trips through `export_snapshot()` and `load_snapshot()`. Entries that were already present in the loaded snapshot are still replayed from the original JSON slice, which means post-load mutations to a `DataSet` (e.g. changing `xUnit` on an entry in `snapshot$observed_data`) are not reflected on export (#35, #96).
 - `loadDataSetFromSnapshot()` now preserves the observed-data time unit (`BaseGrid$Unit`) on the resulting `DataSet$xUnit` for every ospsuite Time unit, including `"day(s)"`, `"week(s)"`, `"month(s)"`, `"year(s)"`, and `"ks"`. Previously only `"h"`, `"min"`, and `"s"` survived and any other unit silently reverted to `"h"`, misplacing time points (for example a 24x error for `day(s)`); this also affected `create_observed_data(time_unit = ...)` (#104).
 - `remove_expression_profile()`, `remove_formulation()`, `remove_individual()`, `remove_observed_data()`, and `remove_population()` now report the actual number of entries removed instead of the length of the input vector, so the success message reads correctly when a requested name is not present in the snapshot (#66).

--- a/R/Compound.R
+++ b/R/Compound.R
@@ -181,6 +181,34 @@ Compound <- R6::R6Class(
       value
     },
 
+    # Shared setter for the single-parameter alternative-group fields. A
+    # numeric scalar builds a single default alternative; a list is stored
+    # verbatim as the raw alternative array; NULL clears the key; anything
+    # else aborts naming the field. `unit = NULL` omits the parameter unit
+    # (fraction unbound). Returns the value to assign into private$.data.
+    set_alternative_group = function(value, param_name, unit, field) {
+      if (is.null(value)) {
+        return(NULL)
+      }
+      if (is.numeric(value)) {
+        if (length(value) != 1) {
+          cli::cli_abort("{.arg {field}} must be a numeric value")
+        }
+        return(build_single_param_alternative(
+          "User defined",
+          param_name,
+          value,
+          unit
+        ))
+      }
+      if (is.list(value)) {
+        return(unname(value))
+      }
+      cli::cli_abort(
+        "{.arg {field}} must be a numeric value, a raw alternative list, or NULL"
+      )
+    },
+
     .format_value = function(x) {
       vapply(
         x,
@@ -500,63 +528,180 @@ Compound <- R6::R6Class(
       ""
     },
 
-    #' @field lipophilicity The lipophilicity data of the compound
-    lipophilicity = function() {
-      result <- private$.data$Lipophilicity
-      if (!is.null(result)) {
-        class(result) <- c("physicochemical_property", "list")
-        attr(result, "property_name") <- "Lipophilicity"
+    #' @field lipophilicity The lipophilicity data of the compound. Writable:
+    #'   assign a numeric scalar to create a single default `Lipophilicity`
+    #'   alternative (parameter `"Lipophilicity"`, unit `"Log Units"`), a raw
+    #'   alternative list to set the array verbatim (the escape hatch for
+    #'   multiple, named, or species-specific alternatives), or `NULL` to
+    #'   clear the property.
+    lipophilicity = function(value) {
+      if (missing(value)) {
+        result <- private$.data$Lipophilicity
+        if (!is.null(result)) {
+          class(result) <- c("physicochemical_property", "list")
+          attr(result, "property_name") <- "Lipophilicity"
+        }
+        return(result)
       }
-      result
+      private$.data$Lipophilicity <- private$set_alternative_group(
+        value,
+        "Lipophilicity",
+        "Log Units",
+        "lipophilicity"
+      )
     },
 
-    #' @field fraction_unbound The fraction unbound data of the compound
-    fraction_unbound = function() {
-      result <- private$.data$FractionUnbound
-      if (!is.null(result)) {
-        class(result) <- c("physicochemical_property", "list")
-        attr(result, "property_name") <- "Fraction Unbound"
+    #' @field fraction_unbound The fraction unbound data of the compound.
+    #'   Writable: assign a numeric scalar to create a single default
+    #'   `FractionUnbound` alternative (parameter
+    #'   `"Fraction unbound (plasma, reference value)"`, no unit), a raw
+    #'   alternative list to set the array verbatim, or `NULL` to clear the
+    #'   property.
+    fraction_unbound = function(value) {
+      if (missing(value)) {
+        result <- private$.data$FractionUnbound
+        if (!is.null(result)) {
+          class(result) <- c("physicochemical_property", "list")
+          attr(result, "property_name") <- "Fraction Unbound"
+        }
+        return(result)
       }
-      result
+      private$.data$FractionUnbound <- private$set_alternative_group(
+        value,
+        "Fraction unbound (plasma, reference value)",
+        NULL,
+        "fraction_unbound"
+      )
     },
 
-    #' @field solubility The solubility data of the compound
-    solubility = function() {
-      result <- private$.data$Solubility
-      if (!is.null(result)) {
-        class(result) <- c("physicochemical_property", "list")
-        attr(result, "property_name") <- "Solubility"
+    #' @field solubility The solubility data of the compound. Writable:
+    #'   assign a numeric scalar to create a single default `Solubility`
+    #'   alternative (parameter `"Solubility at reference pH"`, unit
+    #'   `"mg/l"`), a raw alternative list to set the array verbatim, or
+    #'   `NULL` to clear the property. The scalar form cannot express
+    #'   reference pH, gain per charge, or table solubility; set those by
+    #'   assigning a raw alternative list or by using `create_compound()`
+    #'   with its `reference_pH`, `solubility_gain_per_charge`, or
+    #'   `solubility_table` arguments.
+    solubility = function(value) {
+      if (missing(value)) {
+        result <- private$.data$Solubility
+        if (!is.null(result)) {
+          class(result) <- c("physicochemical_property", "list")
+          attr(result, "property_name") <- "Solubility"
+        }
+        return(result)
       }
-      result
+      if (is.null(value)) {
+        private$.data$Solubility <- NULL
+      } else if (is.numeric(value)) {
+        if (length(value) != 1) {
+          cli::cli_abort("{.arg solubility} must be a numeric value")
+        }
+        private$.data$Solubility <- build_solubility_alternative(
+          "User defined",
+          value,
+          "mg/l"
+        )
+      } else if (is.list(value)) {
+        private$.data$Solubility <- unname(value)
+      } else {
+        cli::cli_abort(
+          "{.arg solubility} must be a numeric value, a raw alternative list, or NULL"
+        )
+      }
     },
 
-    #' @field intestinal_permeability The intestinal permeability data of the compound
-    intestinal_permeability = function() {
-      result <- private$.data$IntestinalPermeability
-      if (!is.null(result)) {
-        class(result) <- c("physicochemical_property", "list")
-        attr(result, "property_name") <- "Intestinal Permeability"
+    #' @field intestinal_permeability The intestinal permeability data of the
+    #'   compound. Writable: assign a numeric scalar to create a single
+    #'   default `IntestinalPermeability` alternative (parameter
+    #'   `"Specific intestinal permeability (transcellular)"`, unit
+    #'   `"cm/min"`), a raw alternative list to set the array verbatim, or
+    #'   `NULL` to clear the property.
+    intestinal_permeability = function(value) {
+      if (missing(value)) {
+        result <- private$.data$IntestinalPermeability
+        if (!is.null(result)) {
+          class(result) <- c("physicochemical_property", "list")
+          attr(result, "property_name") <- "Intestinal Permeability"
+        }
+        return(result)
       }
-      result
+      private$.data$IntestinalPermeability <- private$set_alternative_group(
+        value,
+        "Specific intestinal permeability (transcellular)",
+        "cm/min",
+        "intestinal_permeability"
+      )
     },
 
-    #' @field pka_types The pKa types of the compound
-    pka_types = function() {
-      result <- private$.data$PkaTypes
-      if (!is.null(result)) {
-        class(result) <- c("physicochemical_property", "list")
-        attr(result, "property_name") <- "pKa Types"
+    #' @field permeability The permeability data of the compound. Writable:
+    #'   assign a numeric scalar to create a single default `Permeability`
+    #'   alternative (parameter `"Permeability"`, unit `"cm/min"`), a raw
+    #'   alternative list to set the array verbatim, or `NULL` to clear the
+    #'   property.
+    permeability = function(value) {
+      if (missing(value)) {
+        result <- private$.data$Permeability
+        if (!is.null(result)) {
+          class(result) <- c("physicochemical_property", "list")
+          attr(result, "property_name") <- "Permeability"
+        }
+        return(result)
       }
-      result
+      private$.data$Permeability <- private$set_alternative_group(
+        value,
+        "Permeability",
+        "cm/min",
+        "permeability"
+      )
+    },
+
+    #' @field pka_types The pKa types of the compound. Writable: assign a
+    #'   list of `list(type =, value =)` entries (the `create_compound()`
+    #'   `pKa` shape, converted to `list(Type =, Pka =)`), a raw `PkaType[]`
+    #'   list (entries carrying `Type`/`Pka`, set verbatim), or `NULL` /
+    #'   `list()` to clear the pKa types.
+    pka_types = function(value) {
+      if (missing(value)) {
+        result <- private$.data$PkaTypes
+        if (!is.null(result)) {
+          class(result) <- c("physicochemical_property", "list")
+          attr(result, "property_name") <- "pKa Types"
+        }
+        return(result)
+      }
+      if (is.null(value) || length(value) == 0) {
+        private$.data$PkaTypes <- NULL
+      } else if (!is.list(value) || is.object(value)) {
+        cli::cli_abort("{.arg pka_types} must be a list")
+      } else if ("type" %in% names(value[[1]])) {
+        validate_pka(value)
+        private$.data$PkaTypes <- build_pka_types(value)
+      } else {
+        private$.data$PkaTypes <- unname(value)
+      }
     },
 
     #' @field processes A flat named list of [Process] objects, one per
     #'   entry in the compound's `Processes` array. Duplicate names are
     #'   disambiguated with a numeric suffix (`_1`, `_2`, ...). The list is
     #'   built once at construction so that state changes made on a
-    #'   [Process] persist across accesses.
-    processes = function() {
-      private$.processes
+    #'   [Process] persist across accesses. Writable: assign a list of
+    #'   [Process] objects and/or raw process lists to rebuild the processes
+    #'   (duplicate names are disambiguated as at construction), or `NULL` /
+    #'   `list()` to clear them.
+    processes = function(value) {
+      if (missing(value)) {
+        return(private$.processes)
+      }
+      raw <- if (is.null(value) || length(value) == 0) {
+        NULL
+      } else {
+        to_raw_r6_or_list(value, "Process", "processes")
+      }
+      private$.data$Processes <- raw
+      private$.processes <- build_processes_from_raw(raw)
     },
 
     #' @field calculation_methods A [CalculationMethods] object holding the

--- a/R/Compound.R
+++ b/R/Compound.R
@@ -89,6 +89,7 @@ Compound <- R6::R6Class(
           fraction_unbound = "Fraction Unbound",
           solubility = "Solubility",
           intestinal_permeability = "Intestinal Permeability",
+          permeability = "Permeability",
           pka_types = "pKa Types"
         )
 
@@ -142,7 +143,8 @@ Compound <- R6::R6Class(
         "halogens",
         "pKa",
         "solubility",
-        "intestinal_permeability"
+        "intestinal_permeability",
+        "permeability"
       )) {
         prop_data <- private$.get_property_data(p)
         if (!is.null(prop_data) && length(prop_data) > 0) {
@@ -237,6 +239,7 @@ Compound <- R6::R6Class(
         "pKa" = private$.extract_pka(),
         "solubility" = private$.extract_solubility(),
         "intestinal_permeability" = private$.extract_intestinal_permeability(),
+        "permeability" = private$.extract_permeability(),
         NULL
       )
     },
@@ -417,6 +420,25 @@ Compound <- R6::R6Class(
         data[[j]] <- private$.extract_parameters(
           intestinal_permeability_data[[j]]$Parameters,
           "Specific intestinal permeability (transcellular)"
+        )
+      }
+      data
+    },
+
+    .extract_permeability = function() {
+      permeability_data <- private$.data$Permeability
+      if (is.null(permeability_data)) {
+        return(NULL)
+      }
+
+      names <- purrr::map_chr(permeability_data, "Name")
+      data <- vector("list", length(names))
+      names(data) <- names
+
+      for (j in seq_along(names)) {
+        data[[j]] <- private$.extract_parameters(
+          permeability_data[[j]]$Parameters,
+          "Permeability"
         )
       }
       data

--- a/R/Compound.R
+++ b/R/Compound.R
@@ -50,7 +50,9 @@ Compound <- R6::R6Class(
 
         # Display basic compound properties
         cli::cli_h2("Basic Properties")
-        if (!is.null(self$is_small_molecule)) {
+        if (
+          !is.null(self$is_small_molecule) && !is.na(self$is_small_molecule)
+        ) {
           molecule_type <- if (self$is_small_molecule) {
             "Small Molecule"
           } else {

--- a/R/create_compound.R
+++ b/R/create_compound.R
@@ -82,8 +82,10 @@
 #' @param pKa List of typed pKa entries, each a list with a `type`
 #'   (one of `"Acid"`, `"Base"`, `"Neutral"`) and a numeric `value`, for
 #'   example `list(list(type = "Base", value = 10.02))`. Order is
-#'   preserved. An empty `list()` clears the pKa types; `NULL` leaves them
-#'   unset.
+#'   preserved. Both `NULL` (the default) and an empty `list()` leave the
+#'   created compound with no pKa types set. (The clearing semantics, where
+#'   an empty `list()` removes existing values, apply to the writable
+#'   `Compound$pka_types` field, not to construction.)
 #' @param processes List of [Process] objects (created with
 #'   [create_process()]) or raw process lists to attach to the compound.
 #'
@@ -221,6 +223,15 @@ create_compound <- function(
     if (!is.data.frame(solubility_table) || ncol(solubility_table) != 2) {
       cli::cli_abort(
         "{.arg solubility_table} must be a data frame with two columns (pH, value)"
+      )
+    }
+    if (
+      nrow(solubility_table) == 0 ||
+        !is.numeric(solubility_table[[1]]) ||
+        !is.numeric(solubility_table[[2]])
+    ) {
+      cli::cli_abort(
+        "{.arg solubility_table} must have at least one row with numeric pH and value columns"
       )
     }
   }

--- a/R/create_compound.R
+++ b/R/create_compound.R
@@ -1,13 +1,17 @@
 #' Create a new compound
 #'
 #' @description
-#' Create a minimally populated [Compound] building block from named
-#' arguments. This is a thin factory around `Compound$new()` that builds
-#' the raw list shape for you.
+#' Create a [Compound] building block from named arguments. This is a thin
+#' factory around `Compound$new()` that builds the raw list shape for you,
+#' including the physicochemical properties, pKa, and processes.
 #'
-#' For richer compound structures (full lipophilicity alternatives,
-#' processes, calculation methods, and so on), build the raw list directly
-#' or load a template snapshot and mutate it.
+#' Each of lipophilicity, fraction unbound, solubility (including reference
+#' pH, gain per charge, and table solubility), intestinal permeability,
+#' permeability, and pKa must be set through its dedicated argument (or by
+#' mutating the matching writable [Compound] field). The `parameters`
+#' argument is for additional/loose compound parameters only; it cannot set
+#' these physicochemical properties, because each lives in its own
+#' top-level alternative array or typed list rather than in `Parameters`.
 #'
 #' @param name Character. Name of the compound (required).
 #' @param description Character. Free-text description of the compound.
@@ -21,8 +25,67 @@
 #' @param calculation_methods Character vector. Calculation method names
 #'   that PK-Sim uses to derive compound quantities.
 #' @param parameters List of [Parameter] objects (created with
-#'   [create_parameter()]) or raw parameter lists to attach to the
-#'   compound.
+#'   [create_parameter()]) or raw parameter lists to attach as additional
+#'   compound parameters. This does not set physicochemical properties;
+#'   use the dedicated arguments below for those.
+#' @param lipophilicity Numeric scalar. Lipophilicity value. When supplied,
+#'   one default `Lipophilicity` alternative is created.
+#' @param lipophilicity_unit Character. Unit for the lipophilicity
+#'   parameter, validated against dimension `"Log Units"`. Defaults to
+#'   `"Log Units"`.
+#' @param lipophilicity_name Character. `Name` of the created lipophilicity
+#'   alternative. Defaults to `"User defined"`.
+#' @param fraction_unbound Numeric scalar. Fraction unbound value. When
+#'   supplied, one default `FractionUnbound` alternative is created. The
+#'   fraction-unbound parameter carries no unit.
+#' @param fraction_unbound_name Character. `Name` of the created
+#'   fraction-unbound alternative. Defaults to `"User defined"`.
+#' @param solubility Numeric scalar. Solubility-at-reference-pH value. When
+#'   supplied, one scalar-based `Solubility` alternative is created.
+#'   Mutually exclusive with `solubility_table`.
+#' @param solubility_unit Character. Unit for the solubility parameter,
+#'   validated against dimension `"Concentration (mass)"`. Reused as the
+#'   table Y unit. Defaults to `"mg/l"`.
+#' @param reference_pH Numeric scalar. Reference pH added to the same
+#'   scalar `Solubility` alternative as `solubility`. Not a standalone
+#'   property: it is ignored unless `solubility` is supplied, and it does
+#'   not apply to the table path.
+#' @param solubility_gain_per_charge Numeric scalar. Optional
+#'   `Solubility gain per charge` parameter added to the same scalar
+#'   `Solubility` alternative as `solubility`. Not a standalone property:
+#'   it is ignored unless `solubility` is supplied.
+#' @param solubility_table Two-column data frame giving table-based
+#'   solubility: the first column is pH and the second is the solubility
+#'   value. When supplied, one `Solubility` alternative with a
+#'   `Solubility table` parameter carrying a `TableFormula` is created
+#'   instead of a scalar solubility. Mutually exclusive with `solubility`.
+#'   Note: on import PK-Sim runs a table-solubility preparation step that
+#'   this package does not perform; the package emits the faithful raw
+#'   `Solubility table` + `TableFormula` shape that round-trips through
+#'   load/export at the JSON level.
+#' @param solubility_name Character. `Name` of the created solubility
+#'   alternative (scalar or table). Defaults to `"User defined"`.
+#' @param intestinal_permeability Numeric scalar. Intestinal permeability
+#'   value. When supplied, one default `IntestinalPermeability` alternative
+#'   is created.
+#' @param intestinal_permeability_unit Character. Unit for the
+#'   intestinal-permeability parameter, validated against dimension
+#'   `"Velocity"`. Defaults to `"cm/min"`.
+#' @param intestinal_permeability_name Character. `Name` of the created
+#'   intestinal-permeability alternative. Defaults to `"User defined"`.
+#' @param permeability Numeric scalar. Permeability value. When supplied,
+#'   one default `Permeability` alternative is created.
+#' @param permeability_unit Character. Unit for the permeability parameter,
+#'   validated against dimension `"Velocity"`. Defaults to `"cm/min"`.
+#' @param permeability_name Character. `Name` of the created permeability
+#'   alternative. Defaults to `"User defined"`.
+#' @param pKa List of typed pKa entries, each a list with a `type`
+#'   (one of `"Acid"`, `"Base"`, `"Neutral"`) and a numeric `value`, for
+#'   example `list(list(type = "Base", value = 10.02))`. Order is
+#'   preserved. An empty `list()` clears the pKa types; `NULL` leaves them
+#'   unset.
+#' @param processes List of [Process] objects (created with
+#'   [create_process()]) or raw process lists to attach to the compound.
 #'
 #' @return A [Compound] object.
 #' @export
@@ -39,7 +102,53 @@
 #'   plasma_protein_binding_partner = "Albumin"
 #' )
 #'
-#' # Create a compound with additional parameters
+#' # Set the single-parameter physicochemical properties
+#' compound <- create_compound(
+#'   name = "Drug X",
+#'   lipophilicity = 2.5,
+#'   fraction_unbound = 0.1,
+#'   intestinal_permeability = 1.14e-05,
+#'   permeability = 0.0069
+#' )
+#'
+#' # Solubility with reference pH and gain per charge
+#' compound <- create_compound(
+#'   name = "Drug X",
+#'   solubility = 9999,
+#'   reference_pH = 7,
+#'   solubility_gain_per_charge = 1000
+#' )
+#'
+#' # Table-based solubility (first column pH, second column value)
+#' compound <- create_compound(
+#'   name = "Drug X",
+#'   solubility_table = data.frame(
+#'     pH = c(3, 6, 6.8),
+#'     value = c(5000, 3000, 90)
+#'   )
+#' )
+#'
+#' # Multiple pKa entries
+#' compound <- create_compound(
+#'   name = "Drug X",
+#'   pKa = list(
+#'     list(type = "Base", value = 10.02),
+#'     list(type = "Acid", value = 1.7)
+#'   )
+#' )
+#'
+#' # Attach a process
+#' compound <- create_compound(
+#'   name = "Drug X",
+#'   processes = list(
+#'     create_process(
+#'       internal_name = "GlomerularFiltration",
+#'       data_source = "Publication X"
+#'     )
+#'   )
+#' )
+#'
+#' # Additional/loose parameters (not physicochemical properties)
 #' compound <- create_compound(
 #'   name = "Drug X",
 #'   parameters = list(
@@ -54,7 +163,26 @@ create_compound <- function(
   molecular_weight = NULL,
   molecular_weight_unit = "g/mol",
   calculation_methods = NULL,
-  parameters = NULL
+  parameters = NULL,
+  lipophilicity = NULL,
+  lipophilicity_unit = "Log Units",
+  lipophilicity_name = "User defined",
+  fraction_unbound = NULL,
+  fraction_unbound_name = "User defined",
+  solubility = NULL,
+  solubility_unit = "mg/l",
+  reference_pH = NULL,
+  solubility_gain_per_charge = NULL,
+  solubility_table = NULL,
+  solubility_name = "User defined",
+  intestinal_permeability = NULL,
+  intestinal_permeability_unit = "cm/min",
+  intestinal_permeability_name = "User defined",
+  permeability = NULL,
+  permeability_unit = "cm/min",
+  permeability_name = "User defined",
+  pKa = NULL,
+  processes = NULL
 ) {
   check_required_string(name, "name")
   if (!is.null(is_small_molecule) && !is.logical(is_small_molecule)) {
@@ -65,6 +193,52 @@ create_compound <- function(
   }
   if (!is.null(molecular_weight)) {
     validate_unit(molecular_weight_unit, "Molecular weight")
+  }
+
+  # Numeric-scalar guards for the physicochemical property values.
+  for (arg in c(
+    "lipophilicity",
+    "fraction_unbound",
+    "solubility",
+    "reference_pH",
+    "solubility_gain_per_charge",
+    "intestinal_permeability",
+    "permeability"
+  )) {
+    val <- get(arg)
+    if (!is.null(val) && (!is.numeric(val) || length(val) != 1)) {
+      cli::cli_abort("{.arg {arg}} must be a numeric value")
+    }
+  }
+
+  if (!is.null(solubility) && !is.null(solubility_table)) {
+    cli::cli_abort(c(
+      "Solubility is set either by a single value or by a table, not both.",
+      "i" = "Supply {.arg solubility} or {.arg solubility_table}, not both."
+    ))
+  }
+  if (!is.null(solubility_table)) {
+    if (!is.data.frame(solubility_table) || ncol(solubility_table) != 2) {
+      cli::cli_abort(
+        "{.arg solubility_table} must be a data frame with two columns (pH, value)"
+      )
+    }
+  }
+
+  if (!is.null(lipophilicity)) {
+    validate_unit(lipophilicity_unit, "Log Units")
+  }
+  if (!is.null(solubility) || !is.null(solubility_table)) {
+    validate_unit(solubility_unit, "Concentration (mass)")
+  }
+  if (!is.null(intestinal_permeability)) {
+    validate_unit(intestinal_permeability_unit, "Velocity")
+  }
+  if (!is.null(permeability)) {
+    validate_unit(permeability_unit, "Velocity")
+  }
+  if (!is.null(pKa)) {
+    validate_pka(pKa)
   }
 
   data <- list(Name = name)
@@ -104,5 +278,184 @@ create_compound <- function(
     data$Parameters <- parameter_list
   }
 
+  if (!is.null(lipophilicity)) {
+    data$Lipophilicity <- build_single_param_alternative(
+      lipophilicity_name,
+      "Lipophilicity",
+      lipophilicity,
+      lipophilicity_unit
+    )
+  }
+  if (!is.null(fraction_unbound)) {
+    data$FractionUnbound <- build_single_param_alternative(
+      fraction_unbound_name,
+      "Fraction unbound (plasma, reference value)",
+      fraction_unbound,
+      unit = NULL
+    )
+  }
+  if (!is.null(solubility)) {
+    data$Solubility <- build_solubility_alternative(
+      solubility_name,
+      solubility,
+      solubility_unit,
+      reference_pH,
+      solubility_gain_per_charge
+    )
+  } else if (!is.null(solubility_table)) {
+    data$Solubility <- build_solubility_table_alternative(
+      solubility_name,
+      solubility_table,
+      solubility_unit
+    )
+  }
+  if (!is.null(intestinal_permeability)) {
+    data$IntestinalPermeability <- build_single_param_alternative(
+      intestinal_permeability_name,
+      "Specific intestinal permeability (transcellular)",
+      intestinal_permeability,
+      intestinal_permeability_unit
+    )
+  }
+  if (!is.null(permeability)) {
+    data$Permeability <- build_single_param_alternative(
+      permeability_name,
+      "Permeability",
+      permeability,
+      permeability_unit
+    )
+  }
+  if (!is.null(pKa) && length(pKa) > 0) {
+    data$PkaTypes <- build_pka_types(pKa)
+  }
+  if (!is.null(processes)) {
+    data$Processes <- to_raw_r6_or_list(processes, "Process", "processes")
+  }
+
   Compound$new(data)
+}
+
+# Internal ----
+
+# Internal: build a one-element (unnamed) alternative array holding a single
+# default alternative with one parameter. Shared by the four single-parameter
+# alternative groups (lipophilicity, fraction unbound, intestinal
+# permeability, permeability). `unit = NULL` omits the parameter `Unit` field
+# (fraction unbound stores a bare value).
+build_single_param_alternative <- function(
+  name,
+  param_name,
+  value,
+  unit = NULL
+) {
+  param <- list(Name = param_name, Value = value)
+  if (!is.null(unit)) {
+    param$Unit <- unit
+  }
+  list(list(Name = name, IsDefault = TRUE, Parameters = list(param)))
+}
+
+# Internal: build a one-element (unnamed) scalar `Solubility` alternative
+# bundling the reference pH and optional gain-per-charge into the same
+# alternative. `Reference pH` and `Solubility gain per charge` are emitted
+# only when supplied.
+build_solubility_alternative <- function(
+  name,
+  value,
+  unit,
+  reference_pH = NULL,
+  gain_per_charge = NULL
+) {
+  params <- list(
+    list(Name = "Solubility at reference pH", Value = value, Unit = unit)
+  )
+  if (!is.null(reference_pH)) {
+    params <- c(params, list(list(Name = "Reference pH", Value = reference_pH)))
+  }
+  if (!is.null(gain_per_charge)) {
+    params <- c(
+      params,
+      list(list(Name = "Solubility gain per charge", Value = gain_per_charge))
+    )
+  }
+  list(list(Name = name, IsDefault = TRUE, Parameters = params))
+}
+
+# Internal: build a one-element (unnamed) table-based `Solubility`
+# alternative whose single `Solubility table` parameter carries a
+# `TableFormula`. The parameter `Value` is the first table Y value, matching
+# observed PK-Sim exports.
+build_solubility_table_alternative <- function(name, table, unit) {
+  param <- list(
+    Name = "Solubility table",
+    Value = table[[2]][1],
+    Unit = unit,
+    TableFormula = build_solubility_table_formula(table, unit)
+  )
+  list(list(Name = name, IsDefault = TRUE, Parameters = list(param)))
+}
+
+# Internal: build the solubility `TableFormula` from a two-column table
+# (col 1 pH, col 2 value). No `XUnit` field (matches the observed solubility
+# table shape). Points are an unnamed list.
+build_solubility_table_formula <- function(table, y_unit) {
+  points <- lapply(seq_len(nrow(table)), function(i) {
+    list(X = table[[1]][i], Y = table[[2]][i], RestartSolver = FALSE)
+  })
+  list(
+    Name = "Solubility",
+    XName = "pH",
+    XDimension = "Dimensionless",
+    YName = "Solubility",
+    YDimension = "Concentration (mass)",
+    YUnit = y_unit,
+    UseDerivedValues = FALSE,
+    Points = points
+  )
+}
+
+# Internal: convert the `pKa` argument list to a `PkaType[]` (unnamed list of
+# `list(Type =, Pka =)`). Validation lives in `validate_pka()`.
+build_pka_types <- function(pKa) {
+  unname(lapply(pKa, function(e) list(Type = e$type, Pka = e$value)))
+}
+
+# Internal: validate the `pKa` argument (a list of `list(type =, value =)`
+# entries). Aborts on a non-list, a non-list entry, a `type` outside
+# Acid/Base/Neutral, or a non-numeric scalar `value`, naming the offending
+# index.
+validate_pka <- function(pKa, call = parent.frame()) {
+  if (!is.list(pKa) || is.object(pKa)) {
+    cli::cli_abort("{.arg pKa} must be a list", call = call)
+  }
+  valid_types <- c("Acid", "Base", "Neutral")
+  for (i in seq_along(pKa)) {
+    entry <- pKa[[i]]
+    if (!is.list(entry) || is.object(entry)) {
+      cli::cli_abort(
+        "Entry {i} of {.arg pKa} must be a list with {.field type} and {.field value}",
+        call = call
+      )
+    }
+    if (
+      is.null(entry$type) ||
+        length(entry$type) != 1 ||
+        !(entry$type %in% valid_types)
+    ) {
+      cli::cli_abort(
+        c(
+          "Entry {i} of {.arg pKa} has an invalid {.field type}.",
+          "i" = "{.field type} must be one of {.val {valid_types}}."
+        ),
+        call = call
+      )
+    }
+    if (!is.numeric(entry$value) || length(entry$value) != 1) {
+      cli::cli_abort(
+        "Entry {i} of {.arg pKa} must have a numeric {.field value}",
+        call = call
+      )
+    }
+  }
+  invisible(pKa)
 }

--- a/man/Compound.Rd
+++ b/man/Compound.Rd
@@ -33,21 +33,57 @@ objects so that mutations flow back to the export payload.}
 
     \item{\code{molecular_weight_unit}}{The unit of the molecular weight}
 
-    \item{\code{lipophilicity}}{The lipophilicity data of the compound}
+    \item{\code{lipophilicity}}{The lipophilicity data of the compound. Writable:
+assign a numeric scalar to create a single default \code{Lipophilicity}
+alternative (parameter \code{"Lipophilicity"}, unit \code{"Log Units"}), a raw
+alternative list to set the array verbatim (the escape hatch for
+multiple, named, or species-specific alternatives), or \code{NULL} to
+clear the property.}
 
-    \item{\code{fraction_unbound}}{The fraction unbound data of the compound}
+    \item{\code{fraction_unbound}}{The fraction unbound data of the compound.
+Writable: assign a numeric scalar to create a single default
+\code{FractionUnbound} alternative (parameter
+\code{"Fraction unbound (plasma, reference value)"}, no unit), a raw
+alternative list to set the array verbatim, or \code{NULL} to clear the
+property.}
 
-    \item{\code{solubility}}{The solubility data of the compound}
+    \item{\code{solubility}}{The solubility data of the compound. Writable:
+assign a numeric scalar to create a single default \code{Solubility}
+alternative (parameter \code{"Solubility at reference pH"}, unit
+\code{"mg/l"}), a raw alternative list to set the array verbatim, or
+\code{NULL} to clear the property. The scalar form cannot express
+reference pH, gain per charge, or table solubility; set those by
+assigning a raw alternative list or by using \code{create_compound()}
+with its \code{reference_pH}, \code{solubility_gain_per_charge}, or
+\code{solubility_table} arguments.}
 
-    \item{\code{intestinal_permeability}}{The intestinal permeability data of the compound}
+    \item{\code{intestinal_permeability}}{The intestinal permeability data of the
+compound. Writable: assign a numeric scalar to create a single
+default \code{IntestinalPermeability} alternative (parameter
+\code{"Specific intestinal permeability (transcellular)"}, unit
+\code{"cm/min"}), a raw alternative list to set the array verbatim, or
+\code{NULL} to clear the property.}
 
-    \item{\code{pka_types}}{The pKa types of the compound}
+    \item{\code{permeability}}{The permeability data of the compound. Writable:
+assign a numeric scalar to create a single default \code{Permeability}
+alternative (parameter \code{"Permeability"}, unit \code{"cm/min"}), a raw
+alternative list to set the array verbatim, or \code{NULL} to clear the
+property.}
+
+    \item{\code{pka_types}}{The pKa types of the compound. Writable: assign a
+list of \code{list(type =, value =)} entries (the \code{create_compound()}
+\code{pKa} shape, converted to \code{list(Type =, Pka =)}), a raw \code{PkaType[]}
+list (entries carrying \code{Type}/\code{Pka}, set verbatim), or \code{NULL} /
+\code{list()} to clear the pKa types.}
 
     \item{\code{processes}}{A flat named list of \link{Process} objects, one per
 entry in the compound's \code{Processes} array. Duplicate names are
 disambiguated with a numeric suffix (\verb{_1}, \verb{_2}, ...). The list is
 built once at construction so that state changes made on a
-\link{Process} persist across accesses.}
+\link{Process} persist across accesses. Writable: assign a list of
+\link{Process} objects and/or raw process lists to rebuild the processes
+(duplicate names are disambiguated as at construction), or \code{NULL} /
+\code{list()} to clear them.}
 
     \item{\code{calculation_methods}}{A \link{CalculationMethods} object holding the
 compound's calculation methods.}

--- a/man/create_compound.Rd
+++ b/man/create_compound.Rd
@@ -129,8 +129,10 @@ alternative. Defaults to \code{"User defined"}.}
 \item{pKa}{List of typed pKa entries, each a list with a \code{type}
 (one of \code{"Acid"}, \code{"Base"}, \code{"Neutral"}) and a numeric \code{value}, for
 example \code{list(list(type = "Base", value = 10.02))}. Order is
-preserved. An empty \code{list()} clears the pKa types; \code{NULL} leaves them
-unset.}
+preserved. Both \code{NULL} (the default) and an empty \code{list()} leave the
+created compound with no pKa types set. (The clearing semantics, where
+an empty \code{list()} removes existing values, apply to the writable
+\code{Compound$pka_types} field, not to construction.)}
 
 \item{processes}{List of \link{Process} objects (created with
 \code{\link[=create_process]{create_process()}}) or raw process lists to attach to the compound.}

--- a/man/create_compound.Rd
+++ b/man/create_compound.Rd
@@ -12,7 +12,26 @@ create_compound(
   molecular_weight = NULL,
   molecular_weight_unit = "g/mol",
   calculation_methods = NULL,
-  parameters = NULL
+  parameters = NULL,
+  lipophilicity = NULL,
+  lipophilicity_unit = "Log Units",
+  lipophilicity_name = "User defined",
+  fraction_unbound = NULL,
+  fraction_unbound_name = "User defined",
+  solubility = NULL,
+  solubility_unit = "mg/l",
+  reference_pH = NULL,
+  solubility_gain_per_charge = NULL,
+  solubility_table = NULL,
+  solubility_name = "User defined",
+  intestinal_permeability = NULL,
+  intestinal_permeability_unit = "cm/min",
+  intestinal_permeability_name = "User defined",
+  permeability = NULL,
+  permeability_unit = "cm/min",
+  permeability_name = "User defined",
+  pKa = NULL,
+  processes = NULL
 )
 }
 \arguments{
@@ -35,20 +54,102 @@ Defaults to \code{"g/mol"}.}
 that PK-Sim uses to derive compound quantities.}
 
 \item{parameters}{List of \link{Parameter} objects (created with
-\code{\link[=create_parameter]{create_parameter()}}) or raw parameter lists to attach to the
-compound.}
+\code{\link[=create_parameter]{create_parameter()}}) or raw parameter lists to attach as additional
+compound parameters. This does not set physicochemical properties;
+use the dedicated arguments below for those.}
+
+\item{lipophilicity}{Numeric scalar. Lipophilicity value. When supplied,
+one default \code{Lipophilicity} alternative is created.}
+
+\item{lipophilicity_unit}{Character. Unit for the lipophilicity
+parameter, validated against dimension \code{"Log Units"}. Defaults to
+\code{"Log Units"}.}
+
+\item{lipophilicity_name}{Character. \code{Name} of the created lipophilicity
+alternative. Defaults to \code{"User defined"}.}
+
+\item{fraction_unbound}{Numeric scalar. Fraction unbound value. When
+supplied, one default \code{FractionUnbound} alternative is created. The
+fraction-unbound parameter carries no unit.}
+
+\item{fraction_unbound_name}{Character. \code{Name} of the created
+fraction-unbound alternative. Defaults to \code{"User defined"}.}
+
+\item{solubility}{Numeric scalar. Solubility-at-reference-pH value. When
+supplied, one scalar-based \code{Solubility} alternative is created.
+Mutually exclusive with \code{solubility_table}.}
+
+\item{solubility_unit}{Character. Unit for the solubility parameter,
+validated against dimension \code{"Concentration (mass)"}. Reused as the
+table Y unit. Defaults to \code{"mg/l"}.}
+
+\item{reference_pH}{Numeric scalar. Reference pH added to the same
+scalar \code{Solubility} alternative as \code{solubility}. Not a standalone
+property: it is ignored unless \code{solubility} is supplied, and it does
+not apply to the table path.}
+
+\item{solubility_gain_per_charge}{Numeric scalar. Optional
+\verb{Solubility gain per charge} parameter added to the same scalar
+\code{Solubility} alternative as \code{solubility}. Not a standalone property:
+it is ignored unless \code{solubility} is supplied.}
+
+\item{solubility_table}{Two-column data frame giving table-based
+solubility: the first column is pH and the second is the solubility
+value. When supplied, one \code{Solubility} alternative with a
+\verb{Solubility table} parameter carrying a \code{TableFormula} is created
+instead of a scalar solubility. Mutually exclusive with \code{solubility}.
+Note: on import PK-Sim runs a table-solubility preparation step that
+this package does not perform; the package emits the faithful raw
+\verb{Solubility table} + \code{TableFormula} shape that round-trips through
+load/export at the JSON level.}
+
+\item{solubility_name}{Character. \code{Name} of the created solubility
+alternative (scalar or table). Defaults to \code{"User defined"}.}
+
+\item{intestinal_permeability}{Numeric scalar. Intestinal permeability
+value. When supplied, one default \code{IntestinalPermeability} alternative
+is created.}
+
+\item{intestinal_permeability_unit}{Character. Unit for the
+intestinal-permeability parameter, validated against dimension
+\code{"Velocity"}. Defaults to \code{"cm/min"}.}
+
+\item{intestinal_permeability_name}{Character. \code{Name} of the created
+intestinal-permeability alternative. Defaults to \code{"User defined"}.}
+
+\item{permeability}{Numeric scalar. Permeability value. When supplied,
+one default \code{Permeability} alternative is created.}
+
+\item{permeability_unit}{Character. Unit for the permeability parameter,
+validated against dimension \code{"Velocity"}. Defaults to \code{"cm/min"}.}
+
+\item{permeability_name}{Character. \code{Name} of the created permeability
+alternative. Defaults to \code{"User defined"}.}
+
+\item{pKa}{List of typed pKa entries, each a list with a \code{type}
+(one of \code{"Acid"}, \code{"Base"}, \code{"Neutral"}) and a numeric \code{value}, for
+example \code{list(list(type = "Base", value = 10.02))}. Order is
+preserved. An empty \code{list()} clears the pKa types; \code{NULL} leaves them
+unset.}
+
+\item{processes}{List of \link{Process} objects (created with
+\code{\link[=create_process]{create_process()}}) or raw process lists to attach to the compound.}
 }
 \value{
 A \link{Compound} object.
 }
 \description{
-Create a minimally populated \link{Compound} building block from named
-arguments. This is a thin factory around \code{Compound$new()} that builds
-the raw list shape for you.
+Create a \link{Compound} building block from named arguments. This is a thin
+factory around \code{Compound$new()} that builds the raw list shape for you,
+including the physicochemical properties, pKa, and processes.
 
-For richer compound structures (full lipophilicity alternatives,
-processes, calculation methods, and so on), build the raw list directly
-or load a template snapshot and mutate it.
+Each of lipophilicity, fraction unbound, solubility (including reference
+pH, gain per charge, and table solubility), intestinal permeability,
+permeability, and pKa must be set through its dedicated argument (or by
+mutating the matching writable \link{Compound} field). The \code{parameters}
+argument is for additional/loose compound parameters only; it cannot set
+these physicochemical properties, because each lives in its own
+top-level alternative array or typed list rather than in \code{Parameters}.
 }
 \examples{
 # Create a minimal compound
@@ -62,7 +163,53 @@ compound <- create_compound(
   plasma_protein_binding_partner = "Albumin"
 )
 
-# Create a compound with additional parameters
+# Set the single-parameter physicochemical properties
+compound <- create_compound(
+  name = "Drug X",
+  lipophilicity = 2.5,
+  fraction_unbound = 0.1,
+  intestinal_permeability = 1.14e-05,
+  permeability = 0.0069
+)
+
+# Solubility with reference pH and gain per charge
+compound <- create_compound(
+  name = "Drug X",
+  solubility = 9999,
+  reference_pH = 7,
+  solubility_gain_per_charge = 1000
+)
+
+# Table-based solubility (first column pH, second column value)
+compound <- create_compound(
+  name = "Drug X",
+  solubility_table = data.frame(
+    pH = c(3, 6, 6.8),
+    value = c(5000, 3000, 90)
+  )
+)
+
+# Multiple pKa entries
+compound <- create_compound(
+  name = "Drug X",
+  pKa = list(
+    list(type = "Base", value = 10.02),
+    list(type = "Acid", value = 1.7)
+  )
+)
+
+# Attach a process
+compound <- create_compound(
+  name = "Drug X",
+  processes = list(
+    create_process(
+      internal_name = "GlomerularFiltration",
+      data_source = "Publication X"
+    )
+  )
+)
+
+# Additional/loose parameters (not physicochemical properties)
 compound <- create_compound(
   name = "Drug X",
   parameters = list(

--- a/tests/testthat/_snaps/Compound.md
+++ b/tests/testthat/_snaps/Compound.md
@@ -408,6 +408,19 @@
         * Br: 1 [Unknown]
         * Cl: 1 [Unknown]
 
+# Compound prints when is_small_molecule is unset
+
+    Code
+      print(compound)
+    Output
+      
+      -- Compound: NoFlag ------------------------------------------------------------
+      
+      -- Basic Properties --
+      
+      -- Physicochemical Properties --
+      
+
 # Compounds sections can be accessed and are correctly printed
 
     Code

--- a/tests/testthat/_snaps/Compound.md
+++ b/tests/testthat/_snaps/Compound.md
@@ -944,3 +944,19 @@
       Compound$induction was deprecated in osp.snapshots 0.3.0.
       i Use `compound$processes` (a flat named list of `Process` objects, filtered by `$category`) or the long-form `processes` tibble returned by `get_compounds_dfs()` instead.
 
+# invalid physicochemical field assignments abort
+
+    Code
+      compound$lipophilicity <- "high"
+    Condition
+      Error in `private$set_alternative_group()`:
+      ! `lipophilicity` must be a numeric value, a raw alternative list, or NULL
+
+---
+
+    Code
+      compound$permeability <- "high"
+    Condition
+      Error in `private$set_alternative_group()`:
+      ! `permeability` must be a numeric value, a raw alternative list, or NULL
+

--- a/tests/testthat/_snaps/Compound.md
+++ b/tests/testthat/_snaps/Compound.md
@@ -885,6 +885,24 @@
       182 Rifampicin    renal_c~ TubularSecr~ TSspec    55    1/min RenCL_rif   "Assu~
       # i 3 more variables: molecule <chr>, metabolite <chr>, species <chr>
 
+# permeability is surfaced in print and the properties tibble
+
+    Code
+      print(compound)
+    Output
+      
+      -- Compound: X -----------------------------------------------------------------
+      
+      -- Basic Properties --
+      
+      * Type: Small Molecule
+      * Molecular Weight: 250 g/mol
+      
+      -- Physicochemical Properties --
+      
+      * Permeability:
+        * 0.0069 cm/min [Unknown]
+
 # Deprecated category accessors warn
 
     Code

--- a/tests/testthat/_snaps/create_compound.md
+++ b/tests/testthat/_snaps/create_compound.md
@@ -47,3 +47,139 @@
       ! Invalid unit: not-a-unit
       i Valid units for Molecular weight are: kg/µmol, kg/mol, kDa, g/mol
 
+# create_compound rejects both scalar and table solubility
+
+    Code
+      create_compound(name = "X", solubility = 1, solubility_table = data.frame(pH = 3,
+        value = 5000))
+    Condition
+      Error in `create_compound()`:
+      ! Solubility is set either by a single value or by a table, not both.
+      i Supply `solubility` or `solubility_table`, not both.
+
+# create_compound rejects invalid pKa entries
+
+    Code
+      create_compound(name = "X", pKa = list(list(type = "Weak", value = 1)))
+    Condition
+      Error in `create_compound()`:
+      ! Entry 1 of `pKa` has an invalid type.
+      i type must be one of "Acid", "Base", and "Neutral".
+
+---
+
+    Code
+      create_compound(name = "X", pKa = list(list(type = "Base", value = "big")))
+    Condition
+      Error in `create_compound()`:
+      ! Entry 1 of `pKa` must have a numeric value
+
+# create_compound rejects non-numeric property values
+
+    Code
+      create_compound(name = "X", lipophilicity = "a")
+    Condition
+      Error in `create_compound()`:
+      ! `lipophilicity` must be a numeric value
+
+---
+
+    Code
+      create_compound(name = "X", fraction_unbound = "a")
+    Condition
+      Error in `create_compound()`:
+      ! `fraction_unbound` must be a numeric value
+
+---
+
+    Code
+      create_compound(name = "X", solubility = "a")
+    Condition
+      Error in `create_compound()`:
+      ! `solubility` must be a numeric value
+
+---
+
+    Code
+      create_compound(name = "X", reference_pH = "a")
+    Condition
+      Error in `create_compound()`:
+      ! `reference_pH` must be a numeric value
+
+---
+
+    Code
+      create_compound(name = "X", solubility_gain_per_charge = "a")
+    Condition
+      Error in `create_compound()`:
+      ! `solubility_gain_per_charge` must be a numeric value
+
+---
+
+    Code
+      create_compound(name = "X", intestinal_permeability = "a")
+    Condition
+      Error in `create_compound()`:
+      ! `intestinal_permeability` must be a numeric value
+
+---
+
+    Code
+      create_compound(name = "X", permeability = "a")
+    Condition
+      Error in `create_compound()`:
+      ! `permeability` must be a numeric value
+
+# create_compound rejects a non-list processes argument
+
+    Code
+      create_compound(name = "X", processes = "not a list")
+    Condition
+      Error in `create_compound()`:
+      ! `processes` must be a list
+
+# create_compound rejects a malformed solubility table
+
+    Code
+      create_compound(name = "X", solubility_table = c(3, 6))
+    Condition
+      Error in `create_compound()`:
+      ! `solubility_table` must be a data frame with two columns (pH, value)
+
+# create_compound validates property units
+
+    Code
+      create_compound(name = "X", lipophilicity = 2.5, lipophilicity_unit = "nope")
+    Condition
+      Error in `validate_unit()`:
+      ! Invalid unit: nope
+      i Valid units for Log Units are: Log Units
+
+---
+
+    Code
+      create_compound(name = "X", solubility = 1, solubility_unit = "nope")
+    Condition
+      Error in `validate_unit()`:
+      ! Invalid unit: nope
+      i Valid units for Concentration (mass) are: g/l, mg/l, µg/l, ng/l, pg/l, mg/dl, mg/ml, µg/ml, ng/ml, pg/ml, kg/l
+
+---
+
+    Code
+      create_compound(name = "X", intestinal_permeability = 1,
+        intestinal_permeability_unit = "nope")
+    Condition
+      Error in `validate_unit()`:
+      ! Invalid unit: nope
+      i Valid units for Velocity are: cm/min, cm/s, dm/min
+
+---
+
+    Code
+      create_compound(name = "X", permeability = 1, permeability_unit = "nope")
+    Condition
+      Error in `validate_unit()`:
+      ! Invalid unit: nope
+      i Valid units for Velocity are: cm/min, cm/s, dm/min
+

--- a/tests/testthat/_snaps/create_compound.md
+++ b/tests/testthat/_snaps/create_compound.md
@@ -146,6 +146,24 @@
       Error in `create_compound()`:
       ! `solubility_table` must be a data frame with two columns (pH, value)
 
+# create_compound rejects an empty or non-numeric solubility table
+
+    Code
+      create_compound(name = "X", solubility_table = data.frame(pH = numeric(0),
+      value = numeric(0)))
+    Condition
+      Error in `create_compound()`:
+      ! `solubility_table` must have at least one row with numeric pH and value columns
+
+---
+
+    Code
+      create_compound(name = "X", solubility_table = data.frame(pH = c(3, 6), value = c(
+        "a", "b")))
+    Condition
+      Error in `create_compound()`:
+      ! `solubility_table` must have at least one row with numeric pH and value columns
+
 # create_compound validates property units
 
     Code

--- a/tests/testthat/test-Compound.R
+++ b/tests/testthat/test-Compound.R
@@ -17,6 +17,12 @@ test_that("Compounds are printed correctly", {
   }
 })
 
+test_that("Compound prints when is_small_molecule is unset", {
+  compound <- create_compound(name = "NoFlag")
+  expect_equal(compound$is_small_molecule, NA)
+  expect_snapshot(print(compound))
+})
+
 test_that("Compounds sections can be accessed and are correctly printed", {
   expect_no_error({
     snapshot$compounds[[1]]$name

--- a/tests/testthat/test-Compound.R
+++ b/tests/testthat/test-Compound.R
@@ -88,6 +88,24 @@ test_that("Compounds can be converted to dataframes", {
   expect_snapshot(print(dfs$processes, n = Inf))
 })
 
+test_that("permeability is surfaced in print and the properties tibble", {
+  compound <- create_compound(
+    name = "X",
+    is_small_molecule = TRUE,
+    molecular_weight = 250,
+    permeability = 0.0069
+  )
+
+  expect_snapshot(print(compound))
+
+  snap <- add_compound(create_snapshot(), compound)
+  properties <- get_compounds_dfs(snap)$properties
+  perm_rows <- properties[properties$type == "permeability", ]
+  expect_equal(nrow(perm_rows), 1)
+  expect_equal(unname(perm_rows$value), "0.0069")
+  expect_equal(unname(perm_rows$unit), "cm/min")
+})
+
 
 # Process accessor -------------------------------------------------------
 

--- a/tests/testthat/test-Compound.R
+++ b/tests/testthat/test-Compound.R
@@ -137,6 +137,217 @@ test_that("Deprecated category accessors warn", {
 })
 
 
+# Writable physicochemical fields ----------------------------------------
+
+test_that("single-parameter physicochemical fields are writable by scalar", {
+  compound <- test_snapshot$clone()$compounds[[1]]$clone(deep = TRUE)
+
+  compound$lipophilicity <- 3.3
+  expect_equal(
+    compound$data$Lipophilicity[[1]]$Parameters[[1]]$Value,
+    3.3
+  )
+  expect_equal(compound$data$Lipophilicity[[1]]$Name, "User defined")
+
+  compound$fraction_unbound <- 0.2
+  fu <- compound$data$FractionUnbound[[1]]$Parameters[[1]]
+  expect_equal(fu$Value, 0.2)
+  expect_null(fu$Unit)
+
+  compound$solubility <- 500
+  sol <- compound$data$Solubility[[1]]$Parameters[[1]]
+  expect_equal(sol$Name, "Solubility at reference pH")
+  expect_equal(sol$Value, 500)
+  expect_equal(sol$Unit, "mg/l")
+
+  compound$intestinal_permeability <- 2e-05
+  ip <- compound$data$IntestinalPermeability[[1]]$Parameters[[1]]
+  expect_equal(ip$Value, 2e-05)
+  expect_equal(ip$Unit, "cm/min")
+})
+
+test_that("permeability field reads and writes on a compound without the key", {
+  compound <- test_snapshot$clone()$compounds[[1]]$clone(deep = TRUE)
+
+  expect_null(compound$permeability)
+
+  compound$permeability <- 0.007
+  expect_s3_class(compound$permeability, "physicochemical_property")
+  param <- compound$data$Permeability[[1]]$Parameters[[1]]
+  expect_equal(param$Name, "Permeability")
+  expect_equal(param$Value, 0.007)
+  expect_equal(param$Unit, "cm/min")
+})
+
+test_that("physicochemical fields accept a raw alternative list verbatim", {
+  compound <- test_snapshot$clone()$compounds[[1]]$clone(deep = TRUE)
+
+  raw <- list(list(
+    Name = "Custom",
+    IsDefault = TRUE,
+    Parameters = list(
+      list(Name = "Solubility at reference pH", Value = 12, Unit = "mg/l"),
+      list(Name = "Reference pH", Value = 7)
+    )
+  ))
+  compound$solubility <- raw
+  expect_equal(compound$data$Solubility, raw)
+})
+
+test_that("pka_types is writable via list shape and raw shape", {
+  compound <- test_snapshot$clone()$compounds[[1]]$clone(deep = TRUE)
+
+  compound$pka_types <- list(list(type = "Base", value = 7.9))
+  expect_equal(
+    compound$data$PkaTypes,
+    list(list(Type = "Base", Pka = 7.9))
+  )
+
+  compound$pka_types <- list(list(Type = "Acid", Pka = 1.2))
+  expect_equal(
+    compound$data$PkaTypes,
+    list(list(Type = "Acid", Pka = 1.2))
+  )
+})
+
+test_that("processes field is writable", {
+  compound <- test_snapshot$clone()$compounds[[1]]$clone(deep = TRUE)
+
+  compound$processes <- list(
+    create_process(
+      internal_name = "GlomerularFiltration",
+      data_source = "Publication X"
+    )
+  )
+  expect_length(compound$processes, 1)
+  expect_equal(compound$processes[[1]]$category, "renal_clearance")
+  expect_null(names(compound$data$Processes))
+})
+
+test_that("assigning NULL clears the single-parameter physicochemical keys", {
+  compound <- test_snapshot$clone()$compounds[[1]]$clone(deep = TRUE)
+
+  compound$lipophilicity <- NULL
+  compound$fraction_unbound <- NULL
+  compound$solubility <- NULL
+  compound$intestinal_permeability <- NULL
+  compound$permeability <- 0.007
+  compound$permeability <- NULL
+
+  expect_null(compound$data$Lipophilicity)
+  expect_null(compound$data$FractionUnbound)
+  expect_null(compound$data$Solubility)
+  expect_null(compound$data$IntestinalPermeability)
+  expect_null(compound$data$Permeability)
+})
+
+test_that("clearing pka_types and processes with NULL or list()", {
+  compound <- test_snapshot$clone()$compounds[[1]]$clone(deep = TRUE)
+
+  compound$pka_types <- NULL
+  expect_null(compound$data$PkaTypes)
+
+  compound$pka_types <- list(list(type = "Base", value = 7.9))
+  compound$pka_types <- list()
+  expect_null(compound$data$PkaTypes)
+
+  compound$processes <- list()
+  expect_length(compound$processes, 0)
+  expect_null(compound$data$Processes)
+
+  compound$processes <- list(
+    create_process(internal_name = "GlomerularFiltration", data_source = "X")
+  )
+  compound$processes <- NULL
+  expect_length(compound$processes, 0)
+  expect_null(compound$data$Processes)
+})
+
+test_that("invalid physicochemical field assignments abort", {
+  compound <- test_snapshot$clone()$compounds[[1]]$clone(deep = TRUE)
+  expect_snapshot(error = TRUE, compound$lipophilicity <- "high")
+  expect_snapshot(error = TRUE, compound$permeability <- "high")
+})
+
+
+# Round trip -------------------------------------------------------------
+
+test_that("compound built with new arguments round-trips through export", {
+  compound <- create_compound(
+    name = "RTX",
+    lipophilicity = 2.5,
+    fraction_unbound = 1,
+    solubility = 9999,
+    reference_pH = 7,
+    solubility_gain_per_charge = 1000,
+    intestinal_permeability = 1.14e-05,
+    permeability = 0.0069,
+    pKa = list(list(type = "Base", value = 10.02)),
+    processes = list(
+      create_process(
+        internal_name = "GlomerularFiltration",
+        data_source = "X"
+      )
+    )
+  )
+  snap <- add_compound(create_snapshot(), compound)
+
+  path <- withr::local_tempfile(fileext = ".json")
+  export_snapshot(snap, path)
+  reloaded <- load_snapshot(path)
+  rc <- reloaded$compounds[[1]]
+
+  expect_equal(rc$data$Lipophilicity, compound$data$Lipophilicity)
+  expect_equal(rc$data$FractionUnbound, compound$data$FractionUnbound)
+  expect_equal(rc$data$Solubility, compound$data$Solubility)
+  expect_equal(
+    rc$data$IntestinalPermeability,
+    compound$data$IntestinalPermeability
+  )
+  expect_equal(rc$data$Permeability, compound$data$Permeability)
+  expect_equal(rc$data$PkaTypes, compound$data$PkaTypes)
+  expect_equal(rc$data$Processes, compound$data$Processes)
+})
+
+test_that("mutating a loaded compound leaves unreassigned sections intact", {
+  original <- jsonlite::fromJSON(
+    txt = testthat::test_path("data", "test_snapshot.json"),
+    simplifyDataFrame = FALSE,
+    simplifyVector = FALSE
+  )
+  snap <- load_snapshot(testthat::test_path("data", "test_snapshot.json"))
+  compound <- snap$compounds[[1]]
+
+  compound$lipophilicity <- 4.2
+  compound$pka_types <- list(list(type = "Base", value = 5.5))
+
+  path <- withr::local_tempfile(fileext = ".json")
+  export_snapshot(snap, path)
+  reloaded <- jsonlite::fromJSON(
+    txt = path,
+    simplifyDataFrame = FALSE,
+    simplifyVector = FALSE
+  )
+
+  # Value equality, not byte-identity: exporting whole-number doubles and
+  # re-parsing them can flip their JSON storage type (double <-> integer),
+  # a pre-existing artifact of the export path that is unrelated to whether
+  # a section was mutated.
+  expect_equal(
+    reloaded$Compounds[[1]]$Parameters,
+    original$Compounds[[1]]$Parameters
+  )
+  expect_equal(
+    reloaded$Compounds[[1]]$CalculationMethods,
+    original$Compounds[[1]]$CalculationMethods
+  )
+  expect_equal(
+    reloaded$Compounds[[1]]$Solubility,
+    original$Compounds[[1]]$Solubility
+  )
+})
+
+
 # Deep clone -------------------------------------------------------------
 
 test_that("Compound$clone(deep = TRUE) isolates calculation_methods", {

--- a/tests/testthat/test-create_compound.R
+++ b/tests/testthat/test-create_compound.R
@@ -292,6 +292,29 @@ test_that("create_compound rejects a malformed solubility table", {
   )
 })
 
+test_that("create_compound rejects an empty or non-numeric solubility table", {
+  expect_snapshot(
+    error = TRUE,
+    create_compound(
+      name = "X",
+      solubility_table = data.frame(
+        pH = numeric(0),
+        value = numeric(0)
+      )
+    )
+  )
+  expect_snapshot(
+    error = TRUE,
+    create_compound(
+      name = "X",
+      solubility_table = data.frame(
+        pH = c(3, 6),
+        value = c("a", "b")
+      )
+    )
+  )
+})
+
 test_that("create_compound validates property units", {
   expect_snapshot(
     error = TRUE,

--- a/tests/testthat/test-create_compound.R
+++ b/tests/testthat/test-create_compound.R
@@ -60,3 +60,271 @@ test_that("create_compound validates required arguments", {
     )
   )
 })
+
+
+# Physicochemical property arguments -------------------------------------
+
+test_that("create_compound sets a lipophilicity alternative", {
+  compound <- create_compound(name = "X", lipophilicity = 2.5)
+
+  alt <- compound$data$Lipophilicity
+  expect_length(alt, 1)
+  expect_equal(alt[[1]]$Name, "User defined")
+  expect_equal(alt[[1]]$IsDefault, TRUE)
+  expect_equal(alt[[1]]$Parameters[[1]]$Name, "Lipophilicity")
+  expect_equal(alt[[1]]$Parameters[[1]]$Value, 2.5)
+  expect_equal(alt[[1]]$Parameters[[1]]$Unit, "Log Units")
+  expect_s3_class(compound$lipophilicity, "physicochemical_property")
+})
+
+test_that("create_compound sets a fraction unbound alternative without a unit", {
+  compound <- create_compound(name = "X", fraction_unbound = 1)
+
+  param <- compound$data$FractionUnbound[[1]]$Parameters[[1]]
+  expect_equal(param$Name, "Fraction unbound (plasma, reference value)")
+  expect_equal(param$Value, 1)
+  expect_null(param$Unit)
+})
+
+test_that("create_compound bundles reference pH and gain per charge into solubility", {
+  compound <- create_compound(
+    name = "X",
+    solubility = 9999,
+    reference_pH = 7,
+    solubility_gain_per_charge = 1000
+  )
+
+  params <- compound$data$Solubility[[1]]$Parameters
+  expect_length(params, 3)
+  expect_equal(params[[1]]$Name, "Solubility at reference pH")
+  expect_equal(params[[1]]$Value, 9999)
+  expect_equal(params[[1]]$Unit, "mg/l")
+  expect_equal(params[[2]]$Name, "Reference pH")
+  expect_equal(params[[2]]$Value, 7)
+  expect_equal(params[[3]]$Name, "Solubility gain per charge")
+  expect_equal(params[[3]]$Value, 1000)
+})
+
+test_that("create_compound omits reference pH and gain per charge when not supplied", {
+  compound <- create_compound(name = "X", solubility = 9999)
+
+  params <- compound$data$Solubility[[1]]$Parameters
+  expect_length(params, 1)
+  expect_equal(params[[1]]$Name, "Solubility at reference pH")
+})
+
+test_that("create_compound builds a table solubility alternative", {
+  compound <- create_compound(
+    name = "X",
+    solubility_table = data.frame(
+      pH = c(3, 6, 6.8),
+      value = c(5000, 3000, 90)
+    )
+  )
+
+  param <- compound$data$Solubility[[1]]$Parameters[[1]]
+  expect_equal(param$Name, "Solubility table")
+  expect_equal(param$Value, 5000)
+  expect_equal(param$Unit, "mg/l")
+
+  formula <- param$TableFormula
+  expect_equal(formula$XDimension, "Dimensionless")
+  expect_equal(formula$YDimension, "Concentration (mass)")
+  expect_equal(formula$YUnit, "mg/l")
+  expect_equal(formula$UseDerivedValues, FALSE)
+  expect_length(formula$Points, 3)
+  expect_equal(
+    formula$Points[[1]],
+    list(X = 3, Y = 5000, RestartSolver = FALSE)
+  )
+  expect_equal(
+    formula$Points[[2]],
+    list(X = 6, Y = 3000, RestartSolver = FALSE)
+  )
+  expect_equal(
+    formula$Points[[3]],
+    list(X = 6.8, Y = 90, RestartSolver = FALSE)
+  )
+})
+
+test_that("create_compound rejects both scalar and table solubility", {
+  expect_snapshot(
+    error = TRUE,
+    create_compound(
+      name = "X",
+      solubility = 1,
+      solubility_table = data.frame(pH = 3, value = 5000)
+    )
+  )
+})
+
+test_that("reference pH or gain per charge alone create no solubility alternative", {
+  compound <- create_compound(
+    name = "X",
+    reference_pH = 7,
+    solubility_gain_per_charge = 1000
+  )
+  expect_null(compound$data$Solubility)
+})
+
+test_that("create_compound sets an intestinal permeability alternative", {
+  compound <- create_compound(name = "X", intestinal_permeability = 1.14e-05)
+
+  param <- compound$data$IntestinalPermeability[[1]]$Parameters[[1]]
+  expect_equal(param$Name, "Specific intestinal permeability (transcellular)")
+  expect_equal(param$Value, 1.14e-05)
+  expect_equal(param$Unit, "cm/min")
+})
+
+test_that("create_compound sets a permeability alternative", {
+  compound <- create_compound(name = "X", permeability = 0.0069)
+
+  param <- compound$data$Permeability[[1]]$Parameters[[1]]
+  expect_equal(param$Name, "Permeability")
+  expect_equal(param$Value, 0.0069)
+  expect_equal(param$Unit, "cm/min")
+})
+
+test_that("create_compound sets pKa types preserving order", {
+  compound <- create_compound(
+    name = "X",
+    pKa = list(
+      list(type = "Base", value = 10.02),
+      list(type = "Acid", value = 1.7)
+    )
+  )
+
+  expect_equal(
+    compound$data$PkaTypes,
+    list(
+      list(Type = "Base", Pka = 10.02),
+      list(Type = "Acid", Pka = 1.7)
+    )
+  )
+})
+
+test_that("create_compound rejects invalid pKa entries", {
+  expect_snapshot(
+    error = TRUE,
+    create_compound(name = "X", pKa = list(list(type = "Weak", value = 1)))
+  )
+  expect_snapshot(
+    error = TRUE,
+    create_compound(name = "X", pKa = list(list(type = "Base", value = "big")))
+  )
+})
+
+test_that("*_name arguments override the alternative name", {
+  compound <- create_compound(
+    name = "X",
+    lipophilicity = 2.5,
+    lipophilicity_name = "Custom lipo",
+    fraction_unbound = 1,
+    fraction_unbound_name = "Custom fu",
+    solubility = 9999,
+    solubility_name = "Custom sol",
+    intestinal_permeability = 1.14e-05,
+    intestinal_permeability_name = "Custom ip",
+    permeability = 0.0069,
+    permeability_name = "Custom perm"
+  )
+
+  expect_equal(compound$data$Lipophilicity[[1]]$Name, "Custom lipo")
+  expect_equal(compound$data$FractionUnbound[[1]]$Name, "Custom fu")
+  expect_equal(compound$data$Solubility[[1]]$Name, "Custom sol")
+  expect_equal(compound$data$IntestinalPermeability[[1]]$Name, "Custom ip")
+  expect_equal(compound$data$Permeability[[1]]$Name, "Custom perm")
+})
+
+test_that("create_compound attaches processes", {
+  compound <- create_compound(
+    name = "X",
+    processes = list(
+      create_process(
+        internal_name = "GlomerularFiltration",
+        data_source = "Publication X"
+      )
+    )
+  )
+
+  expect_length(compound$processes, 1)
+  expect_equal(compound$processes[[1]]$category, "renal_clearance")
+  expect_null(names(compound$data$Processes))
+  expect_equal(
+    compound$data$Processes[[1]]$InternalName,
+    "GlomerularFiltration"
+  )
+})
+
+test_that("create_compound rejects non-numeric property values", {
+  expect_snapshot(
+    error = TRUE,
+    create_compound(name = "X", lipophilicity = "a")
+  )
+  expect_snapshot(
+    error = TRUE,
+    create_compound(name = "X", fraction_unbound = "a")
+  )
+  expect_snapshot(error = TRUE, create_compound(name = "X", solubility = "a"))
+  expect_snapshot(error = TRUE, create_compound(name = "X", reference_pH = "a"))
+  expect_snapshot(
+    error = TRUE,
+    create_compound(name = "X", solubility_gain_per_charge = "a")
+  )
+  expect_snapshot(
+    error = TRUE,
+    create_compound(name = "X", intestinal_permeability = "a")
+  )
+  expect_snapshot(error = TRUE, create_compound(name = "X", permeability = "a"))
+})
+
+test_that("create_compound rejects a non-list processes argument", {
+  expect_snapshot(
+    error = TRUE,
+    create_compound(name = "X", processes = "not a list")
+  )
+})
+
+test_that("create_compound rejects a malformed solubility table", {
+  expect_snapshot(
+    error = TRUE,
+    create_compound(name = "X", solubility_table = c(3, 6))
+  )
+})
+
+test_that("create_compound validates property units", {
+  expect_snapshot(
+    error = TRUE,
+    create_compound(
+      name = "X",
+      lipophilicity = 2.5,
+      lipophilicity_unit = "nope"
+    )
+  )
+  expect_snapshot(
+    error = TRUE,
+    create_compound(name = "X", solubility = 1, solubility_unit = "nope")
+  )
+  expect_snapshot(
+    error = TRUE,
+    create_compound(
+      name = "X",
+      intestinal_permeability = 1,
+      intestinal_permeability_unit = "nope"
+    )
+  )
+  expect_snapshot(
+    error = TRUE,
+    create_compound(name = "X", permeability = 1, permeability_unit = "nope")
+  )
+})
+
+test_that("create_compound accepts the default property units", {
+  expect_no_error(create_compound(
+    name = "X",
+    lipophilicity = 2.5,
+    solubility = 1,
+    intestinal_permeability = 1,
+    permeability = 1
+  ))
+})


### PR DESCRIPTION
Closes #115

`create_compound()` could not produce a compound whose physicochemical properties or processes were correctly registered, and a compound loaded from a snapshot had no supported way to set them. Reaching for the `parameters` argument silently misfiled the values under "Additional Parameters" instead of the physicochemical property groups PK-Sim expects, with no warning. This PR makes every settable building-block compound property first class, both on the `create_compound()` factory and as writable `Compound` fields, so a compound can be built or mutated without hand-authoring raw lists. The scope is 100% coverage of the settable compound properties, verified against all 75 `osp_models()` templates and the snapshot schema.

## New create_compound() arguments

`create_compound()` gains arguments for all five single-parameter alternative groups (`lipophilicity`, `fraction_unbound`, `solubility`, `intestinal_permeability`, `permeability`), each with its `_unit` and `_name` companions and sensible defaults. Solubility is covered in full: `reference_pH`, `solubility_gain_per_charge`, and a table-based `solubility_table` (a two-column pH/value data frame producing a `TableFormula`), with the scalar and table forms mutually exclusive. pKa is set through a typed list argument (`pKa = list(list(type = "Base", value = 10.02), ...)`), and processes attach through `processes = list(create_process(...))`. Unit validation uses the dimensions PK-Sim actually resolves (`"Log Units"`, `"Concentration (mass)"`, `"Velocity"` for both permeability groups).

The roxygen now states explicitly that `parameters` is for additional/loose parameters only and cannot set physicochemical properties, and points to the dedicated arguments instead.

## Writable Compound fields

The matching `Compound` fields (`$lipophilicity`, `$fraction_unbound`, `$solubility`, `$intestinal_permeability`, `$permeability`, `$pka_types`, `$processes`) are now writable, so a compound loaded from a snapshot can be mutated in place. A bare numeric scalar builds the default alternative; a raw list is stored verbatim (the escape hatch for multiple/named/species alternatives, value origins, or table solubility); `NULL` clears the property. `$permeability` is a brand-new read/write binding (only `$intestinal_permeability` existed before).

## Print fix

Printing a compound created without `is_small_molecule` aborted with "missing value where TRUE/FALSE needed" because the unset flag reads as `NA`. The type line is now skipped when the flag is unset, so such a compound prints cleanly.

## Round-trip fidelity

A compound built with the new arguments, added with `add_compound()` and exported with `export_snapshot()`, reloads with the same `Lipophilicity`, `FractionUnbound`, `Solubility`, `IntestinalPermeability`, `Permeability`, `PkaTypes`, and `Processes`. Reassigning a subset of fields on a loaded compound leaves the untouched sections, `Parameters`, and `CalculationMethods` intact. Table-based solubility round-trips at the JSON level; PK-Sim's import-side table preparation is not run by this package (documented on the argument).

## Example

```r
library(osp.snapshots)

inulin <- create_compound(
  name = "Inulin",
  is_small_molecule = TRUE,
  molecular_weight = 5500,
  lipophilicity = -10,
  fraction_unbound = 1,
  solubility = 9999,
  reference_pH = 7,
  pKa = list(list(type = "Base", value = 10.02))
)

inulin
#> ── Compound: Inulin ────────────────────────────────────────────────
#>
#> ── Basic Properties ──
#> • Type: Small Molecule
#> • Molecular Weight: 5500 g/mol
#>
#> ── Physicochemical Properties ──
#> • Lipophilicity:
#>   • -10 Log Units [Unknown]
#> • Fraction Unbound:
#>   • 1 [Unknown]
#> • Solubility:
#>   • 9999 mg/l (pH 7) [Unknown]
#> • pKa Types:
#>   • Base: 10.02 [Unknown]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Create compounds with additional physicochemical inputs (lipophilicity, fraction unbound, solubility, intestinal permeability, permeability), plus pKa entries and attached processes.
  * Solubility supports scalar inputs (with optional reference pH and gain-per-charge) or pH-based tables.
* **Bug Fixes**
  * Compound printing no longer errors when the small-molecule flag is left unset/NA.
  * Improved handling and validation of physicochemical property assignments (including clearing with `NULL`).
* **Documentation**
  * Updated class and function reference docs and release notes; added snapshot test coverage for edge cases and validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->