### PR TITLE
Loosen create_formulation() type and parameter vocabulary

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 - `create_descriptor_condition()` builds a container criterion (`Tag`, and an open-string `Type` such as `"InContainer"` or `"MatchTag"`) for an observer's container criteria (#119).
 - `create_formula_reference()` builds a formula reference (`Alias`, `Path`, optional `Dimension`) for an observer's formula (#119).
+- `create_formulation()` accepts an arbitrary `FormulationType` string and a raw `parameters` form (a list of `create_parameter()` objects or `list(Name=, Value=, ...)` dicts), so you can author unknown formulation types and set arbitrary parameters by name, per-parameter `ValueOrigin`, and a custom `TableFormula` on any type; the curated alias form is unchanged and `Formulation$formulation_type` now accepts any non-empty string (#120).
 - `create_molecule_list()` builds an observer's molecule list from `for_all`, `include`, and `exclude` (#119).
 - `create_observer()` builds a single observer for an observer set, with arguments for name, type, dimension, formula, formula references, container criteria, and molecule list (#119).
 - `Observer` now exposes a lossless writable `container_criteria` field (preserving each criterion's `Type`), a writable `formula_references` field, and a writable `molecule_list` field, and validates `type` against `Amount`/`Container` on assignment (#119).

--- a/R/Formulation.R
+++ b/R/Formulation.R
@@ -361,12 +361,16 @@ Formulation <- R6::R6Class(
       if (missing(value)) {
         return(private$.data$FormulationType)
       }
-      # Validate formulation type
-      if (!(value %in% VALID_FORMULATION_TYPES)) {
-        cli::cli_abort(
-          "Invalid formulation type: {value}",
-          "Formulation type must be one of {VALID_FORMULATION_TYPES}"
-        )
+      # `FormulationType` is a free-form repository key (see snapshot-spec):
+      # accept any non-empty scalar string, rejecting only empty, `NA`,
+      # non-character, or non-scalar input.
+      if (
+        !is.character(value) ||
+          length(value) != 1 ||
+          is.na(value) ||
+          !nzchar(value)
+      ) {
+        cli::cli_abort("{.arg formulation_type} must be a non-empty string")
       }
       private$.data$FormulationType <- value
     },
@@ -444,17 +448,36 @@ Formulation <- R6::R6Class(
 #' Create a new formulation with the specified properties.
 #' All arguments are optional except for name and type.
 #'
-#' @param name Character. Name of the formulation
-#' @param type Character. Type of formulation, one of:
+#' @param name Character. Name of the formulation.
+#' @param type Character. Type of formulation. A curated human-readable alias
+#'   or a known raw `Formulation_*` key resolves to that key:
 #'   * "Dissolved" - Immediate release solution
 #'   * "Weibull" - Weibull tablet formulation
 #'   * "Lint80" - Lint80 tablet formulation
 #'   * "Particle" - Particle formulation
 #'   * "Table" - Custom release profile table
-#'   * "ZeroOrder" - Zero-order release formulation
-#'   * "FirstOrder" - First-order release formulation
-#' @param parameters List. A named list of parameters for the formulation. The valid parameters
-#'        depend on the formulation type. Invalid parameters will result in an error.
+#'   * "Zero Order" - Zero-order release formulation
+#'   * "First Order" - First-order release formulation
+#'
+#'   Any other non-empty string is accepted verbatim and written straight to
+#'   `FormulationType`, so a new or otherwise unknown PK-Sim template type can
+#'   be authored (mirroring how [create_event()] treats `template`). The
+#'   curated parameter vocabulary below only exists for the known types.
+#' @param parameters List. Accepts either of two mutually exclusive forms
+#'   (they are never mixed in one call):
+#'   * Curated form: a named list drawn from the per-type alias vocabulary of a
+#'     known `type` (documented in the sections below), with scalar/vector
+#'     values. Defaults, informational messages, alias-to-`Name` synthesis, and
+#'     the built-in `Table` shape apply. Invalid aliases error.
+#'   * Raw form: a list of [Parameter] objects (built with [create_parameter()])
+#'     and/or raw `list(Name=, Value=, ...)` dicts. Each entry is written to
+#'     `data$Parameters` with its `Name`, `Value`, `Unit`, `ValueOrigin`, and
+#'     `TableFormula` preserved verbatim, for any `type`. This is the form that
+#'     unlocks arbitrary real parameter names (including on `Dissolved`),
+#'     per-parameter `ValueOrigin`, and a custom `TableFormula` on any type.
+#'
+#'   Only the raw form is valid for an unknown `type` (there is no alias
+#'   vocabulary to interpret a curated-looking list against).
 #'
 #' @section Weibull formulation parameters:
 #' * dissolution_time - Time to achieve 50% dissolution (numeric, default: 240)
@@ -545,21 +568,82 @@ Formulation <- R6::R6Class(
 #'     suspension = TRUE
 #'   )
 #' )
+#'
+#' # Raw form: set an arbitrary parameter (with a ValueOrigin) on Dissolved
+#' raw_dissolved <- create_formulation(
+#'   name = "Suspension",
+#'   type = "Dissolved",
+#'   parameters = list(
+#'     create_parameter(
+#'       name = "Use as suspension",
+#'       value = 1,
+#'       source = "Lit",
+#'       description = "Reference XYZ"
+#'     )
+#'   )
+#' )
+#'
+#' # Raw form on an unknown type carrying a custom TableFormula
+#' custom_type <- create_formulation(
+#'   name = "Novel",
+#'   type = "Formulation_BrandNew",
+#'   parameters = list(
+#'     create_parameter(
+#'       name = "Fraction (dose)",
+#'       value = 0,
+#'       table_points = list(list(x = 0, y = 0), list(x = 60, y = 1)),
+#'       x_name = "Time",
+#'       y_name = "Fraction",
+#'       x_unit = "min",
+#'       x_dimension = "Time",
+#'       y_dimension = "Fraction"
+#'     )
+#'   )
+#' )
 create_formulation <- function(name, type, parameters = NULL) {
-  # Convert human-readable type to PK-Sim formulation type if needed
-  # Use the inverse mapping of FORMULATION_TYPE_MAP
+  check_required_string(name, "name")
+  check_required_string(type, "type")
+
+  # Resolve `type` in precedence order: a curated human alias or a known raw
+  # `Formulation_*` key maps to that key; any other non-empty string passes
+  # through verbatim (matching how `create_event()` treats `template`).
   inverse_map <- stats::setNames(
     names(FORMULATION_TYPE_MAP),
     FORMULATION_TYPE_MAP
   )
-  pk_sim_type <- inverse_map[[type]] %||% type
+  pk_sim_type <- if (type %in% names(inverse_map)) {
+    inverse_map[[type]]
+  } else {
+    type
+  }
+  known_type <- pk_sim_type %in% VALID_FORMULATION_TYPES
 
-  # Validate formulation type
-  if (!(pk_sim_type %in% VALID_FORMULATION_TYPES)) {
-    cli::cli_abort(
-      "Invalid formulation type: {type}",
-      "Formulation type must be one of {VALID_FORMULATION_TYPES}"
-    )
+  # A non-list `parameters` is invalid in either form.
+  if (!is.null(parameters) && !is.list(parameters)) {
+    cli::cli_abort("Parameters must be provided as a named list")
+  }
+
+  # The raw/passthrough form (a list of `Parameter` objects or raw dicts) is
+  # written straight to `data$Parameters` for any type, curated or unknown.
+  # This unlocks arbitrary `Name`s, per-parameter `ValueOrigin`, and custom
+  # `TableFormula` on any type, including `Dissolved` and unknown types.
+  if (is_raw_parameters_list(parameters)) {
+    data <- list(Name = name, FormulationType = pk_sim_type)
+    data$Parameters <- to_raw_parameters(parameters, "Name")
+    return(Formulation$new(data))
+  }
+
+  # From here on `parameters` is the curated alias form (or NULL/empty). The
+  # curated per-type alias vocabulary only exists for the known types.
+  if (!known_type) {
+    if (length(parameters) > 0) {
+      cli::cli_abort(c(
+        "There is no curated parameter vocabulary for the {.val {type}} formulation type.",
+        "i" = "Supply parameters for a custom type as a list of {.fn create_parameter} objects (or {.code list(Name=, Value=, ...)} dicts)."
+      ))
+    }
+    # Unknown type with no parameters: a bare formulation.
+    return(Formulation$new(list(Name = name, FormulationType = pk_sim_type)))
   }
 
   # Define valid parameters for each formulation type
@@ -602,10 +686,6 @@ create_formulation <- function(name, type, parameters = NULL) {
   )
 
   # Check if there are any invalid parameters for this formulation type
-  if (!is.null(parameters) && !is.list(parameters)) {
-    cli::cli_abort("Parameters must be provided as a named list")
-  }
-
   param_names <- names(parameters)
   if (length(param_names) > 0) {
     invalid_params <- param_names[
@@ -1073,6 +1153,25 @@ create_formulation <- function(name, type, parameters = NULL) {
 
   # Create and return the Formulation object
   Formulation$new(data)
+}
+
+# Internal: TRUE when `parameters` is the raw passthrough form (every entry
+# is a `Parameter` R6 object or a raw dict carrying a `Name`), as opposed to
+# the curated alias form (bare scalar/vector values keyed by alias names).
+# `NULL` and `list()` return FALSE (they fall to the curated branch, which
+# no-ops to an empty-parameter formulation).
+is_raw_parameters_list <- function(parameters) {
+  if (!is.list(parameters) || length(parameters) == 0) {
+    return(FALSE)
+  }
+  all(vapply(
+    parameters,
+    function(entry) {
+      inherits(entry, "Parameter") ||
+        (is.list(entry) && !is.null(entry$Name))
+    },
+    logical(1)
+  ))
 }
 
 #' Add a formulation to a snapshot

--- a/man/create_formulation.Rd
+++ b/man/create_formulation.Rd
@@ -7,21 +7,42 @@
 create_formulation(name, type, parameters = NULL)
 }
 \arguments{
-\item{name}{Character. Name of the formulation}
+\item{name}{Character. Name of the formulation.}
 
-\item{type}{Character. Type of formulation, one of:
+\item{type}{Character. Type of formulation. A curated human-readable alias
+or a known raw \verb{Formulation_*} key resolves to that key:
 \itemize{
 \item "Dissolved" - Immediate release solution
 \item "Weibull" - Weibull tablet formulation
 \item "Lint80" - Lint80 tablet formulation
 \item "Particle" - Particle formulation
 \item "Table" - Custom release profile table
-\item "ZeroOrder" - Zero-order release formulation
-\item "FirstOrder" - First-order release formulation
-}}
+\item "Zero Order" - Zero-order release formulation
+\item "First Order" - First-order release formulation
+}
 
-\item{parameters}{List. A named list of parameters for the formulation. The valid parameters
-depend on the formulation type. Invalid parameters will result in an error.}
+Any other non-empty string is accepted verbatim and written straight to
+\code{FormulationType}, so a new or otherwise unknown PK-Sim template type can
+be authored (mirroring how \code{\link[=create_event]{create_event()}} treats \code{template}). The
+curated parameter vocabulary below only exists for the known types.}
+
+\item{parameters}{List. Accepts either of two mutually exclusive forms
+(they are never mixed in one call):
+\itemize{
+\item Curated form: a named list drawn from the per-type alias vocabulary of a
+known \code{type} (documented in the sections below), with scalar/vector
+values. Defaults, informational messages, alias-to-\code{Name} synthesis, and
+the built-in \code{Table} shape apply. Invalid aliases error.
+\item Raw form: a list of \link{Parameter} objects (built with \code{\link[=create_parameter]{create_parameter()}})
+and/or raw \code{list(Name=, Value=, ...)} dicts. Each entry is written to
+\code{data$Parameters} with its \code{Name}, \code{Value}, \code{Unit}, \code{ValueOrigin}, and
+\code{TableFormula} preserved verbatim, for any \code{type}. This is the form that
+unlocks arbitrary real parameter names (including on \code{Dissolved}),
+per-parameter \code{ValueOrigin}, and a custom \code{TableFormula} on any type.
+}
+
+Only the raw form is valid for an unknown \code{type} (there is no alias
+vocabulary to interpret a curated-looking list against).}
 }
 \value{
 A Formulation object
@@ -140,6 +161,38 @@ custom <- create_formulation(
     tableX = c(0, 0.5, 1, 2, 4, 8),
     tableY = c(0, 0.1, 0.3, 0.6, 0.9, 1.0),
     suspension = TRUE
+  )
+)
+
+# Raw form: set an arbitrary parameter (with a ValueOrigin) on Dissolved
+raw_dissolved <- create_formulation(
+  name = "Suspension",
+  type = "Dissolved",
+  parameters = list(
+    create_parameter(
+      name = "Use as suspension",
+      value = 1,
+      source = "Lit",
+      description = "Reference XYZ"
+    )
+  )
+)
+
+# Raw form on an unknown type carrying a custom TableFormula
+custom_type <- create_formulation(
+  name = "Novel",
+  type = "Formulation_BrandNew",
+  parameters = list(
+    create_parameter(
+      name = "Fraction (dose)",
+      value = 0,
+      table_points = list(list(x = 0, y = 0), list(x = 60, y = 1)),
+      x_name = "Time",
+      y_name = "Fraction",
+      x_unit = "min",
+      x_dimension = "Time",
+      y_dimension = "Fraction"
+    )
   )
 )
 }

--- a/tests/testthat/_snaps/Formulation.md
+++ b/tests/testthat/_snaps/Formulation.md
@@ -87,6 +87,14 @@
       
       * New Parameter: 100 mg
 
+# Formulation validates formulation type
+
+    Code
+      test_formulation$formulation_type <- ""
+    Condition
+      Error:
+      ! `formulation_type` must be a non-empty string
+
 # formulation to_df method works correctly
 
     Code

--- a/tests/testthat/_snaps/create_formulation.md
+++ b/tests/testthat/_snaps/create_formulation.md
@@ -1,0 +1,294 @@
+# create_formulation preserves ValueOrigin from raw parameters
+
+    Code
+      form$parameters[["Dissolution shape"]]$value_origin
+    Output
+      $Source
+      [1] "Lit"
+      
+      $Description
+      [1] "ref"
+      
+
+# create_formulation preserves a custom TableFormula on any type
+
+    Code
+      from_points$parameters[[1]]$table_formula
+    Output
+      $Name
+      [1] "Fraction (dose)"
+      
+      $XName
+      [1] "Custom X"
+      
+      $YName
+      [1] "Custom Y"
+      
+      $XDimension
+      [1] "Time"
+      
+      $YDimension
+      [1] "Fraction"
+      
+      $UseDerivedValues
+      [1] TRUE
+      
+      $Points
+      $Points[[1]]
+      $Points[[1]]$X
+      [1] 0
+      
+      $Points[[1]]$Y
+      [1] 0
+      
+      $Points[[1]]$RestartSolver
+      [1] FALSE
+      
+      
+      $Points[[2]]
+      $Points[[2]]$X
+      [1] 60
+      
+      $Points[[2]]$Y
+      [1] 1
+      
+      $Points[[2]]$RestartSolver
+      [1] FALSE
+      
+      
+      
+      $XUnit
+      [1] "min"
+      
+
+---
+
+    Code
+      from_formula$parameters[[1]]$table_formula
+    Output
+      $Name
+      [1] "Fraction (dose)"
+      
+      $XName
+      [1] "Time"
+      
+      $YName
+      [1] "Fraction"
+      
+      $XDimension
+      [1] "Time"
+      
+      $YDimension
+      [1] "Fraction"
+      
+      $XUnit
+      [1] "min"
+      
+      $UseDerivedValues
+      [1] FALSE
+      
+      $Points
+      $Points[[1]]
+      $Points[[1]]$X
+      [1] 0
+      
+      $Points[[1]]$Y
+      [1] 0
+      
+      $Points[[1]]$RestartSolver
+      [1] FALSE
+      
+      
+      
+
+# create_formulation curated form still errors on out-of-vocabulary alias
+
+    Code
+      create_formulation(name = "X", type = "Weibull", parameters = list(not_a_param = 1))
+    Condition
+      Error in `create_formulation()`:
+      ! Invalid parameters for Weibull formulation: not_a_param
+      i Valid parameters are: dissolution_time, dissolution_time_unit, lag_time, lag_time_unit, dissolution_shape, and suspension
+
+# create_formulation rejects curated-looking parameters for an unknown type
+
+    Code
+      create_formulation(name = "X", type = "Formulation_BrandNew", parameters = list(
+        some_alias = 1))
+    Condition
+      Error in `create_formulation()`:
+      ! There is no curated parameter vocabulary for the "Formulation_BrandNew" formulation type.
+      i Supply parameters for a custom type as a list of `create_parameter()` objects (or `list(Name=, Value=, ...)` dicts).
+
+# create_formulation validates name and type
+
+    Code
+      create_formulation()
+    Condition
+      Error in `create_formulation()`:
+      ! `name` must be a non-empty string
+
+---
+
+    Code
+      create_formulation(name = "X")
+    Condition
+      Error in `create_formulation()`:
+      ! `type` must be a non-empty string
+
+---
+
+    Code
+      create_formulation(name = "", type = "Dissolved")
+    Condition
+      Error in `create_formulation()`:
+      ! `name` must be a non-empty string
+
+---
+
+    Code
+      create_formulation(name = "X", type = "Dissolved", parameters = "nope")
+    Condition
+      Error in `create_formulation()`:
+      ! Parameters must be provided as a named list
+
+# create_formulation curated Table shape is unchanged
+
+    Code
+      form <- create_formulation(name = "X", type = "Table", parameters = list(
+        tableX = c(0, 1), tableY = c(0, 1)))
+    Message
+      No suspension parameter provided, using default value of TRUE
+    Code
+      form$data$Parameters
+    Output
+      [[1]]
+      [[1]]$Name
+      [1] "Use as suspension"
+      
+      [[1]]$Value
+      [1] 1
+      
+      
+      [[2]]
+      [[2]]$Name
+      [1] "Fraction (dose)"
+      
+      [[2]]$Value
+      [1] 0
+      
+      [[2]]$TableFormula
+      [[2]]$TableFormula$Name
+      [1] "Fraction (dose)"
+      
+      [[2]]$TableFormula$XName
+      [1] "Time"
+      
+      [[2]]$TableFormula$XDimension
+      [1] "Time"
+      
+      [[2]]$TableFormula$XUnit
+      [1] "h"
+      
+      [[2]]$TableFormula$YName
+      [1] "Fraction (dose)"
+      
+      [[2]]$TableFormula$YDimension
+      [1] "Dimensionless"
+      
+      [[2]]$TableFormula$UseDerivedValues
+      [1] TRUE
+      
+      [[2]]$TableFormula$Points
+      [[2]]$TableFormula$Points[[1]]
+      [[2]]$TableFormula$Points[[1]]$X
+      [1] 0
+      
+      [[2]]$TableFormula$Points[[1]]$Y
+      [1] 0
+      
+      [[2]]$TableFormula$Points[[1]]$RestartSolver
+      [1] FALSE
+      
+      
+      [[2]]$TableFormula$Points[[2]]
+      [[2]]$TableFormula$Points[[2]]$X
+      [1] 1
+      
+      [[2]]$TableFormula$Points[[2]]$Y
+      [1] 1
+      
+      [[2]]$TableFormula$Points[[2]]$RestartSolver
+      [1] FALSE
+      
+      
+      
+      
+      
+
+# raw-form formulation round-trips through export
+
+    Code
+      reloaded_form$data$Parameters
+    Output
+      [[1]]
+      [[1]]$Name
+      [1] "Use as suspension"
+      
+      [[1]]$Value
+      [1] 1
+      
+      [[1]]$ValueOrigin
+      [[1]]$ValueOrigin$Source
+      [1] "Lit"
+      
+      [[1]]$ValueOrigin$Description
+      [1] "ref"
+      
+      
+      
+      [[2]]
+      [[2]]$Name
+      [1] "Fraction (dose)"
+      
+      [[2]]$Value
+      [1] 0
+      
+      [[2]]$TableFormula
+      [[2]]$TableFormula$Name
+      [1] "Fraction (dose)"
+      
+      [[2]]$TableFormula$XName
+      [1] "Time"
+      
+      [[2]]$TableFormula$YName
+      [1] "Fraction"
+      
+      [[2]]$TableFormula$XDimension
+      [1] "Time"
+      
+      [[2]]$TableFormula$YDimension
+      [1] "Fraction"
+      
+      [[2]]$TableFormula$XUnit
+      [1] "min"
+      
+      [[2]]$TableFormula$UseDerivedValues
+      [1] FALSE
+      
+      [[2]]$TableFormula$Points
+      [[2]]$TableFormula$Points[[1]]
+      [[2]]$TableFormula$Points[[1]]$X
+      [1] 0
+      
+      [[2]]$TableFormula$Points[[1]]$Y
+      [1] 0
+      
+      [[2]]$TableFormula$Points[[1]]$RestartSolver
+      [1] FALSE
+      
+      
+      
+      
+      
+

--- a/tests/testthat/test-Formulation.R
+++ b/tests/testthat/test-Formulation.R
@@ -199,10 +199,15 @@ test_that("Formulation validates formulation type", {
     expect_equal(test_formulation$formulation_type, type)
   }
 
-  # Test invalid formulation type
-  expect_error(
-    test_formulation$formulation_type <- "InvalidType",
-    "Invalid formulation type: InvalidType"
+  # An arbitrary non-empty string is now accepted verbatim (FormulationType is
+  # a free-form repository key).
+  expect_no_error(test_formulation$formulation_type <- "InvalidType")
+  expect_equal(test_formulation$formulation_type, "InvalidType")
+
+  # An empty string is still rejected.
+  expect_snapshot(
+    error = TRUE,
+    test_formulation$formulation_type <- ""
   )
 })
 

--- a/tests/testthat/test-create_formulation.R
+++ b/tests/testthat/test-create_formulation.R
@@ -1,0 +1,195 @@
+test_that("create_formulation accepts an unknown FormulationType verbatim", {
+  raw_key <- create_formulation(name = "X", type = "Formulation_BrandNew")
+  expect_equal(raw_key$formulation_type, "Formulation_BrandNew")
+
+  human_label <- create_formulation(
+    name = "X",
+    type = "Some Human Label Not In Map"
+  )
+  expect_equal(human_label$formulation_type, "Some Human Label Not In Map")
+})
+
+test_that("create_formulation maps curated aliases and known keys", {
+  aliased <- create_formulation(name = "X", type = "Weibull")
+  expect_equal(aliased$formulation_type, "Formulation_Tablet_Weibull")
+
+  keyed <- create_formulation(name = "X", type = "Formulation_Tablet_Weibull")
+  expect_equal(keyed$formulation_type, "Formulation_Tablet_Weibull")
+})
+
+test_that("create_formulation accepts raw parameters on Dissolved", {
+  form <- create_formulation(
+    name = "X",
+    type = "Dissolved",
+    parameters = list(create_parameter(name = "Use as suspension", value = 1))
+  )
+
+  expect_equal(form$formulation_type, "Formulation_Dissolved")
+  expect_equal(form$parameters[["Use as suspension"]]$value, 1)
+  expect_equal(form$data$Parameters[[1]]$Name, "Use as suspension")
+})
+
+test_that("create_formulation accepts a real snapshot Name on a known type", {
+  form <- create_formulation(
+    name = "X",
+    type = "Weibull",
+    parameters = list(create_parameter(name = "Dissolution shape", value = 0.7))
+  )
+
+  expect_equal(form$formulation_type, "Formulation_Tablet_Weibull")
+  expect_equal(form$parameters[["Dissolution shape"]]$value, 0.7)
+})
+
+test_that("create_formulation accepts raw parameter dicts", {
+  form <- create_formulation(
+    name = "X",
+    type = "Dissolved",
+    parameters = list(list(Name = "t1/2", Value = 0.02, Unit = "min"))
+  )
+
+  expect_equal(form$parameters[["t1/2"]]$value, 0.02)
+  expect_equal(form$parameters[["t1/2"]]$unit, "min")
+})
+
+test_that("create_formulation preserves ValueOrigin from raw parameters", {
+  form <- create_formulation(
+    name = "X",
+    type = "Weibull",
+    parameters = list(create_parameter(
+      name = "Dissolution shape",
+      value = 0.9,
+      source = "Lit",
+      description = "ref"
+    ))
+  )
+
+  expect_snapshot(form$parameters[["Dissolution shape"]]$value_origin)
+})
+
+test_that("create_formulation preserves a custom TableFormula on any type", {
+  # Custom TableFormula via table_points on a non-Table type.
+  from_points <- create_formulation(
+    name = "X",
+    type = "Dissolved",
+    parameters = list(create_parameter(
+      name = "Fraction (dose)",
+      value = 0,
+      table_points = list(list(x = 0, y = 0), list(x = 60, y = 1)),
+      x_name = "Custom X",
+      y_name = "Custom Y",
+      x_unit = "min",
+      x_dimension = "Time",
+      y_dimension = "Fraction"
+    ))
+  )
+  expect_snapshot(from_points$parameters[[1]]$table_formula)
+
+  # A fully custom TableFormula (including UseDerivedValues = FALSE) on an
+  # unknown type.
+  from_formula <- create_formulation(
+    name = "X",
+    type = "Formulation_BrandNew",
+    parameters = list(create_parameter(
+      name = "Fraction (dose)",
+      value = 0,
+      table_formula = list(
+        Name = "Fraction (dose)",
+        XName = "Time",
+        YName = "Fraction",
+        XDimension = "Time",
+        YDimension = "Fraction",
+        XUnit = "min",
+        UseDerivedValues = FALSE,
+        Points = list(list(X = 0, Y = 0, RestartSolver = FALSE))
+      )
+    ))
+  )
+  expect_snapshot(from_formula$parameters[[1]]$table_formula)
+})
+
+test_that("create_formulation curated form still errors on out-of-vocabulary alias", {
+  expect_snapshot(
+    error = TRUE,
+    create_formulation(
+      name = "X",
+      type = "Weibull",
+      parameters = list(not_a_param = 1)
+    )
+  )
+})
+
+test_that("create_formulation rejects curated-looking parameters for an unknown type", {
+  expect_snapshot(
+    error = TRUE,
+    create_formulation(
+      name = "X",
+      type = "Formulation_BrandNew",
+      parameters = list(some_alias = 1)
+    )
+  )
+})
+
+test_that("create_formulation validates name and type", {
+  expect_snapshot(error = TRUE, create_formulation())
+  expect_snapshot(error = TRUE, create_formulation(name = "X"))
+  expect_snapshot(
+    error = TRUE,
+    create_formulation(name = "", type = "Dissolved")
+  )
+  expect_snapshot(
+    error = TRUE,
+    create_formulation(name = "X", type = "Dissolved", parameters = "nope")
+  )
+})
+
+test_that("create_formulation curated Table shape is unchanged", {
+  expect_snapshot({
+    form <- create_formulation(
+      name = "X",
+      type = "Table",
+      parameters = list(tableX = c(0, 1), tableY = c(0, 1))
+    )
+    form$data$Parameters
+  })
+})
+
+test_that("raw-form formulation round-trips through export", {
+  snapshot <- load_snapshot(test_path("data", "empty_snapshot.json"))
+
+  form <- create_formulation(
+    name = "Novel",
+    type = "Formulation_BrandNew",
+    parameters = list(
+      create_parameter(
+        name = "Use as suspension",
+        value = 1,
+        source = "Lit",
+        description = "ref"
+      ),
+      create_parameter(
+        name = "Fraction (dose)",
+        value = 0,
+        table_formula = list(
+          Name = "Fraction (dose)",
+          XName = "Time",
+          YName = "Fraction",
+          XDimension = "Time",
+          YDimension = "Fraction",
+          XUnit = "min",
+          UseDerivedValues = FALSE,
+          Points = list(list(X = 0, Y = 0, RestartSolver = FALSE))
+        )
+      )
+    )
+  )
+
+  snapshot <- add_formulation(snapshot, form)
+
+  out <- withr::local_tempfile(fileext = ".json")
+  export_snapshot(snapshot, out)
+  reloaded <- load_snapshot(out)
+
+  reloaded_form <- reloaded$formulations[["Novel"]]
+  expect_equal(reloaded_form$formulation_type, "Formulation_BrandNew")
+  expect_snapshot(reloaded_form$data$Parameters)
+})


### PR DESCRIPTION
Closes #120

`create_formulation()` previously reached all three Formulation schema properties but through a closed vocabulary: `type` was validated against a hardcoded 7-entry allow-list, and `parameters` was confined to a fixed per-type alias set. Some valid formulations could not be authored through the factory and forced a drop to `Formulation$new(raw_data)`. This change loosens both constraints, aligning `create_formulation()` with the established sibling-factory pattern (free-form type string like `create_event()`'s `template`, and a raw `parameters` passthrough), so a user can author unknown formulation types, arbitrary parameters by real snapshot name, per-parameter `ValueOrigin`, and custom `TableFormula` shapes on any type. The curated alias form is preserved unchanged.

## Free-form `FormulationType`

`create_formulation(type = ...)` now resolves `type` in precedence order: a curated human-readable alias or a known raw `Formulation_*` key maps to that key exactly as before; any other non-empty string is accepted verbatim and written straight to `FormulationType`. The hard abort on unknown types is removed. This lets a new or otherwise unknown PK-Sim template type be authored without touching the curated map.

The `Formulation$formulation_type` active-binding setter is loosened to match: it now accepts any non-empty scalar string and rejects only empty, `NA`, non-character, or non-scalar input. This keeps a formulation authored with an unknown type mutable and re-exportable, and makes the setter consistent with the constructor and the reader (`get_human_formulation_type()` already fell back to the raw string).

## Raw `parameters` passthrough

`create_formulation()` now accepts two mutually exclusive `parameters` forms, disambiguated by entry shape and never mixed in one call:

- Curated form (unchanged): a named list of scalar/vector alias values for a known `type`. Defaults, informational messages, alias-to-`Name` synthesis, and the built-in `Table` shape all behave exactly as before.
- Raw form: a list of `Parameter` objects (built with `create_parameter()`) and/or raw `list(Name=, Value=, ...)` dicts, routed through `to_raw_parameters(parameters, "Name")`. Each entry is written to `data$Parameters` with its `Name`, `Value`, `Unit`, `ValueOrigin`, and `TableFormula` preserved verbatim, for any `type` including `Dissolved` and unknown types.

An internal `is_raw_parameters_list()` helper decides the form: `parameters` is the raw form when it is a non-empty list whose every entry is a `Parameter` object or a raw dict carrying a `$Name`; otherwise it is the curated form. Because a curated alias entry is always a bare scalar keyed by an alias name, and a raw entry is always a classed object or a `Name`-bearing dict, the two can never be confused. A curated-looking non-empty list supplied for an unknown type (which has no alias vocabulary) is a clear error that names the raw form as the fix.

This raw form is what unlocks arbitrary real parameter names (including on `Dissolved`, which previously accepted no parameters), per-parameter `ValueOrigin` at creation, and a custom `TableFormula` (any units, dimensions, axis names, and `UseDerivedValues`) on any type.

## Input validation

`create_formulation()` now guards `name` and `type` with `check_required_string()`, matching the sibling factories, so a missing or empty `name`/`type` produces a clear early error instead of undefined downstream behaviour.

## Tests, docs, and NEWS

- A new `tests/testthat/test-create_formulation.R` covers the unknown-type passthrough, curated alias mapping, raw parameters on `Dissolved`, real snapshot names on known types, raw parameter dicts, `ValueOrigin` preservation, custom `TableFormula` on non-`Table` and unknown types, the unchanged curated `Table` shape, the out-of-vocabulary and unknown-type error paths, `name`/`type` validation, and a full round-trip through snapshot export and reload.
- The existing `Formulation validates formulation type` test is updated: an arbitrary non-empty string is now accepted by the setter, and a new snapshot documents the remaining empty-string rejection. No other existing test or snapshot changed, confirming the curated path is unaffected.
- The `create_formulation()` roxygen documents the verbatim type passthrough, the two `parameters` forms, `ValueOrigin`, and custom `TableFormula`, with added examples of the raw form.
- `NEWS.md` gains one bullet under the development version.

## Example

Authoring a formulation that the curated vocabulary could not previously express (an arbitrary parameter with a `ValueOrigin` on `Dissolved`, and an unknown `FormulationType`):

```r
library(osp.snapshots)

# Raw form: set an arbitrary parameter (with a ValueOrigin) on Dissolved,
# which previously accepted no parameters at all.
f1 <- create_formulation(
  name = "Suspension",
  type = "Dissolved",
  parameters = list(
    create_parameter(name = "Use as suspension", value = 1, source = "Lit")
  )
)
f1$formulation_type
#> [1] "Formulation_Dissolved"
f1$parameters[["Use as suspension"]]$value
#> [1] 1
f1$parameters[["Use as suspension"]]$value_origin$Source
#> [1] "Lit"

# An unknown / new FormulationType is now accepted verbatim.
f2 <- create_formulation(name = "Novel", type = "Formulation_BrandNew")
f2$formulation_type
#> [1] "Formulation_BrandNew"
```

The output above is the real captured console result, not rendered through `reprex` (the package's dev-tree load emits snapshot-loading messages that would clutter a reprex); the values are faithful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Formulations now support custom, non-standard formulation types.
  - Parameters can be provided in a raw format, allowing preserved metadata such as value origin and custom table formulas.
  - Existing curated formulation options continue to work as before.

- **Bug Fixes**
  - Improved validation for formulation type values.
  - Added clearer error handling for invalid or mismatched parameter inputs.
  - Preserves formulation details more reliably when exporting and reloading data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->