### PR TITLE
Document why create_event() requires name

### DIFF
--- a/.claude/snapshot-spec.md
+++ b/.claude/snapshot-spec.md
@@ -192,6 +192,8 @@ Created via `IEventFactory.Create(templateName)`.
 | `Template` | `string` | Yes | Event template name passed to the factory. Determines which event type is created. |
 | `Parameters` | [Parameter](#parameter)[] | No | Mapped onto the event's parameters. |
 
+> Although the schema marks `Name` as optional, the `create_event()` factory in this package intentionally requires it, because events are added, referenced, and removed by name in a name-keyed collection (#122).
+
 ---
 
 ## ObserverSet

--- a/R/create_event.R
+++ b/R/create_event.R
@@ -9,7 +9,11 @@
 #' emptying, or organ removal). PK-Sim creates events by cloning a named
 #' template and overriding parameters, so a template name is required.
 #'
-#' @param name Character. Name of the event (required).
+#' @param name Character. Name of the event (required). This package
+#'   requires a name because events are added, referenced, and removed by
+#'   name, so an unnamed event cannot be used. This is intentionally
+#'   stricter than the PK-Sim snapshot specification, which marks the
+#'   event name as optional.
 #' @param template Character. Event template name passed to the PK-Sim
 #'   factory (required). Determines which event type is created.
 #' @param parameters List of [Parameter] objects (created with

--- a/man/create_event.Rd
+++ b/man/create_event.Rd
@@ -7,7 +7,11 @@
 create_event(name, template, parameters = NULL)
 }
 \arguments{
-\item{name}{Character. Name of the event (required).}
+\item{name}{Character. Name of the event (required). This package
+requires a name because events are added, referenced, and removed by
+name, so an unnamed event cannot be used. This is intentionally
+stricter than the PK-Sim snapshot specification, which marks the
+event name as optional.}
 
 \item{template}{Character. Event template name passed to the PK-Sim
 factory (required). Determines which event type is created.}


### PR DESCRIPTION
Closes #122

Records the outcome of the Event building block audit for `create_event()`. The audit confirmed the factory already exposes every Event property (`Name`, `Template`, `Parameters`), so there is no missing capability to add. The one open question, whether `create_event()` should relax its mandatory `name` argument to match the snapshot schema (which marks Event `Name` as optional), is resolved as a deliberate design decision: keep `name` required. A nameless Event cannot be added to, referenced by, or removed from a snapshot, because the package keys events by name throughout. This is a documentation-only change with no behavioural difference.

## Factory documentation

Expanded the `@param name` roxygen entry of `create_event()` (`R/create_event.R`) to explain that this package requires a name because events are added, referenced, and removed by name, so an unnamed event cannot be used, and that this is intentionally stricter than the PK-Sim snapshot specification, which marks the event name as optional. The function body, all other parameters, the description, examples, and return value are unchanged. The regenerated `man/create_event.Rd` carries the same wording.

## Schema reference

Added a short note beneath the Event section table in `.claude/snapshot-spec.md` recording that, although the schema marks `Name` as optional, `create_event()` intentionally requires it, because events live in a name-keyed collection. The note references `#122` and leaves the table rows and every other section untouched.

## Verification

The existing `create_event()` tests pass unchanged (13 passed, 0 failed) with no snapshot updates, confirming behaviour is identical. `pkgdown::check_pkgdown()` reports no missing topics. `devtools::document()` regenerated only `man/create_event.Rd`; `git status` confirms the only modified files are `R/create_event.R`, `.claude/snapshot-spec.md`, and `man/create_event.Rd`, with no diff to `NAMESPACE`, `NEWS.md`, or any out-of-scope source file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that event names are required when creating events, with guidance on how events are identified and managed.
  * Updated user-facing documentation to note that this requirement is stricter than the snapshot specification, helping avoid confusion when setting up events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->