### PR TITLE
Configure the base individual and missing settings in create_population()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,7 @@ Suggests:
 VignetteBuilder: knitr
 Config/testthat/edition: 3
 Remotes:
-    ospsuite=Open-Systems-Pharmacology/OSPSuite-R@*release
+    ospsuite=Open-Systems-Pharmacology/OSPSuite-R
 Config/Needs/website: quarto
 Roxygen: list(markdown = TRUE)
 Config/roxygen2/version: 8.0.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: osp.snapshots
 Type: Package
 Title: Import and Manipulate Open Systems Pharmacology Project Snapshots
-Version: 1.0.0
+Version: 1.0.0.9000
 Authors@R: c(
     person(
       "Felix", "MIL",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# osp.snapshots 1.0.0.9000
+
+- `create_population()` gains `description`, `gestational_age_range`, `disease_state_parameters`, and `individual` arguments, the last composing a base individual from `create_individual()` to fully configure the population's base individual (#118).
+- `Population` objects gain read/write `description`, `gestational_age_range`, and `disease_state_parameters` bindings and a read-only `individual` binding exposing the base individual (#118).
+- `Population$egfr_range` now persists into the population settings, so an eGFR range set on a population survives export (#118).
+
 # osp.snapshots 1.0.0
 
 ## Breaking changes

--- a/R/Population.R
+++ b/R/Population.R
@@ -53,6 +53,14 @@ Population <- R6::R6Class(
         )
       }
 
+      if (!is.null(data$Settings$GestationalAge)) {
+        private$.gestational_age_range <- Range$new(
+          data$Settings$GestationalAge$Min,
+          data$Settings$GestationalAge$Max,
+          data$Settings$GestationalAge$Unit
+        )
+      }
+
       # Initialize advanced parameters if present
       if (!is.null(data$AdvancedParameters)) {
         private$.advanced_parameters <- lapply(
@@ -63,19 +71,10 @@ Population <- R6::R6Class(
         )
       }
 
-      # Initialize disease state parameter ranges (eGFR for now)
-      private$.egfr_range <- NULL
-      if (!is.null(data$Settings$DiseaseStateParameters)) {
-        for (param in data$Settings$DiseaseStateParameters) {
-          if (!is.null(param$Name) && tolower(param$Name) == "egfr") {
-            private$.egfr_range <- Range$new(
-              param$Min,
-              param$Max,
-              param$Unit
-            )
-          }
-        }
-      }
+      # Initialize disease state parameter ranges (eGFR convenience cache)
+      private$.egfr_range <- egfr_range_from_entries(
+        data$Settings$DiseaseStateParameters
+      )
     },
 
     #' @description
@@ -93,6 +92,11 @@ Population <- R6::R6Class(
           ""
         }
         cli::cli_h2("Population: {self$name}{seed_text}")
+
+        # Description (if available)
+        if (!is.null(self$description)) {
+          cli::cli_text("Description: {self$description}")
+        }
 
         # Individual name (if available)
         if (!is.null(self$individual_name)) {
@@ -137,6 +141,13 @@ Population <- R6::R6Class(
         if (!is.null(self$bmi_range)) {
           cli::cli_text(
             "BMI range: {self$bmi_range$min} - {self$bmi_range$max} {self$bmi_range$unit}"
+          )
+        }
+
+        # Gestational age range (if available)
+        if (!is.null(self$gestational_age_range)) {
+          cli::cli_text(
+            "Gestational age range: {self$gestational_age_range$min} - {self$gestational_age_range$max} {self$gestational_age_range$unit}"
           )
         }
 
@@ -279,6 +290,14 @@ Population <- R6::R6Class(
       private$.data$Name <- value
     },
 
+    #' @field description A free-text description of the population
+    description = function(value) {
+      if (missing(value)) {
+        return(private$.data$Description)
+      }
+      private$.data$Description <- value
+    },
+
     #' @field source_population The source population name (read-only)
     source_population = function(value) {
       # not editable
@@ -295,6 +314,21 @@ Population <- R6::R6Class(
         cli::cli_abort("individual_name is read-only")
       }
       return(private$.data$Settings$Individual$Name)
+    },
+
+    #' @field individual The base individual the population samples from,
+    #'   returned as an [Individual] object built from the base individual
+    #'   in the population settings, or `NULL` when none is set
+    #'   (read-only). Author it at construction time via the `individual`
+    #'   argument of [create_population()].
+    individual = function(value) {
+      if (!missing(value)) {
+        cli::cli_abort("individual is read-only")
+      }
+      if (is.null(private$.data$Settings$Individual)) {
+        return(NULL)
+      }
+      Individual$new(private$.data$Settings$Individual)
     },
 
     #' @field seed The seed used for population generation
@@ -450,13 +484,50 @@ Population <- R6::R6Class(
       )
     },
 
-    #' @field egfr_range The eGFR range for the population (if available)
+    #' @field gestational_age_range The gestational age range used for
+    #'   population generation
+    gestational_age_range = function(value) {
+      if (missing(value)) {
+        return(private$.gestational_age_range)
+      }
+      if (is.null(value)) {
+        private$.gestational_age_range <- NULL
+        private$.data$Settings$GestationalAge <- NULL
+        return(invisible(NULL))
+      }
+      if (!inherits(value, "Range")) {
+        if (is.null(private$.gestational_age_range)) {
+          cli::cli_abort(c(
+            "gestational_age_range is empty and individual elements cannot be set",
+            "i" = "Use `...$gestational_age_range <- range(...)` to initialize a new range first."
+          ))
+        } else {
+          cli::cli_abort("gestational_age_range must be a Range object")
+        }
+      }
+      # Set gestational_age_range and update data
+      private$.gestational_age_range <- value
+      private$.data$Settings$GestationalAge <- list(
+        Min = value$min,
+        Max = value$max,
+        Unit = value$unit
+      )
+    },
+
+    #' @field egfr_range The eGFR range for the population (if available).
+    #'   Convenience over the case-insensitive `"egfr"` entry of
+    #'   `disease_state_parameters`; writes persist into the population
+    #'   settings so they survive export.
     egfr_range = function(value) {
       if (missing(value)) {
         return(private$.egfr_range)
       }
       if (is.null(value)) {
         private$.egfr_range <- NULL
+        private$.data$Settings$DiseaseStateParameters <- upsert_egfr_entry(
+          private$.data$Settings$DiseaseStateParameters,
+          NULL
+        )
         return(invisible(NULL))
       }
       if (!inherits(value, "Range")) {
@@ -470,6 +541,73 @@ Population <- R6::R6Class(
         }
       }
       private$.egfr_range <- value
+      private$.data$Settings$DiseaseStateParameters <- upsert_egfr_entry(
+        private$.data$Settings$DiseaseStateParameters,
+        value
+      )
+    },
+
+    #' @field disease_state_parameters The population disease-state
+    #'   parameters as a named list mapping each parameter name to a
+    #'   [Range] object. Assign a named list of `Range` objects to
+    #'   replace them, or `NULL` to clear them. This population-level
+    #'   name-to-`Range` map is distinct from the base individual's own
+    #'   `disease_state_parameters`, which carries scalar parameter
+    #'   values.
+    disease_state_parameters = function(value) {
+      if (missing(value)) {
+        result <- list()
+        for (param in private$.data$Settings$DiseaseStateParameters) {
+          result[[param$Name]] <- Range$new(
+            param$Min,
+            param$Max,
+            param$Unit
+          )
+        }
+        return(result)
+      }
+      if (is.null(value)) {
+        private$.data$Settings$DiseaseStateParameters <- NULL
+        private$.egfr_range <- NULL
+        return(invisible(NULL))
+      }
+      if (!is.list(value)) {
+        cli::cli_abort(c(
+          "disease_state_parameters must be a named list of Range objects",
+          "i" = "Use `range()` to create one."
+        ))
+      }
+      param_names <- names(value)
+      if (
+        is.null(param_names) ||
+          any(is.na(param_names)) ||
+          any(param_names == "")
+      ) {
+        cli::cli_abort(c(
+          "disease_state_parameters must be a named list of Range objects",
+          "i" = "Each entry must be `name = range(...)`."
+        ))
+      }
+      entries <- list()
+      for (nm in param_names) {
+        range_value <- value[[nm]]
+        if (!inherits(range_value, "Range")) {
+          cli::cli_abort(c(
+            "disease_state_parameters must be a named list of Range objects",
+            "i" = "Use `range()` to create one."
+          ))
+        }
+        entries[[length(entries) + 1]] <- disease_state_param_to_list(
+          nm,
+          list(
+            Min = range_value$min,
+            Max = range_value$max,
+            Unit = range_value$unit
+          )
+        )
+      }
+      private$.data$Settings$DiseaseStateParameters <- entries
+      private$.egfr_range <- egfr_range_from_entries(entries)
     },
 
     #' @field advanced_parameters Advanced parameters for the population
@@ -485,6 +623,7 @@ Population <- R6::R6Class(
     .weight_range = NULL,
     .height_range = NULL,
     .bmi_range = NULL,
+    .gestational_age_range = NULL,
     .egfr_range = NULL
   )
 )
@@ -578,3 +717,58 @@ AdvancedParameter <- R6::R6Class(
     .data = NULL
   )
 )
+
+# Serialize a single disease-state parameter to its `ParameterRange` shape.
+# `range_list` is the `list(Min, Max, Unit)` produced by `range_to_list()`,
+# so the element order is exactly `Name, Min, Max, Unit`.
+disease_state_param_to_list <- function(name, range_list) {
+  c(list(Name = name), range_list)
+}
+
+# Upsert or remove the case-insensitive "egfr" entry of a
+# `DiseaseStateParameters` list, preserving all other entries and their
+# order. Returns the updated list (or NULL when it becomes empty).
+upsert_egfr_entry <- function(entries, range) {
+  entries <- entries %||% list()
+  egfr_index <- NULL
+  for (i in seq_along(entries)) {
+    nm <- entries[[i]]$Name
+    if (!is.null(nm) && tolower(nm) == "egfr") {
+      egfr_index <- i
+      break
+    }
+  }
+  if (is.null(range)) {
+    if (!is.null(egfr_index)) {
+      entries[[egfr_index]] <- NULL
+    }
+    if (length(entries) == 0) {
+      return(NULL)
+    }
+    return(entries)
+  }
+  range_list <- list(Min = range$min, Max = range$max, Unit = range$unit)
+  if (is.null(egfr_index)) {
+    entries[[length(entries) + 1]] <- disease_state_param_to_list(
+      "eGFR",
+      range_list
+    )
+  } else {
+    entries[[egfr_index]] <- disease_state_param_to_list(
+      entries[[egfr_index]]$Name,
+      range_list
+    )
+  }
+  entries
+}
+
+# Reconstruct the eGFR `Range` from a `DiseaseStateParameters` list using
+# the case-insensitive "egfr" match. Returns NULL when absent.
+egfr_range_from_entries <- function(entries) {
+  for (param in entries) {
+    if (!is.null(param$Name) && tolower(param$Name) == "egfr") {
+      return(Range$new(param$Min, param$Max, param$Unit))
+    }
+  }
+  NULL
+}

--- a/R/create_population.R
+++ b/R/create_population.R
@@ -29,6 +29,23 @@
 #' @param advanced_parameters List of [AdvancedParameter] objects or raw
 #'   advanced-parameter lists that override default variability
 #'   distributions.
+#' @param description Character. Free-text description of the population.
+#' @param gestational_age_range A [Range] object describing the
+#'   gestational age range used for population generation (see [range()]).
+#'   This is the population-settings range, distinct from the base
+#'   individual's own scalar gestational age.
+#' @param disease_state_parameters A named list mapping a disease-state
+#'   parameter name to a [Range] object, for example
+#'   `list(eGFR = range(60, 120, "ml/min/1.73m²"))`. Each entry
+#'   becomes one range in the population settings. This population-level
+#'   name-to-`Range` map is distinct from the base individual's own
+#'   `disease_state_parameters`, which carries scalar parameter values.
+#' @param individual An [Individual] object (typically from
+#'   [create_individual()]) used as the base individual the population
+#'   samples from. When supplied, it fully configures the base individual
+#'   (gender, origin data, calculation methods, seed, description,
+#'   parameters) and cannot be combined with `individual_name`, `species`,
+#'   or `source_population`.
 #'
 #' @return A [Population] object.
 #' @export
@@ -50,6 +67,23 @@
 #'   age_range = range(20, 60, "year(s)"),
 #'   weight_range = range(50, 90, "kg")
 #' )
+#'
+#' # Compose a base individual and set a disease-state parameter
+#' pop <- create_population(
+#'   name = "Renal Impairment",
+#'   number_of_individuals = 25,
+#'   individual = create_individual(
+#'     name = "Base",
+#'     species = "Human",
+#'     population = "European_ICRP_2002",
+#'     gender = "MALE"
+#'   ),
+#'   gestational_age_range = range(37, 42, "week(s)"),
+#'   disease_state_parameters = list(
+#'     eGFR = range(60, 120, "ml/min/1.73m²")
+#'   ),
+#'   description = "Adults with reduced renal function"
+#' )
 create_population <- function(
   name,
   number_of_individuals,
@@ -62,7 +96,11 @@ create_population <- function(
   height_range = NULL,
   bmi_range = NULL,
   seed = NULL,
-  advanced_parameters = NULL
+  advanced_parameters = NULL,
+  description = NULL,
+  gestational_age_range = NULL,
+  disease_state_parameters = NULL,
+  individual = NULL
 ) {
   check_required_string(name, "name")
   if (
@@ -88,6 +126,23 @@ create_population <- function(
       "{.arg proportion_of_females} must be a number between 0 and 100"
     )
   }
+  if (!is.null(individual)) {
+    if (
+      !is.null(individual_name) ||
+        !is.null(species) ||
+        !is.null(source_population)
+    ) {
+      cli::cli_abort(c(
+        "{.arg individual} cannot be combined with {.arg individual_name}, {.arg species}, or {.arg source_population}.",
+        "i" = "Fold those fields into the {.fn create_individual} call instead."
+      ))
+    }
+    if (!inherits(individual, "Individual")) {
+      cli::cli_abort(
+        "{.arg individual} must be an {.cls Individual} object (see {.fn create_individual})."
+      )
+    }
+  }
   if (!is.null(species)) {
     validate_species(species)
   }
@@ -111,22 +166,26 @@ create_population <- function(
   settings <- list(NumberOfIndividuals = number_of_individuals)
   settings$ProportionOfFemales <- proportion_of_females
 
-  individual_data <- list()
-  if (!is.null(individual_name)) {
-    individual_data$Name <- individual_name
-  }
-  origin_data <- list()
-  if (!is.null(species)) {
-    origin_data$Species <- species
-  }
-  if (!is.null(source_population)) {
-    origin_data$Population <- source_population
-  }
-  if (length(origin_data) > 0) {
-    individual_data$OriginData <- origin_data
-  }
-  if (length(individual_data) > 0) {
-    settings$Individual <- individual_data
+  if (!is.null(individual)) {
+    settings$Individual <- individual$data
+  } else {
+    individual_data <- list()
+    if (!is.null(individual_name)) {
+      individual_data$Name <- individual_name
+    }
+    origin_data <- list()
+    if (!is.null(species)) {
+      origin_data$Species <- species
+    }
+    if (!is.null(source_population)) {
+      origin_data$Population <- source_population
+    }
+    if (length(origin_data) > 0) {
+      individual_data$OriginData <- origin_data
+    }
+    if (length(individual_data) > 0) {
+      settings$Individual <- individual_data
+    }
   }
 
   age <- range_to_list(age_range, "age_range")
@@ -145,10 +204,50 @@ create_population <- function(
   if (!is.null(bmi)) {
     settings$BMI <- bmi
   }
+  gestational_age <- range_to_list(
+    gestational_age_range,
+    "gestational_age_range"
+  )
+  if (!is.null(gestational_age)) {
+    settings$GestationalAge <- gestational_age
+  }
+
+  if (!is.null(disease_state_parameters)) {
+    if (!is.list(disease_state_parameters)) {
+      cli::cli_abort(
+        "{.arg disease_state_parameters} must be a named list of {.cls Range} objects."
+      )
+    }
+    param_names <- names(disease_state_parameters)
+    if (
+      is.null(param_names) ||
+        any(is.na(param_names)) ||
+        any(param_names == "")
+    ) {
+      cli::cli_abort(c(
+        "{.arg disease_state_parameters} must be a named list of {.cls Range} objects.",
+        "i" = "Each entry must be `name = range(...)`."
+      ))
+    }
+    settings$DiseaseStateParameters <- unname(mapply(
+      function(nm, value) {
+        disease_state_param_to_list(
+          nm,
+          range_to_list(value, "disease_state_parameters")
+        )
+      },
+      param_names,
+      disease_state_parameters,
+      SIMPLIFY = FALSE
+    ))
+  }
 
   data <- list(Name = name, Settings = settings)
   if (!is.null(seed)) {
     data$Seed <- seed
+  }
+  if (!is.null(description)) {
+    data$Description <- description
   }
   if (!is.null(advanced_parameters)) {
     if (!is.list(advanced_parameters)) {

--- a/man/Population.Rd
+++ b/man/Population.Rd
@@ -15,9 +15,17 @@ and display a summary of its information.
 
     \item{\code{name}}{The name of the population}
 
+    \item{\code{description}}{A free-text description of the population}
+
     \item{\code{source_population}}{The source population name (read-only)}
 
     \item{\code{individual_name}}{The individual name (read-only)}
+
+    \item{\code{individual}}{The base individual the population samples from,
+returned as an \link{Individual} object built from the base individual
+in the population settings, or \code{NULL} when none is set
+(read-only). Author it at construction time via the \code{individual}
+argument of \code{\link[=create_population]{create_population()}}.}
 
     \item{\code{seed}}{The seed used for population generation}
 
@@ -33,7 +41,21 @@ and display a summary of its information.
 
     \item{\code{bmi_range}}{The BMI range for the population}
 
-    \item{\code{egfr_range}}{The eGFR range for the population (if available)}
+    \item{\code{gestational_age_range}}{The gestational age range used for
+population generation}
+
+    \item{\code{egfr_range}}{The eGFR range for the population (if available).
+Convenience over the case-insensitive \code{"egfr"} entry of
+\code{disease_state_parameters}; writes persist into the population
+settings so they survive export.}
+
+    \item{\code{disease_state_parameters}}{The population disease-state
+parameters as a named list mapping each parameter name to a
+\link{Range} object. Assign a named list of \code{Range} objects to
+replace them, or \code{NULL} to clear them. This population-level
+name-to-\code{Range} map is distinct from the base individual's own
+\code{disease_state_parameters}, which carries scalar parameter
+values.}
 
     \item{\code{advanced_parameters}}{Advanced parameters for the population}
   }

--- a/man/create_population.Rd
+++ b/man/create_population.Rd
@@ -16,7 +16,11 @@ create_population(
   height_range = NULL,
   bmi_range = NULL,
   seed = NULL,
-  advanced_parameters = NULL
+  advanced_parameters = NULL,
+  description = NULL,
+  gestational_age_range = NULL,
+  disease_state_parameters = NULL,
+  individual = NULL
 )
 }
 \arguments{
@@ -51,6 +55,27 @@ individual (for example \code{"European_ICRP_2002"}).}
 \item{advanced_parameters}{List of \link{AdvancedParameter} objects or raw
 advanced-parameter lists that override default variability
 distributions.}
+
+\item{description}{Character. Free-text description of the population.}
+
+\item{gestational_age_range}{A \link{Range} object describing the
+gestational age range used for population generation (see \code{\link[=range]{range()}}).
+This is the population-settings range, distinct from the base
+individual's own scalar gestational age.}
+
+\item{disease_state_parameters}{A named list mapping a disease-state
+parameter name to a \link{Range} object, for example
+\code{list(eGFR = range(60, 120, "ml/min/1.73m²"))}. Each entry
+becomes one range in the population settings. This population-level
+name-to-\code{Range} map is distinct from the base individual's own
+\code{disease_state_parameters}, which carries scalar parameter values.}
+
+\item{individual}{An \link{Individual} object (typically from
+\code{\link[=create_individual]{create_individual()}}) used as the base individual the population
+samples from. When supplied, it fully configures the base individual
+(gender, origin data, calculation methods, seed, description,
+parameters) and cannot be combined with \code{individual_name}, \code{species},
+or \code{source_population}.}
 }
 \value{
 A \link{Population} object.
@@ -80,5 +105,22 @@ pop <- create_population(
   source_population = "European_ICRP_2002",
   age_range = range(20, 60, "year(s)"),
   weight_range = range(50, 90, "kg")
+)
+
+# Compose a base individual and set a disease-state parameter
+pop <- create_population(
+  name = "Renal Impairment",
+  number_of_individuals = 25,
+  individual = create_individual(
+    name = "Base",
+    species = "Human",
+    population = "European_ICRP_2002",
+    gender = "MALE"
+  ),
+  gestational_age_range = range(37, 42, "week(s)"),
+  disease_state_parameters = list(
+    eGFR = range(60, 120, "ml/min/1.73m²")
+  ),
+  description = "Adults with reduced renal function"
 )
 }

--- a/tests/testthat/_snaps/create_population.md
+++ b/tests/testthat/_snaps/create_population.md
@@ -66,6 +66,74 @@
       ! `age_range` must be a <Range> object
       i Use `range()` to create one.
 
+---
+
+    Code
+      create_population(name = "P", number_of_individuals = 10,
+        gestational_age_range = list(min = 25, max = 42, unit = "week(s)"))
+    Condition
+      Error in `range_to_list()`:
+      ! `gestational_age_range` must be a <Range> object
+      i Use `range()` to create one.
+
+# create_population validates disease state parameters
+
+    Code
+      create_population(name = "P", number_of_individuals = 10,
+        disease_state_parameters = "not a list")
+    Condition
+      Error in `create_population()`:
+      ! `disease_state_parameters` must be a named list of <Range> objects.
+
+---
+
+    Code
+      create_population(name = "P", number_of_individuals = 10,
+        disease_state_parameters = list(eGFR = list(min = 60, max = 120)))
+    Condition
+      Error in `range_to_list()`:
+      ! `disease_state_parameters` must be a <Range> object
+      i Use `range()` to create one.
+
+---
+
+    Code
+      create_population(name = "P", number_of_individuals = 10,
+        disease_state_parameters = list(range(60, 120, "ml/min/1.73m²")))
+    Condition
+      Error in `create_population()`:
+      ! `disease_state_parameters` must be a named list of <Range> objects.
+      i Each entry must be `name = range(...)`.
+
+# create_population rejects individual combined with legacy args
+
+    Code
+      create_population(name = "P", number_of_individuals = 10, individual = ind,
+        species = "Human")
+    Condition
+      Error in `create_population()`:
+      ! `individual` cannot be combined with `individual_name`, `species`, or `source_population`.
+      i Fold those fields into the `create_individual()` call instead.
+
+---
+
+    Code
+      create_population(name = "P", number_of_individuals = 10, individual = ind,
+        individual_name = "Base", source_population = "European_ICRP_2002")
+    Condition
+      Error in `create_population()`:
+      ! `individual` cannot be combined with `individual_name`, `species`, or `source_population`.
+      i Fold those fields into the `create_individual()` call instead.
+
+# create_population rejects a non-Individual individual
+
+    Code
+      create_population(name = "P", number_of_individuals = 10, individual = list(
+        Name = "Base"))
+    Condition
+      Error in `create_population()`:
+      ! `individual` must be an <Individual> object (see `create_individual()`).
+
 # create_population rejects NA name
 
     Code

--- a/tests/testthat/_snaps/population.md
+++ b/tests/testthat/_snaps/population.md
@@ -31,6 +31,31 @@
       Proportion of females: 0%
       Age range: 30 - 40 year(s)
 
+---
+
+    Code
+      print(rich_population)
+    Output
+      
+      -- Population: Rich Population --
+      
+      Description: A richly configured cohort
+      Individual name: Base
+      Source Population: European_ICRP_2002
+      Number of individuals: 50
+      Proportion of females: 50%
+      Gestational age range: 37 - 42 week(s)
+      eGFR range: 60 - 120 ml/min/1.73m²
+
+# Population disease_state_parameters rejects non-Range values
+
+    Code
+      population$disease_state_parameters <- list(eGFR = list(min = 60))
+    Condition
+      Error:
+      ! disease_state_parameters must be a named list of Range objects
+      i Use `range()` to create one.
+
 # AdvancedParameter class works correctly
 
     Code

--- a/tests/testthat/test-create_population.R
+++ b/tests/testthat/test-create_population.R
@@ -69,6 +69,131 @@ test_that("create_population validates required arguments", {
       age_range = list(min = 20, max = 60, unit = "year(s)")
     )
   )
+  expect_snapshot(
+    error = TRUE,
+    create_population(
+      name = "P",
+      number_of_individuals = 10,
+      gestational_age_range = list(min = 25, max = 42, unit = "week(s)")
+    )
+  )
+})
+
+test_that("create_population stores description", {
+  pop <- create_population(
+    name = "P",
+    number_of_individuals = 10,
+    description = "A cohort"
+  )
+  expect_equal(pop$data$Description, "A cohort")
+
+  pop_no_desc <- create_population(name = "P", number_of_individuals = 10)
+  expect_null(pop_no_desc$data$Description)
+})
+
+test_that("create_population stores gestational age range", {
+  pop <- create_population(
+    name = "P",
+    number_of_individuals = 10,
+    gestational_age_range = range(25, 42, "week(s)")
+  )
+  expect_equal(
+    pop$data$Settings$GestationalAge,
+    list(Min = 25, Max = 42, Unit = "week(s)")
+  )
+  expect_s3_class(pop$gestational_age_range, "Range")
+  expect_equal(pop$gestational_age_range$min, 25)
+})
+
+test_that("create_population stores disease state parameters", {
+  pop <- create_population(
+    name = "P",
+    number_of_individuals = 10,
+    disease_state_parameters = list(eGFR = range(60, 120, "ml/min/1.73m²"))
+  )
+  expect_length(pop$data$Settings$DiseaseStateParameters, 1)
+  expect_equal(
+    pop$data$Settings$DiseaseStateParameters[[1]],
+    list(Name = "eGFR", Min = 60, Max = 120, Unit = "ml/min/1.73m²")
+  )
+})
+
+test_that("create_population validates disease state parameters", {
+  expect_snapshot(
+    error = TRUE,
+    create_population(
+      name = "P",
+      number_of_individuals = 10,
+      disease_state_parameters = "not a list"
+    )
+  )
+  expect_snapshot(
+    error = TRUE,
+    create_population(
+      name = "P",
+      number_of_individuals = 10,
+      disease_state_parameters = list(eGFR = list(min = 60, max = 120))
+    )
+  )
+  expect_snapshot(
+    error = TRUE,
+    create_population(
+      name = "P",
+      number_of_individuals = 10,
+      disease_state_parameters = list(range(60, 120, "ml/min/1.73m²"))
+    )
+  )
+})
+
+test_that("create_population carries a composed base individual verbatim", {
+  ind <- create_individual(
+    name = "Base",
+    species = "Human",
+    population = "European_ICRP_2002",
+    gender = "MALE",
+    age = 40,
+    seed = 99
+  )
+  pop <- create_population(
+    name = "P",
+    number_of_individuals = 10,
+    individual = ind
+  )
+  expect_equal(pop$data$Settings$Individual, ind$data)
+})
+
+test_that("create_population rejects individual combined with legacy args", {
+  ind <- create_individual(species = "Human")
+  expect_snapshot(
+    error = TRUE,
+    create_population(
+      name = "P",
+      number_of_individuals = 10,
+      individual = ind,
+      species = "Human"
+    )
+  )
+  expect_snapshot(
+    error = TRUE,
+    create_population(
+      name = "P",
+      number_of_individuals = 10,
+      individual = ind,
+      individual_name = "Base",
+      source_population = "European_ICRP_2002"
+    )
+  )
+})
+
+test_that("create_population rejects a non-Individual individual", {
+  expect_snapshot(
+    error = TRUE,
+    create_population(
+      name = "P",
+      number_of_individuals = 10,
+      individual = list(Name = "Base")
+    )
+  )
 })
 
 test_that("create_population rejects NA name", {

--- a/tests/testthat/test-population.R
+++ b/tests/testthat/test-population.R
@@ -83,6 +83,43 @@ minimal_population_data <- list(
   )
 )
 
+# Create rich population data exercising the fields added in #118
+rich_population_data <- list(
+  Name = "Rich Population",
+  Description = "A richly configured cohort",
+  Settings = list(
+    NumberOfIndividuals = 50,
+    ProportionOfFemales = 50,
+    GestationalAge = list(
+      Min = 37.0,
+      Max = 42.0,
+      Unit = "week(s)"
+    ),
+    Individual = list(
+      Name = "Base",
+      OriginData = list(
+        Species = "Human",
+        Population = "European_ICRP_2002",
+        Gender = "MALE"
+      )
+    ),
+    DiseaseStateParameters = list(
+      list(
+        Name = "eGFR",
+        Min = 60.0,
+        Max = 120.0,
+        Unit = "ml/min/1.73m²"
+      ),
+      list(
+        Name = "Tumour Volume",
+        Min = 1.0,
+        Max = 5.0,
+        Unit = "l"
+      )
+    )
+  )
+)
+
 # ---- Population class logic tests ----
 test_that("Population class initialization works", {
   # Create test population objects
@@ -170,10 +207,12 @@ test_that("Population print method returns formatted output", {
   # Create test population objects
   complete_population <- Population$new(complete_population_data)
   minimal_population <- Population$new(minimal_population_data)
+  rich_population <- Population$new(rich_population_data)
 
   # Test print outputs
   expect_snapshot(print(complete_population))
   expect_snapshot(print(minimal_population))
+  expect_snapshot(print(rich_population))
 })
 
 test_that("Population fields can be modified through active bindings", {
@@ -304,6 +343,137 @@ test_that("Read-only fields cannot be modified", {
     ),
     "individual_name is read-only"
   )
+  expect_error(
+    tryCatch(
+      {
+        population$individual <- create_individual(species = "Human")
+        NULL
+      },
+      error = function(e) stop(e$message)
+    ),
+    "individual is read-only"
+  )
+})
+
+test_that("Population description binding reads and writes", {
+  population <- Population$new(rich_population_data)
+  expect_equal(population$description, "A richly configured cohort")
+
+  population$description <- "Updated description"
+  expect_equal(population$description, "Updated description")
+  expect_equal(population$data$Description, "Updated description")
+})
+
+test_that("Population gestational_age_range binding reads and writes", {
+  population <- Population$new(rich_population_data)
+
+  expect_s3_class(population$gestational_age_range, "Range")
+  expect_equal(population$gestational_age_range$min, 37)
+  expect_equal(population$gestational_age_range$max, 42)
+  expect_equal(population$gestational_age_range$unit, "week(s)")
+
+  population$gestational_age_range <- Range$new(38, 41, "week(s)")
+  expect_equal(
+    population$data$Settings$GestationalAge,
+    list(Min = 38, Max = 41, Unit = "week(s)")
+  )
+
+  population$gestational_age_range <- NULL
+  expect_null(population$gestational_age_range)
+  expect_null(population$data$Settings$GestationalAge)
+})
+
+test_that("Population disease_state_parameters getter and setter work", {
+  population <- Population$new(rich_population_data)
+
+  params <- population$disease_state_parameters
+  expect_named(params, c("eGFR", "Tumour Volume"))
+  expect_s3_class(params$eGFR, "Range")
+  expect_equal(params$eGFR$min, 60)
+  expect_equal(params[["Tumour Volume"]]$max, 5)
+
+  population$disease_state_parameters <- list(
+    eGFR = range(30, 90, "ml/min/1.73m²")
+  )
+  expect_length(population$data$Settings$DiseaseStateParameters, 1)
+  expect_equal(
+    population$data$Settings$DiseaseStateParameters[[1]],
+    list(Name = "eGFR", Min = 30, Max = 90, Unit = "ml/min/1.73m²")
+  )
+  expect_equal(population$egfr_range$min, 30)
+
+  population$disease_state_parameters <- NULL
+  expect_null(population$data$Settings$DiseaseStateParameters)
+  expect_null(population$egfr_range)
+})
+
+test_that("Population disease_state_parameters rejects non-Range values", {
+  population <- Population$new(rich_population_data)
+  expect_snapshot(
+    error = TRUE,
+    population$disease_state_parameters <- list(eGFR = list(min = 60))
+  )
+})
+
+test_that("egfr_range setter persists into population data", {
+  population <- Population$new(rich_population_data)
+
+  population$egfr_range <- range(30, 90, "ml/min/1.73m²")
+  egfr_entry <- Filter(
+    function(p) tolower(p$Name) == "egfr",
+    population$data$Settings$DiseaseStateParameters
+  )
+  expect_length(egfr_entry, 1)
+  expect_equal(egfr_entry[[1]]$Min, 30)
+  expect_equal(egfr_entry[[1]]$Max, 90)
+  expect_equal(
+    population$disease_state_parameters[["eGFR"]]$min,
+    30
+  )
+  # Other entries are preserved
+  expect_length(population$data$Settings$DiseaseStateParameters, 2)
+
+  population$egfr_range <- NULL
+  expect_null(population$egfr_range)
+  egfr_after <- Filter(
+    function(p) tolower(p$Name) == "egfr",
+    population$data$Settings$DiseaseStateParameters
+  )
+  expect_length(egfr_after, 0)
+  # The non-eGFR entry survives removal of eGFR
+  expect_length(population$data$Settings$DiseaseStateParameters, 1)
+})
+
+test_that("egfr_range set to NULL drops empty DiseaseStateParameters key", {
+  population <- Population$new(complete_population_data)
+  population$egfr_range <- NULL
+  expect_null(population$data$Settings$DiseaseStateParameters)
+})
+
+test_that("Population individual binding is read-only and derived", {
+  population <- Population$new(rich_population_data)
+  expect_s3_class(population$individual, "Individual")
+  expect_equal(population$individual$name, "Base")
+
+  minimal_population <- Population$new(minimal_population_data)
+  expect_null(minimal_population$individual)
+})
+
+test_that("Population round-trips all fields added in #118", {
+  pop <- create_population(
+    name = "Round Trip",
+    number_of_individuals = 25,
+    individual = create_individual(
+      name = "Base",
+      species = "Human",
+      population = "European_ICRP_2002",
+      gender = "MALE"
+    ),
+    gestational_age_range = range(37, 42, "week(s)"),
+    disease_state_parameters = list(eGFR = range(60, 120, "ml/min/1.73m²")),
+    description = "Adults with reduced renal function"
+  )
+  expect_equal(Population$new(pop$data)$data, pop$data)
 })
 
 test_that("Population to_df method returns correct data frames", {


### PR DESCRIPTION
Closes #118

Configure the base individual and the previously unreachable population settings through `create_population()`, and fix the `egfr_range` round-trip. Before this change, a population's `Description`, gestational-age `Range`, and disease-state parameters had no factory argument, the base individual could carry at most a name, species, and source population, and an eGFR range set on a `Population` object was silently dropped on export. This closes those gaps by composing an `Individual` for the base individual and by persisting the disease-state parameters into the population settings.

## Factory (`create_population()`)

`create_population()` gains four arguments appended after `advanced_parameters`, each defaulting to `NULL` so existing calls produce byte-identical data:

- `description` writes to the top-level `data$Description`.
- `gestational_age_range` accepts a `Range` and, reusing the existing local `range_to_list()` helper, writes `Settings$GestationalAge` as `list(Min, Max, Unit)`. This is the population-generation range, distinct from the base individual's own scalar gestational age.
- `disease_state_parameters` accepts a named list mapping each parameter name to a `Range`, for example `list(eGFR = range(60, 120, "ml/min/1.73m²"))`. Each entry serializes to one `list(Name, Min, Max, Unit)` element (in that order) under `Settings$DiseaseStateParameters`, stored as an unnamed (JSON-array) list. A non-list value, an unnamed entry, or a non-`Range` value errors with a message pointing at `range()`.
- `individual` accepts an `Individual` (typically from `create_individual()`), whose `$data` becomes `Settings$Individual` verbatim, fully configuring the base individual (gender, origin data, calculation methods, seed, description, parameters). Combining `individual` with any of `individual_name`, `species`, or `source_population` errors naming both sides; passing a non-`Individual` errors. When `individual` is absent, the legacy three arguments build the minimal base individual exactly as before.

## Population class (`Population`)

- New read/write `description` binding over `data$Description`.
- New `gestational_age_range` binding mirroring the four existing range bindings exactly (seeded in `initialize` from `Settings$GestationalAge`, persisting into `data`, same empty-vs-set error wording, `NULL` clears both cache and key).
- New `disease_state_parameters` binding: the getter reconstructs a named list of `Range` objects from `Settings$DiseaseStateParameters`; the setter accepts a named list of `Range` objects and writes the unnamed-array shape, or `NULL` to clear the key. Writes refresh the eGFR convenience cache.
- New read-only `individual` binding returning an `Individual` built from `Settings$Individual`, or `NULL` when none is set. It is derived on read; `Population$data` stays verbatim (no write-back is wired, per the spec's deferred decision).
- The `egfr_range` setter is fixed to persist into `Settings$DiseaseStateParameters`: it upserts or removes the case-insensitive `"egfr"` entry (preserving other entries and their order, and dropping the key when it becomes empty), so an eGFR range set on a `Population` now survives export. `egfr_range` and `disease_state_parameters[["eGFR"]]` stay consistent in both directions.
- `print()` gains conditional `Description` and `Gestational age range` lines; the existing eGFR line is preserved.

The disease-state serialization and the eGFR upsert/remove/lookup logic live in three shared file-local helpers so the factory and both bindings use one convention. The tibble layer (`to_df()`) is intentionally left unchanged, keeping the 22-column characteristics schema and avoiding the empty-vs-populated column-parity hazard; the new fields are reachable through the R6 bindings.

## Tests

- `test-create_population.R`: description set and omitted; gestational-age range into `Settings$GestationalAge`; disease-state parameters happy path plus non-list, non-`Range`, and unnamed-entry error paths; verbatim base-individual carry; conflict error when `individual` is combined with each legacy argument; non-`Individual` error; a `gestational_age_range` list case added to the existing validation snapshot block.
- `test-population.R`: a new `rich_population_data` fixture (leaving the verbatim-asserted `complete_population_data` untouched); read/write tests for `description`, `gestational_age_range`, and `disease_state_parameters` (including `NULL`-clear); the eGFR round-trip fix in both directions with sibling-entry preservation and empty-key drop; read-only `individual` (Individual for a populated base individual, `NULL` for a minimal one, assignment errors); full round-trip equality for a population authored with all new fields; an extended print snapshot for the rich population.
- The `get_populations_dfs` 22-column snapshots are untouched, confirming `to_df()` was not widened.

## Documentation and housekeeping

- roxygen added for all new arguments and fields (80-char wrap), with an `@examples` block composing `create_individual()` and a disease-state parameter using the exact `ml/min/1.73m²` unit; docs regenerated with `devtools::document()`; `pkgdown::check_pkgdown()` reports no problems.
- `DESCRIPTION` version bumped from `1.0.0` to `1.0.0.9000`.
- `NEWS.md` gains a `# osp.snapshots 1.0.0.9000` section with three bullets: the `create_population()` additions, the new `Population` bindings, and the `egfr_range` persistence fix.

## Verification

- `testthat::test_file('tests/testthat/test-create_population.R')`: pass (new snapshots reviewed and recorded).
- `testthat::test_file('tests/testthat/test-population.R')`: pass (new snapshots reviewed and recorded).
- `devtools::test(filter = 'create_population|population|Individual')`: pass.
- `devtools::test()`: 0 failures (one pre-existing unrelated template warning in `test-snapshot.R`).
- `devtools::document()` and `pkgdown::check_pkgdown()`: clean.
- `devtools::check()`: 0 errors, 0 warnings, 1 note (the `.git` worktree artifact, unrelated to the change).

## Example

```r
library(osp.snapshots)

# Compose a base individual and set the new population fields in one call
pop <- create_population(
  name = "Renal Impairment",
  number_of_individuals = 25,
  individual = create_individual(
    name = "Base",
    species = "Human",
    population = "European_ICRP_2002",
    gender = "MALE"
  ),
  gestational_age_range = range(37, 42, "week(s)"),
  disease_state_parameters = list(
    eGFR = range(60, 120, "ml/min/1.73m²")
  ),
  description = "Adults with reduced renal function"
)

pop$description
#> [1] "Adults with reduced renal function"

pop$data$Settings$GestationalAge
#> $Min
#> [1] 37
#> $Max
#> [1] 42
#> $Unit
#> [1] "week(s)"

pop$disease_state_parameters[["eGFR"]]
#> 60 - 120 ml/min/1.73m²

# The composed base individual is carried verbatim
identical(pop$data$Settings$Individual, pop$individual$data)
#> [1] TRUE

# eGFR set on the object now survives export
pop$egfr_range <- range(30, 90, "ml/min/1.73m²")
pop$data$Settings$DiseaseStateParameters[[1]]
#> $Name
#> [1] "eGFR"
#> $Min
#> [1] 30
#> $Max
#> [1] 90
#> $Unit
#> [1] "ml/min/1.73m²"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Populations can now include a free-text description, gestational age range, and disease-state ranges.
  * You can also provide a fully configured base individual when creating a population.
  * Population eGFR settings now persist correctly when exported.

* **Documentation**
  * Updated usage, arguments, and examples to cover the new population options and validation rules.

* **Tests**
  * Expanded coverage for new input validation, population printing, and round-trip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->