### PR TITLE
Validate application_type in create_protocol()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # osp.snapshots 1.0.0.9000
 
 - `create_population()` gains `description`, `gestational_age_range`, `disease_state_parameters`, and `individual` arguments, the last composing a base individual from `create_individual()` to fully configure the population's base individual (#118).
+- `create_protocol()` now validates `application_type` against the canonical PK-Sim application types and errors early on an invalid value, matching `create_schema_item()` (#121).
 - `Population` objects gain read/write `description`, `gestational_age_range`, and `disease_state_parameters` bindings and a read-only `individual` binding exposing the base individual (#118).
 - `Population$egfr_range` now persists into the population settings, so an eGFR range set on a population survives export (#118).
 

--- a/R/create_protocol.R
+++ b/R/create_protocol.R
@@ -12,8 +12,11 @@
 #'
 #' @param name Character. Name of the protocol (required).
 #' @param application_type Character. Application type for a Simple
-#'   Protocol (for example `"Oral"`, `"IntravenousBolus"`, or
-#'   `"IntravenousInfusion"`). Mutually exclusive with `schemas`.
+#'   Protocol. Optional; when supplied it must be one of the canonical
+#'   PK-Sim application types: `"Oral"`, `"IntravenousBolus"`,
+#'   `"IntravenousInfusion"`, `"Intramuscular"`, `"Subcutaneous"`,
+#'   `"Dermal"`, `"Rectal"`, `"Inhalation"`, or `"Intraperitoneal"`.
+#'   Mutually exclusive with `schemas`.
 #' @param dosing_interval Character. Dosing interval identifier for a
 #'   Simple Protocol (for example `"Single"`, `"DI_12_12"`,
 #'   `"DI_8_8_8"`, or `"DI_24"`).
@@ -115,6 +118,16 @@ create_protocol <- function(
   if (!is.null(schemas)) {
     data$Schemas <- to_raw_r6_or_list(schemas, "Schema", "schemas")
   } else {
+    if (
+      !is.null(application_type) &&
+        !application_type %in% schema_item_application_types()
+    ) {
+      cli::cli_abort(c(
+        "{.arg application_type} must be one of the canonical PK-Sim application types.",
+        "x" = "Got {.val {application_type}}.",
+        "i" = "Valid values: {.val {schema_item_application_types()}}."
+      ))
+    }
     if (!is.null(application_type)) {
       data$ApplicationType <- application_type
     }

--- a/man/create_protocol.Rd
+++ b/man/create_protocol.Rd
@@ -19,8 +19,11 @@ create_protocol(
 \item{name}{Character. Name of the protocol (required).}
 
 \item{application_type}{Character. Application type for a Simple
-Protocol (for example \code{"Oral"}, \code{"IntravenousBolus"}, or
-\code{"IntravenousInfusion"}). Mutually exclusive with \code{schemas}.}
+Protocol. Optional; when supplied it must be one of the canonical
+PK-Sim application types: \code{"Oral"}, \code{"IntravenousBolus"},
+\code{"IntravenousInfusion"}, \code{"Intramuscular"}, \code{"Subcutaneous"},
+\code{"Dermal"}, \code{"Rectal"}, \code{"Inhalation"}, or \code{"Intraperitoneal"}.
+Mutually exclusive with \code{schemas}.}
 
 \item{dosing_interval}{Character. Dosing interval identifier for a
 Simple Protocol (for example \code{"Single"}, \code{"DI_12_12"},

--- a/tests/testthat/_snaps/create_protocol.md
+++ b/tests/testthat/_snaps/create_protocol.md
@@ -43,3 +43,13 @@
       Error in `create_protocol()`:
       ! `parameters` must be a list
 
+---
+
+    Code
+      create_protocol(name = "P", application_type = "NotARealType")
+    Condition
+      Error in `create_protocol()`:
+      ! `application_type` must be one of the canonical PK-Sim application types.
+      x Got "NotARealType".
+      i Valid values: "Oral", "IntravenousBolus", "IntravenousInfusion", "Intramuscular", "Subcutaneous", "Dermal", "Rectal", "Inhalation", and "Intraperitoneal".
+

--- a/tests/testthat/test-create_protocol.R
+++ b/tests/testthat/test-create_protocol.R
@@ -204,4 +204,22 @@ test_that("create_protocol validates required arguments", {
     error = TRUE,
     create_protocol(name = "P", parameters = "not a list")
   )
+  expect_snapshot(
+    error = TRUE,
+    create_protocol(name = "P", application_type = "NotARealType")
+  )
+})
+
+test_that("create_protocol accepts a valid application_type and omits the check when NULL", {
+  valid <- create_protocol(name = "P", application_type = "Oral")
+  expect_s3_class(valid, "Protocol")
+  expect_equal(valid$application_type, "Oral")
+
+  no_type <- create_protocol(name = "P")
+  expect_s3_class(no_type, "Protocol")
+  expect_null(no_type$application_type)
+
+  null_type <- create_protocol(name = "P", application_type = NULL)
+  expect_s3_class(null_type, "Protocol")
+  expect_null(null_type$application_type)
 })


### PR DESCRIPTION
Closes #121

Make `create_protocol()` enum-validate its `application_type` argument the same way `create_schema_item()` already does, so both entry points that accept a PK-Sim application type fail early and identically on an invalid value. Previously `create_protocol(application_type = ...)` wrote the string straight into the raw data unchecked, so a typo'd or otherwise invalid application type passed the R factory and only surfaced later inside PK-Sim. The change is additive and non-breaking: any call that omits `application_type`, passes `NULL`, passes one of the nine canonical values, or builds an Advanced Protocol via `schemas` keeps working exactly as before.

## Validation behaviour

The new membership check lives inside the `else` (Simple Protocol) branch of `create_protocol()`, immediately before the existing `data$ApplicationType <- application_type` passthrough. Its guard is `!is.null(application_type) && !application_type %in% schema_item_application_types()`, so it is conditional on a non-`NULL` value (the argument stays optional) and is only reached on the Simple Protocol path. On failure it calls `cli::cli_abort()` with the identical three-element vector shape `create_schema_item()` uses (the canonical-types message, an `"x"` line reporting the offending value, and an `"i"` line listing the valid values), all sourced from `schema_item_application_types()`. Placing the check inside the `else` branch guarantees it never runs for an Advanced Protocol and never masks the existing `schemas` mutual-exclusivity error: when both `schemas` and `application_type` are supplied, the mutual-exclusivity abort still fires first. No new hard-coded copy of the nine application types is introduced; the runtime check reads the single source of truth `PKSIM_APPLICATION_TYPES` through `schema_item_application_types()`.

## Documentation

The `@param application_type` roxygen in `R/create_protocol.R` now states that a supplied value must be one of the canonical PK-Sim application types and lists all nine, mirroring `create_schema_item()`'s wording while keeping the Simple Protocol framing and the `Mutually exclusive with` `schemas` note specific to `create_protocol()`. This enumeration is illustrative only; the runtime check remains the single source of truth. The package was re-documented, updating `man/create_protocol.Rd` with no `NAMESPACE` drift.

## Tests

`tests/testthat/test-create_protocol.R` gains an `expect_snapshot(error = TRUE, ...)` case for an invalid `application_type` inside the existing required-arguments block, so the full error text is reviewable in `tests/testthat/_snaps/create_protocol.md` and confirmed to match `create_schema_item()`'s message except for the header. The pre-existing mutual-exclusivity expectation in that block is unchanged, pinning that the new check does not mask it. A small positive block pins the additive nature: a valid value (`"Oral"`) succeeds, and both an omitted and an explicit `NULL` `application_type` produce a valid `Protocol` whose `application_type` binding returns `NULL` when unset. The targeted file passes and the broader `create_protocol|create_schema` run stays green with no shared-helper regression.

## NEWS

A single-line bullet was added under the `# osp.snapshots 1.0.0.9000` development heading, inserted in alphabetical-by-function position (after the `create_population()` bullet, before the `Population` bullet), referencing (#121).

## Example

The impact is a thrown error on invalid input. Before, an invalid application type was accepted silently:

```r
create_protocol(name = "P", application_type = "NotARealType")
#> <Protocol> (invalid type written through unchecked)
```

After, the call aborts early with an actionable message:

```r
create_protocol(name = "P", application_type = "NotARealType")
#> Error in `create_protocol()`:
#> ! `application_type` must be one of the canonical PK-Sim application types.
#> x Got "NotARealType".
#> i Valid values: "Oral", "IntravenousBolus", "IntravenousInfusion",
#>   "Intramuscular", "Subcutaneous", "Dermal", "Rectal", "Inhalation", and
#>   "Intraperitoneal".
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `application_type` is now checked against the supported PK-Sim types and invalid values fail immediately with a clear error.
  * Valid `application_type` values continue to work, and leaving it blank still produces a protocol without that setting.

* **Documentation**
  * Updated the protocol creation docs to better explain the allowed `application_type` values and its restriction with `schemas`.

* **Tests**
  * Added coverage for valid, missing, and invalid `application_type` inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->