### PR TITLE
create_expression_profile() can set per-organ relative expression and disease state

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # osp.snapshots (development version)
 
 - `create_descriptor_condition()` builds a container criterion (`Tag`, and an open-string `Type` such as `"InContainer"` or `"MatchTag"`) for an observer's container criteria (#119).
+- `create_expression_profile()` gains `expression` and `disease` arguments to set per-organ relative expression (a data frame of container rows, or a raw list) and a disease state, and `ExpressionProfile` gains read/write `expression` and `disease` bindings so a loaded profile can be read and mutated (#116).
 - `create_formula_reference()` builds a formula reference (`Alias`, `Path`, optional `Dimension`) for an observer's formula (#119).
 - `create_molecule_list()` builds an observer's molecule list from `for_all`, `include`, and `exclude` (#119).
 - `create_observer()` builds a single observer for an observer set, with arguments for name, type, dimension, formula, formula references, container criteria, and molecule list (#119).

--- a/R/ExpressionProfile.R
+++ b/R/ExpressionProfile.R
@@ -168,6 +168,30 @@ ExpressionProfile <- R6::R6Class(
       self$data$Parameters
     },
 
+    #' @field expression The per-organ relative expression of the profile.
+    #'   Reading returns the raw `ExpressionContainer[]` list (or `NULL`
+    #'   when unset). Assigning accepts the same shapes as the
+    #'   `expression` argument of [create_expression_profile()] (a data
+    #'   frame of container rows, a raw list, or `NULL`/empty to clear it).
+    expression = function(value) {
+      if (missing(value)) {
+        return(self$data$Expression)
+      }
+      self$data$Expression <- build_expression_containers(value)
+    },
+
+    #' @field disease The disease state of the profile. Reading returns the
+    #'   raw `DiseaseState` list (or `NULL` when unset). Assigning accepts
+    #'   the same shape as the `disease` argument of
+    #'   [create_expression_profile()] (a named list with `name` and
+    #'   optional `parameters`, or `NULL` to clear it).
+    disease = function(value) {
+      if (missing(value)) {
+        return(self$data$Disease)
+      }
+      self$data$Disease <- build_disease_state(value)
+    },
+
     #' @field id The unique identifier of the expression profile
     id = function() {
       category_value <- if (is.null(self$category)) "NA" else self$category

--- a/R/create_expression_profile.R
+++ b/R/create_expression_profile.R
@@ -25,6 +25,22 @@
 #' @param parameters List of [Parameter] objects (created with
 #'   [create_parameter()]) or raw parameter lists describing relative
 #'   expression and other per-organ values.
+#' @param expression Per-organ relative expression, written to the
+#'   snapshot's `Expression` array. Supply a data frame (or tibble), one
+#'   row per organ/compartment, with a required `name` column
+#'   (organ/container name, for example `"Liver"`) and the optional
+#'   columns `value` (relative expression), `compartment` (for example
+#'   `"Intracellular"`), and `transport_direction` (for transporter
+#'   profiles). Missing (`NA`) or absent optional cells emit no key, so a
+#'   row with only `name` and `value` produces a container with just those
+#'   two fields. Row order is preserved and duplicate names are kept.
+#'   Alternatively supply a raw list of container lists (each a named list
+#'   with any of `Name`, `Value`, `CompartmentName`, `TransportDirection`)
+#'   to pass through verbatim. `NULL` or an empty input writes nothing.
+#' @param disease Disease state, written to the snapshot's `Disease`
+#'   object. Supply a named list with `name` (required, the
+#'   `DiseaseState` name) and an optional `parameters` list of [Parameter]
+#'   objects or raw parameter lists. `NULL` writes nothing.
 #' @param description Character. Free-text description of the profile.
 #'
 #' @return An [ExpressionProfile] object.
@@ -48,6 +64,18 @@
 #'   transport_type = "Efflux",
 #'   ontogeny = "P-gp"
 #' )
+#'
+#' # Create an enzyme profile with per-organ relative expression
+#' profile <- create_expression_profile(
+#'   molecule = "CYP3A4",
+#'   species = "Human",
+#'   category = "Healthy",
+#'   type = "Enzyme",
+#'   expression = data.frame(
+#'     name = c("Liver", "Kidney"),
+#'     value = c(1, 0.5)
+#'   )
+#' )
 create_expression_profile <- function(
   molecule,
   species,
@@ -57,6 +85,8 @@ create_expression_profile <- function(
   transport_type = NULL,
   ontogeny = NULL,
   parameters = NULL,
+  expression = NULL,
+  disease = NULL,
   description = NULL
 ) {
   check_required_string(molecule, "molecule")
@@ -94,6 +124,16 @@ create_expression_profile <- function(
       cli::cli_abort("{.arg parameters} must be a list")
     }
     data$Parameters <- to_raw_parameters(parameters, "Path")
+  }
+
+  containers <- build_expression_containers(expression)
+  if (!is.null(containers)) {
+    data$Expression <- containers
+  }
+
+  disease_state <- build_disease_state(disease)
+  if (!is.null(disease_state)) {
+    data$Disease <- disease_state
   }
 
   ExpressionProfile$new(data)

--- a/R/utils-create.R
+++ b/R/utils-create.R
@@ -120,3 +120,112 @@ to_raw_parameters <- function(parameters, name_key) {
     raw
   })
 }
+
+# Internal: map the `expression` argument of `create_expression_profile()`
+# (and the `ExpressionProfile$expression` setter) to a raw
+# `ExpressionContainer[]` list, or `NULL` when the input is empty. The
+# result is an *unnamed* list so jsonlite serialises it as a JSON array
+# (see the `empty_named_list` note above on array vs object shape).
+#
+# Accepts:
+#   - a data frame / tibble, one row per ExpressionContainer, with a
+#     required `name` column and optional `value`, `compartment`, and
+#     `transport_direction` columns. Only non-missing cells become keys
+#     (`Name`, `Value`, `CompartmentName`, `TransportDirection`), so a row
+#     that omits `value` produces a container without a `Value` key. Row
+#     order is preserved and duplicate names are kept as separate entries.
+#   - a bare list of raw container lists (escape hatch), returned unnamed
+#     and verbatim.
+# The data-frame branch is tested before the bare-list branch because a
+# data frame is also `is.list()` and `is.object()` TRUE.
+build_expression_containers <- function(expression, call = parent.frame()) {
+  if (is.null(expression)) {
+    return(NULL)
+  }
+  if (is.data.frame(expression)) {
+    if (nrow(expression) == 0) {
+      return(NULL)
+    }
+    if (!("name" %in% names(expression))) {
+      cli::cli_abort(
+        "{.arg expression} data frame must have a {.field name} column",
+        call = call
+      )
+    }
+    names_col <- expression[["name"]]
+    if (any(is.na(names_col) | !nzchar(as.character(names_col)))) {
+      cli::cli_abort(
+        "Every {.field name} in {.arg expression} must be a non-empty string",
+        call = call
+      )
+    }
+    containers <- lapply(seq_len(nrow(expression)), function(i) {
+      container <- list(Name = as.character(names_col[[i]]))
+      if (
+        "value" %in% names(expression) && !is.na(expression[["value"]][[i]])
+      ) {
+        container$Value <- as.numeric(expression[["value"]][[i]])
+      }
+      if (
+        "compartment" %in%
+          names(expression) &&
+          !is.na(expression[["compartment"]][[i]])
+      ) {
+        container$CompartmentName <- as.character(
+          expression[["compartment"]][[i]]
+        )
+      }
+      if (
+        "transport_direction" %in%
+          names(expression) &&
+          !is.na(expression[["transport_direction"]][[i]])
+      ) {
+        container$TransportDirection <- as.character(
+          expression[["transport_direction"]][[i]]
+        )
+      }
+      container
+    })
+    return(unname(containers))
+  }
+  if (is.list(expression) && !is.object(expression)) {
+    if (length(expression) == 0) {
+      return(NULL)
+    }
+    return(unname(expression))
+  }
+  cli::cli_abort(
+    "{.arg expression} must be a data frame or a list",
+    call = call
+  )
+}
+
+# Internal: map the `disease` argument of `create_expression_profile()`
+# (and the `ExpressionProfile$disease` setter) to a raw `DiseaseState`
+# named list (a JSON object), or `NULL` when unset. `parameters` is keyed
+# on `Name` via `to_raw_parameters()`, matching the `DiseaseState`
+# schema; the `Parameters` key is omitted when no parameters are given.
+build_disease_state <- function(disease, call = parent.frame()) {
+  if (is.null(disease)) {
+    return(NULL)
+  }
+  name <- disease$name
+  if (
+    !is.list(disease) ||
+      is.null(name) ||
+      !is.character(name) ||
+      length(name) != 1 ||
+      is.na(name) ||
+      !nzchar(name)
+  ) {
+    cli::cli_abort(
+      "{.arg disease} must be a named list with a non-empty {.field name}",
+      call = call
+    )
+  }
+  result <- list(Name = name)
+  if (!is.null(disease$parameters)) {
+    result$Parameters <- to_raw_parameters(disease$parameters, "Name")
+  }
+  result
+}

--- a/R/utils-create.R
+++ b/R/utils-create.R
@@ -209,9 +209,10 @@ build_disease_state <- function(disease, call = parent.frame()) {
   if (is.null(disease)) {
     return(NULL)
   }
-  name <- disease$name
+  name <- if (is.list(disease)) disease$name else NULL
   if (
     !is.list(disease) ||
+      is.object(disease) ||
       is.null(name) ||
       !is.character(name) ||
       length(name) != 1 ||

--- a/man/ExpressionProfile.Rd
+++ b/man/ExpressionProfile.Rd
@@ -34,6 +34,18 @@ and display a summary of its information.
 
     \item{\code{parameters}}{The parameters of the expression profile}
 
+    \item{\code{expression}}{The per-organ relative expression of the profile.
+Reading returns the raw \code{ExpressionContainer[]} list (or \code{NULL}
+when unset). Assigning accepts the same shapes as the
+\code{expression} argument of \code{\link[=create_expression_profile]{create_expression_profile()}} (a data
+frame of container rows, a raw list, or \code{NULL}/empty to clear it).}
+
+    \item{\code{disease}}{The disease state of the profile. Reading returns the
+raw \code{DiseaseState} list (or \code{NULL} when unset). Assigning accepts
+the same shape as the \code{disease} argument of
+\code{\link[=create_expression_profile]{create_expression_profile()}} (a named list with \code{name} and
+optional \code{parameters}, or \code{NULL} to clear it).}
+
     \item{\code{id}}{The unique identifier of the expression profile}
   }
   \if{html}{\out{</div>}}

--- a/man/create_expression_profile.Rd
+++ b/man/create_expression_profile.Rd
@@ -13,6 +13,8 @@ create_expression_profile(
   transport_type = NULL,
   ontogeny = NULL,
   parameters = NULL,
+  expression = NULL,
+  disease = NULL,
   description = NULL
 )
 }
@@ -40,6 +42,24 @@ list. If a string is supplied it is wrapped as
 \item{parameters}{List of \link{Parameter} objects (created with
 \code{\link[=create_parameter]{create_parameter()}}) or raw parameter lists describing relative
 expression and other per-organ values.}
+
+\item{expression}{Per-organ relative expression, written to the
+snapshot's \code{Expression} array. Supply a data frame (or tibble), one
+row per organ/compartment, with a required \code{name} column
+(organ/container name, for example \code{"Liver"}) and the optional
+columns \code{value} (relative expression), \code{compartment} (for example
+\code{"Intracellular"}), and \code{transport_direction} (for transporter
+profiles). Missing (\code{NA}) or absent optional cells emit no key, so a
+row with only \code{name} and \code{value} produces a container with just those
+two fields. Row order is preserved and duplicate names are kept.
+Alternatively supply a raw list of container lists (each a named list
+with any of \code{Name}, \code{Value}, \code{CompartmentName}, \code{TransportDirection})
+to pass through verbatim. \code{NULL} or an empty input writes nothing.}
+
+\item{disease}{Disease state, written to the snapshot's \code{Disease}
+object. Supply a named list with \code{name} (required, the
+\code{DiseaseState} name) and an optional \code{parameters} list of \link{Parameter}
+objects or raw parameter lists. \code{NULL} writes nothing.}
 
 \item{description}{Character. Free-text description of the profile.}
 }
@@ -72,5 +92,17 @@ profile <- create_expression_profile(
   type = "Transporter",
   transport_type = "Efflux",
   ontogeny = "P-gp"
+)
+
+# Create an enzyme profile with per-organ relative expression
+profile <- create_expression_profile(
+  molecule = "CYP3A4",
+  species = "Human",
+  category = "Healthy",
+  type = "Enzyme",
+  expression = data.frame(
+    name = c("Liver", "Kidney"),
+    value = c(1, 0.5)
+  )
 )
 }

--- a/tests/testthat/_snaps/create_expression_profile.md
+++ b/tests/testthat/_snaps/create_expression_profile.md
@@ -1,3 +1,40 @@
+# create_expression_profile validates expression and disease
+
+    Code
+      create_expression_profile(molecule = "CYP3A4", species = "Human", category = "Healthy",
+        type = "Enzyme", expression = data.frame(value = 1))
+    Condition
+      Error in `create_expression_profile()`:
+      ! `expression` data frame must have a name column
+
+---
+
+    Code
+      create_expression_profile(molecule = "CYP3A4", species = "Human", category = "Healthy",
+        type = "Enzyme", expression = data.frame(name = c("Liver", NA), value = c(1,
+          2)))
+    Condition
+      Error in `create_expression_profile()`:
+      ! Every name in `expression` must be a non-empty string
+
+---
+
+    Code
+      create_expression_profile(molecule = "CYP3A4", species = "Human", category = "Healthy",
+        type = "Enzyme", expression = "Liver")
+    Condition
+      Error in `create_expression_profile()`:
+      ! `expression` must be a data frame or a list
+
+---
+
+    Code
+      create_expression_profile(molecule = "CYP3A4", species = "Human", category = "Healthy",
+        type = "Enzyme", disease = list(parameters = list()))
+    Condition
+      Error in `create_expression_profile()`:
+      ! `disease` must be a named list with a non-empty name
+
 # create_expression_profile validates required arguments
 
     Code

--- a/tests/testthat/_snaps/create_expression_profile.md
+++ b/tests/testthat/_snaps/create_expression_profile.md
@@ -35,6 +35,15 @@
       Error in `create_expression_profile()`:
       ! `disease` must be a named list with a non-empty name
 
+---
+
+    Code
+      create_expression_profile(molecule = "CYP3A4", species = "Human", category = "Healthy",
+        type = "Enzyme", disease = "CKD")
+    Condition
+      Error in `create_expression_profile()`:
+      ! `disease` must be a named list with a non-empty name
+
 # create_expression_profile validates required arguments
 
     Code

--- a/tests/testthat/_snaps/utils-create.md
+++ b/tests/testthat/_snaps/utils-create.md
@@ -30,3 +30,35 @@
       Error:
       ! Every entry of `items` must be a <SchemaItem> or a raw list
 
+# build_expression_containers validates its input
+
+    Code
+      build_expression_containers("Liver")
+    Condition
+      Error:
+      ! `expression` must be a data frame or a list
+
+---
+
+    Code
+      build_expression_containers(data.frame(value = 1))
+    Condition
+      Error:
+      ! `expression` data frame must have a name column
+
+---
+
+    Code
+      build_expression_containers(data.frame(name = c("Liver", NA), value = c(1, 2)))
+    Condition
+      Error:
+      ! Every name in `expression` must be a non-empty string
+
+# build_disease_state validates a non-empty name
+
+    Code
+      build_disease_state(list(parameters = list()))
+    Condition
+      Error:
+      ! `disease` must be a named list with a non-empty name
+

--- a/tests/testthat/_snaps/utils-create.md
+++ b/tests/testthat/_snaps/utils-create.md
@@ -62,3 +62,11 @@
       Error:
       ! `disease` must be a named list with a non-empty name
 
+# build_disease_state rejects a non-list value
+
+    Code
+      build_disease_state("CKD")
+    Condition
+      Error:
+      ! `disease` must be a named list with a non-empty name
+

--- a/tests/testthat/test-create_expression_profile.R
+++ b/tests/testthat/test-create_expression_profile.R
@@ -205,6 +205,16 @@ test_that("create_expression_profile validates expression and disease", {
       disease = list(parameters = list())
     )
   )
+  expect_snapshot(
+    error = TRUE,
+    create_expression_profile(
+      molecule = "CYP3A4",
+      species = "Human",
+      category = "Healthy",
+      type = "Enzyme",
+      disease = "CKD"
+    )
+  )
 })
 
 test_that("create_expression_profile validates required arguments", {

--- a/tests/testthat/test-create_expression_profile.R
+++ b/tests/testthat/test-create_expression_profile.R
@@ -50,6 +50,163 @@ test_that("create_expression_profile accepts Parameter objects", {
   expect_equal(profile$parameters[[1]]$Value, 4.32)
 })
 
+test_that("create_expression_profile sets per-organ relative expression", {
+  profile <- create_expression_profile(
+    molecule = "CYP3A4",
+    species = "Human",
+    category = "Healthy",
+    type = "Enzyme",
+    expression = data.frame(name = c("Liver", "Kidney"), value = c(1, 0.5))
+  )
+
+  expect_equal(
+    profile$data$Expression,
+    list(
+      list(Name = "Liver", Value = 1),
+      list(Name = "Kidney", Value = 0.5)
+    )
+  )
+})
+
+test_that("create_expression_profile maps transporter expression rows", {
+  profile <- create_expression_profile(
+    molecule = "P-gp",
+    species = "Human",
+    category = "Healthy",
+    type = "Transporter",
+    expression = data.frame(
+      name = "Liver",
+      compartment = "Intracellular",
+      transport_direction = "EffluxIntracellularToInterstitial"
+    )
+  )
+
+  expect_equal(
+    profile$data$Expression,
+    list(list(
+      Name = "Liver",
+      CompartmentName = "Intracellular",
+      TransportDirection = "EffluxIntracellularToInterstitial"
+    ))
+  )
+})
+
+test_that("create_expression_profile preserves order and duplicate names", {
+  profile <- create_expression_profile(
+    molecule = "P-gp",
+    species = "Human",
+    category = "Healthy",
+    type = "Transporter",
+    expression = data.frame(
+      name = c("Kidney", "Kidney"),
+      transport_direction = c("Efflux", "Influx")
+    )
+  )
+
+  expect_length(profile$data$Expression, 2)
+  expect_equal(profile$data$Expression[[1]]$TransportDirection, "Efflux")
+  expect_equal(profile$data$Expression[[2]]$TransportDirection, "Influx")
+})
+
+test_that("create_expression_profile accepts a raw expression list", {
+  profile <- create_expression_profile(
+    molecule = "CYP3A4",
+    species = "Human",
+    category = "Healthy",
+    type = "Enzyme",
+    expression = list(list(Name = "Liver", Value = 1))
+  )
+
+  expect_null(names(profile$data$Expression))
+  expect_equal(profile$data$Expression, list(list(Name = "Liver", Value = 1)))
+})
+
+test_that("create_expression_profile sets a disease state with parameters", {
+  profile <- create_expression_profile(
+    molecule = "CYP3A4",
+    species = "Human",
+    category = "Healthy",
+    type = "Enzyme",
+    disease = list(
+      name = "CKD",
+      parameters = list(create_parameter(name = "p", value = 1))
+    )
+  )
+
+  expect_equal(
+    profile$data$Disease,
+    list(Name = "CKD", Parameters = list(list(Name = "p", Value = 1)))
+  )
+})
+
+test_that("create_expression_profile sets a disease state without parameters", {
+  profile <- create_expression_profile(
+    molecule = "CYP3A4",
+    species = "Human",
+    category = "Healthy",
+    type = "Enzyme",
+    disease = list(name = "CKD")
+  )
+
+  expect_equal(profile$data$Disease, list(Name = "CKD"))
+  expect_null(profile$data$Disease$Parameters)
+})
+
+test_that("create_expression_profile omits Expression and Disease by default", {
+  profile <- create_expression_profile(
+    molecule = "CYP3A4",
+    species = "Human",
+    category = "Healthy",
+    type = "Enzyme"
+  )
+
+  expect_null(profile$data$Expression)
+  expect_null(profile$data$Disease)
+})
+
+test_that("create_expression_profile validates expression and disease", {
+  expect_snapshot(
+    error = TRUE,
+    create_expression_profile(
+      molecule = "CYP3A4",
+      species = "Human",
+      category = "Healthy",
+      type = "Enzyme",
+      expression = data.frame(value = 1)
+    )
+  )
+  expect_snapshot(
+    error = TRUE,
+    create_expression_profile(
+      molecule = "CYP3A4",
+      species = "Human",
+      category = "Healthy",
+      type = "Enzyme",
+      expression = data.frame(name = c("Liver", NA), value = c(1, 2))
+    )
+  )
+  expect_snapshot(
+    error = TRUE,
+    create_expression_profile(
+      molecule = "CYP3A4",
+      species = "Human",
+      category = "Healthy",
+      type = "Enzyme",
+      expression = "Liver"
+    )
+  )
+  expect_snapshot(
+    error = TRUE,
+    create_expression_profile(
+      molecule = "CYP3A4",
+      species = "Human",
+      category = "Healthy",
+      type = "Enzyme",
+      disease = list(parameters = list())
+    )
+  )
+})
+
 test_that("create_expression_profile validates required arguments", {
   expect_snapshot(error = TRUE, create_expression_profile())
   expect_snapshot(

--- a/tests/testthat/test-expression-profile.R
+++ b/tests/testthat/test-expression-profile.R
@@ -172,6 +172,101 @@ test_that("to_df converts expression profile to tibble correctly", {
   expect_equal(nrow(result_no_cat$expression_profiles_parameters), 1)
 })
 
+test_that("ExpressionProfile$expression is a read/write binding", {
+  profile <- create_expression_profile(
+    molecule = "CYP3A4",
+    species = "Human",
+    category = "Healthy",
+    type = "Enzyme"
+  )
+  expect_null(profile$expression)
+
+  profile$expression <- data.frame(
+    name = c("Liver", "Kidney"),
+    value = c(1, 0.5)
+  )
+  expect_equal(
+    profile$expression,
+    list(list(Name = "Liver", Value = 1), list(Name = "Kidney", Value = 0.5))
+  )
+  expect_equal(profile$data$Expression, profile$expression)
+
+  profile$expression <- NULL
+  expect_null(profile$data$Expression)
+  expect_false("Expression" %in% names(profile$data))
+})
+
+test_that("ExpressionProfile$disease is a read/write binding", {
+  profile <- create_expression_profile(
+    molecule = "CYP3A4",
+    species = "Human",
+    category = "Healthy",
+    type = "Enzyme"
+  )
+  expect_null(profile$disease)
+
+  profile$disease <- list(name = "CKD")
+  expect_equal(profile$disease, list(Name = "CKD"))
+  expect_equal(profile$data$Disease, profile$disease)
+
+  profile$disease <- NULL
+  expect_null(profile$data$Disease)
+  expect_false("Disease" %in% names(profile$data))
+})
+
+test_that("ExpressionProfile reads raw Expression and Disease from load", {
+  snapshot_clone <- Snapshot$new(test_snapshot$data)
+  profile <- snapshot_clone$expression_profiles[["P-gp_Human_Healthy"]]
+
+  expect_equal(
+    profile$expression[[1]],
+    list(
+      Name = "Bone",
+      TransportDirection = "EffluxIntracellularToInterstitial",
+      CompartmentName = "Intracellular"
+    )
+  )
+
+  disease_profile <- ExpressionProfile$new(list(
+    Type = "Enzyme",
+    Species = "Human",
+    Molecule = "CYP3A4",
+    Category = "Healthy",
+    Disease = list(Name = "CKD")
+  ))
+  expect_equal(disease_profile$disease, list(Name = "CKD"))
+})
+
+test_that("expression and disease round-trip through export and reload", {
+  profile <- create_expression_profile(
+    molecule = "P-gp",
+    species = "Human",
+    category = "Healthy",
+    type = "Transporter",
+    expression = data.frame(
+      name = c("Liver", "Kidney", "Kidney"),
+      value = c(1, NA, NA),
+      compartment = c(NA, "Intracellular", "Interstitial"),
+      transport_direction = c(NA, "Efflux", "Influx")
+    ),
+    disease = list(
+      name = "CKD",
+      parameters = list(create_parameter(name = "p", value = 1))
+    )
+  )
+  snapshot <- empty_snapshot$clone()
+  snapshot$add_expression_profile(profile)
+
+  path <- withr::local_tempfile(fileext = ".json")
+  snapshot$export(path)
+
+  reloaded <- Snapshot$new(path)
+  reloaded_profile <- reloaded$expression_profiles[["P-gp_Human_Healthy"]]
+
+  expect_equal(reloaded_profile$expression, profile$expression)
+  expect_equal(reloaded_profile$disease, profile$disease)
+})
+
 test_that("expression_profile_collection from cloned test snapshot works", {
   # Clone the test snapshot to avoid mutating the shared object
   snapshot_clone <- Snapshot$new(test_snapshot$data)

--- a/tests/testthat/test-utils-create.R
+++ b/tests/testthat/test-utils-create.R
@@ -57,3 +57,109 @@ test_that("to_raw_r6_or_list returns an empty list for empty input", {
   result <- to_raw_r6_or_list(list(), "SchemaItem", "items")
   expect_equal(result, list())
 })
+
+test_that("build_expression_containers maps name and value rows", {
+  result <- build_expression_containers(
+    data.frame(name = c("Liver", "Kidney"), value = c(1, 0.5))
+  )
+  expect_null(names(result))
+  expect_equal(
+    result,
+    list(
+      list(Name = "Liver", Value = 1),
+      list(Name = "Kidney", Value = 0.5)
+    )
+  )
+})
+
+test_that("build_expression_containers maps transporter rows without value", {
+  result <- build_expression_containers(
+    data.frame(
+      name = "Liver",
+      compartment = "Intracellular",
+      transport_direction = "EffluxIntracellularToInterstitial"
+    )
+  )
+  expect_equal(
+    result,
+    list(list(
+      Name = "Liver",
+      CompartmentName = "Intracellular",
+      TransportDirection = "EffluxIntracellularToInterstitial"
+    ))
+  )
+})
+
+test_that("build_expression_containers preserves order and duplicate names", {
+  result <- build_expression_containers(
+    data.frame(
+      name = c("Kidney", "Kidney"),
+      transport_direction = c("Efflux", "Influx")
+    )
+  )
+  expect_length(result, 2)
+  expect_equal(result[[1]]$TransportDirection, "Efflux")
+  expect_equal(result[[2]]$TransportDirection, "Influx")
+})
+
+test_that("build_expression_containers omits Value for NA rows", {
+  result <- build_expression_containers(
+    data.frame(name = c("Liver", "Kidney"), value = c(1, NA))
+  )
+  expect_equal(result[[1]], list(Name = "Liver", Value = 1))
+  expect_equal(result[[2]], list(Name = "Kidney"))
+})
+
+test_that("build_expression_containers passes a raw list through unnamed", {
+  raw <- list(a = list(Name = "Liver", Value = 1))
+  result <- build_expression_containers(raw)
+  expect_null(names(result))
+  expect_equal(result, list(list(Name = "Liver", Value = 1)))
+})
+
+test_that("build_expression_containers treats empty input as unset", {
+  expect_null(build_expression_containers(NULL))
+  expect_null(build_expression_containers(data.frame(name = character(0))))
+  expect_null(build_expression_containers(list()))
+})
+
+test_that("build_expression_containers validates its input", {
+  expect_snapshot(error = TRUE, build_expression_containers("Liver"))
+  expect_snapshot(
+    error = TRUE,
+    build_expression_containers(data.frame(value = 1))
+  )
+  expect_snapshot(
+    error = TRUE,
+    build_expression_containers(
+      data.frame(name = c("Liver", NA), value = c(1, 2))
+    )
+  )
+})
+
+test_that("build_disease_state maps name and Name-keyed parameters", {
+  result <- build_disease_state(
+    list(
+      name = "CKD",
+      parameters = list(create_parameter(name = "p", value = 1))
+    )
+  )
+  expect_equal(
+    result,
+    list(Name = "CKD", Parameters = list(list(Name = "p", Value = 1)))
+  )
+})
+
+test_that("build_disease_state omits Parameters when none supplied", {
+  result <- build_disease_state(list(name = "CKD"))
+  expect_equal(result, list(Name = "CKD"))
+  expect_false("Parameters" %in% names(result))
+})
+
+test_that("build_disease_state treats NULL as unset", {
+  expect_null(build_disease_state(NULL))
+})
+
+test_that("build_disease_state validates a non-empty name", {
+  expect_snapshot(error = TRUE, build_disease_state(list(parameters = list())))
+})

--- a/tests/testthat/test-utils-create.R
+++ b/tests/testthat/test-utils-create.R
@@ -163,3 +163,7 @@ test_that("build_disease_state treats NULL as unset", {
 test_that("build_disease_state validates a non-empty name", {
   expect_snapshot(error = TRUE, build_disease_state(list(parameters = list())))
 })
+
+test_that("build_disease_state rejects a non-list value", {
+  expect_snapshot(error = TRUE, build_disease_state("CKD"))
+})


### PR DESCRIPTION
Closes #116

Make per-organ relative expression and disease state first-class, round-trip-faithful inputs on expression profiles. Until now `create_expression_profile()` could set only generic `parameters` (routed to `data$Parameters` and re-keyed on `Path`), so it could not author the snapshot's `Expression` array (an `ExpressionContainer[]` keyed on organ `Name`) or its `Disease` object, and `ExpressionProfile` exposed no binding to read or mutate them. This PR adds an `expression` argument and a `disease` argument to the factory, matching read/write bindings on the R6 class, and shared internal builders so the factory and the setters cannot diverge.

## Builders

Two internal helpers live in `R/utils-create.R`, next to the existing `to_raw_*` helpers and the `empty_named_list` note on array-vs-object serialization.

`build_expression_containers(expression, call = parent.frame())` maps the `expression` input to an unnamed list of named lists (a JSON array), or `NULL` when the input is empty. A data frame or tibble is handled first (a data frame is also `is.list()` and `is.object()` TRUE, so it must be tested before the bare-list branch): each row becomes one container, emitting only non-missing cells in the fixed key order `Name`, `Value`, `CompartmentName`, `TransportDirection`, so a row with only `name` and `value` yields exactly those two keys and a transporter row with no `value` yields no `Value` key. Row order is preserved and duplicate names are kept as separate entries. A bare list is the escape hatch, returned unnamed and verbatim. `NULL`, a zero-row data frame, and an empty list all map to `NULL`. A data frame lacking a `name` column, any missing or empty `name`, and an input that is neither a data frame nor a list each abort via `cli::cli_abort()`.

`build_disease_state(disease, call = parent.frame())` maps a named list `list(name=, parameters=)` to a named `DiseaseState` list (a JSON object), or `NULL` when unset. It requires a non-empty scalar character `name`, keys any `parameters` on `Name` via the existing `to_raw_parameters(..., "Name")`, and omits the `Parameters` key entirely when no parameters are supplied.

Both builders default `call` to `parent.frame()` so validation errors attribute to the caller (the factory frame), which keeps the recorded error snapshots reading `Error in create_expression_profile()`.

## Factory arguments

`create_expression_profile()` (`R/create_expression_profile.R`) gains `expression = NULL` and `disease = NULL`, placed after `parameters`. Each delegates to its builder and writes `data$Expression` / `data$Disease` only when the builder returns non-NULL, so a profile created without them is byte-for-byte identical to today (no empty keys emitted). Roxygen `@param` docs describe the data-frame columns (`name` required; `value`, `compartment`, `transport_direction` optional), the raw-list escape hatch, and the `disease` list shape, and a new `@examples` block shows an enzyme profile with a per-organ relative-expression data frame.

## Bindings

`ExpressionProfile` (`R/ExpressionProfile.R`) gains two read/write active bindings following the `Compound$processes` get/set shape but reading and writing the public `self$data` field directly (the class stores raw data in a public `data` field, not `private$.data`). Reading returns the raw `data$Expression` / `data$Disease` slice (or `NULL`); assigning routes through the same builders, and assigning `NULL` clears the slot (the key is removed from `data`). `@field` docs are added for both.

## Tests

- `tests/testthat/test-utils-create.R`: unit tests for both builders (name+value rows, transporter rows without `Value`, order and duplicate preservation, `NA` value omission, raw-list passthrough, empty-input-to-NULL, disease with and without parameters) plus `expect_snapshot(error = TRUE)` validation cases.
- `tests/testthat/test-create_expression_profile.R`: factory tests for each mapping (FR-1/FR-3/FR-4/FR-10), disease with and without parameters, the default no-key case, and validation errors via `expect_snapshot(error = TRUE)`.
- `tests/testthat/test-expression-profile.R`: read/write binding tests for `expression` and `disease` (including `NULL` clearing), an on-load read test using the fixture's real transporter-style `Expression` array on `P-gp_Human_Healthy` (plus a hand-built `Disease`), and the round-trip test that builds a profile with mixed enzyme-`Value` and transporter-direction rows plus a disease with a parameter, exports the wrapping snapshot to a temp JSON via `Snapshot$export()`, reloads it, and asserts the reloaded `$expression` / `$disease` equal what was set. This is the guard against the array-vs-object serialization regression.

## Documentation

`@param` and `@field` roxygen were regenerated with `devtools::document()`; only `man/create_expression_profile.Rd` and `man/ExpressionProfile.Rd` changed, and `NAMESPACE` is unchanged (no new topic). One development-version bullet was added to `NEWS.md`, alphabetical by function name (`create_expression_profile` sits between `create_descriptor_condition` and `create_formula_reference`), single line, citing (#116). `pkgdown::check_pkgdown()` reports no problems.

## Notes on scope

`air format .` reformatted two files I did not otherwise touch (`R/Snapshot.R`, `R/utils.R`, both pre-existing single-line `if (...) return()` style), so those unrelated reformats were reverted to keep the change focused on the four source files this issue targets.

## Verification

- `devtools::load_all()` clean.
- `air format .` run (only the intended `.R` files formatted; unrelated sweeps reverted).
- `NOT_CRAN=true devtools::test(filter = 'utils-create|create_expression_profile|expression-profile')`: 162 passing, 0 failures; new error snapshots recorded and reviewed.
- `devtools::document()`: only the two expected `.Rd` files changed.
- `pkgdown::check_pkgdown()`: no problems found.
- `NOT_CRAN=true devtools::test()`: full suite green, 2602 passing, 0 failures. The single WARN is a pre-existing `cli_warn` in `test-snapshot.R`, unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for capturing per-organ expression and disease state information when creating expression profiles.
  * Expression profiles can now be viewed and updated after loading, including clearing these fields when needed.

* **Bug Fixes**
  * Improved validation for expression and disease inputs to catch invalid shapes and missing required names.
  * Preserved input order and duplicate entries when saving expression data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->