### PR TITLE
docs: reconcile vignettes and README with current API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # osp.snapshots (development version)
 
+- The vignettes and README are updated to match the current API, and now document building an empty snapshot with `create_snapshot()`, the observed-data bridge to ospsuite, and the standalone validators (#131).
 - `create_descriptor_condition()` builds a container criterion (`Tag`, and an open-string `Type` such as `"InContainer"` or `"MatchTag"`) for an observer's container criteria (#119).
 - `create_expression_profile()` gains `expression` and `disease` arguments to set per-organ relative expression (a data frame of container rows, or a raw list) and a disease state, and `ExpressionProfile` gains read/write `expression` and `disease` bindings so a loaded profile can be read and mutated (#116).
 - `create_formula_reference()` builds a formula reference (`Alias`, `Path`, optional `Dimension`) for an observer's formula (#119).

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: end -->
 
-osp.snapshots provides a convenient R interface for working with PKSIM project snapshots. Import, navigate, modify, and export snapshot data with ease, making complex nested JSON structures accessible for analysis within the R ecosystem.
+osp.snapshots provides an R interface for working with PK-Sim project snapshots: import, navigate, modify, and export the nested JSON structure as R objects and data frames.
 
 ## Installation
 
@@ -33,58 +33,38 @@ You can install the development version of osp.snapshots from [GitHub](https://g
 pak::pak("esqLABS/osp.snapshots")
 ```
 
-## Quick Start
-
-```{r, include=FALSE}
-# Copy the test snapshot file to the package's extdata directory
-file.copy(
-  from = file.path("tests/testthat/data/test_snapshot.json"),
-  to = file.path("inst", "extdata", "test_snapshot.json"),
-  overwrite = TRUE
-)
-```
+## Usage
 
 ```{r example, message=FALSE}
 library(osp.snapshots)
 
-# Load a snapshot
-snapshot_path <- system.file(
-  "extdata",
-  "test_snapshot.json",
-  package = "osp.snapshots"
-)
-snapshot <- load_snapshot(snapshot_path)
-
-# Explore the snapshot
+# Load a snapshot from a template name, a local .json path, or a URL
+snapshot <- load_snapshot("Midazolam")
 snapshot
 
-# Access building blocks
+# Navigate the building blocks
 snapshot$individuals$`European (P-gp modified, CYP3A4 36 h)`
 
-# Modify parameters
-snapshot$individuals$`European (P-gp modified, CYP3A4 36 h)`$age <- 40
-
-# Convert to data frames for analysis
-individual_dfs <- get_individuals_dfs(snapshot)
+# Convert a collection to tibbles for analysis
+as_tibbles(snapshot, "individuals")
 ```
 
-## Key Features
+## Key features
 
--   **Import/Export**: Load snapshots from JSON files, URLs, or templates; export back to JSON
--   **Navigate**: Access all building blocks (individuals, compounds, formulations, etc.) with intuitive R syntax
--   **Modify**: Change parameters, add/remove building blocks in place
--   **Convert**: Transform any building block collection to structured data frames
--   **Integrate**: Full compatibility with `ospsuite::DataSet` objects
+* **Import and export**: Load snapshots from JSON files, URLs, or templates, and export the modified snapshot back to JSON.
+* **Navigate**: Reach every building block (individuals, compounds, formulations, and the rest) with R syntax.
+* **Modify**: Change parameters and add or remove building blocks in place.
+* **Convert**: Turn any building block collection into structured tibbles with `as_tibbles()`.
+* **Integrate**: Bridge PK-Sim observed data to `ospsuite::DataSet` objects.
 
-## Learn More
+## Learn more
 
-Get started with osp.snapshots:
+* `vignette("osp-snapshots")` — getting started
+* `vignette("creating-building-blocks")` — creating and managing building blocks
+* `vignette("exporting-snapshots-to-dataframes")` — exporting snapshots to data frames
+* `vignette("simulations")` — building simulations from scratch
 
--   `vignette("osp-snapshots")` - Getting started guide
--   `vignette("exporting-snapshots-to-dataframes")` - Exporting snapshots to data frames
--   `vignette("creating-building-blocks")` - Creating and managing building blocks
+## Getting help
 
-## Getting Help
-
--   [Function reference](https://esqlabs.github.io/osp.snapshots/reference/)
--   [Report bugs](https://github.com/esqLABS/osp.snapshots/issues)
+* [Function reference](https://esqlabs.github.io/osp.snapshots/reference/)
+* [Report bugs](https://github.com/esqLABS/osp.snapshots/issues)

--- a/README.Rmd
+++ b/README.Rmd
@@ -59,10 +59,10 @@ as_tibbles(snapshot, "individuals")
 
 ## Learn more
 
-* `vignette("osp-snapshots")` — getting started
-* `vignette("creating-building-blocks")` — creating and managing building blocks
-* `vignette("exporting-snapshots-to-dataframes")` — exporting snapshots to data frames
-* `vignette("simulations")` — building simulations from scratch
+* `vignette("osp-snapshots")`: getting started
+* `vignette("creating-building-blocks")`: creating and managing building blocks
+* `vignette("exporting-snapshots-to-dataframes")`: exporting snapshots to data frames
+* `vignette("simulations")`: building simulations from scratch
 
 ## Getting help
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@
 
 <!-- badges: end -->
 
-osp.snapshots provides a convenient R interface for working with PKSIM
-project snapshots. Import, navigate, modify, and export snapshot data
-with ease, making complex nested JSON structures accessible for analysis
-within the R ecosystem.
+osp.snapshots provides an R interface for working with PK-Sim project
+snapshots: import, navigate, modify, and export the nested JSON
+structure as R objects and data frames.
 
 ## Installation
 
@@ -23,39 +22,30 @@ You can install the development version of osp.snapshots from
 pak::pak("esqLABS/osp.snapshots")
 ```
 
-## Quick Start
+## Usage
 
 ``` r
 library(osp.snapshots)
 
-# Load a snapshot
-snapshot_path <- system.file(
-  "extdata",
-  "test_snapshot.json",
-  package = "osp.snapshots"
-)
-snapshot <- load_snapshot(snapshot_path)
-
-# Explore the snapshot
+# Load a snapshot from a template name, a local .json path, or a URL
+snapshot <- load_snapshot("Midazolam")
 snapshot
 #> 
 #> ── PKSIM Snapshot ──────────────────────────────────────────────────────────────
-#> ℹ Version: 79 (PKSIM 11.2)
-#> ℹ Path: '../../../../../../../private/var/folders/_6/hdp78hfx2qg6415svlx5rb680000gn/T/Rtmp770tJY/temp_libpath16d5e7e4ddfcf/osp.snapshots/extdata/test_snapshot.json'
-#> • Compounds: 6
-#> • Events: 10
-#> • ExpressionProfiles: 14
-#> • Formulations: 9
-#> • Individuals: 5
-#> • ObservedData: 64
-#> • ObservedDataClassifications: 20
-#> • ObserverSets: 1
-#> • ParameterIdentifications: 1
-#> • Populations: 7
-#> • Protocols: 9
-#> • Simulations: 2
+#> ℹ Version: 80 (PKSIM 12.0)
+#> • Compounds: 1
+#> • Events: 1
+#> • ExpressionProfiles: 8
+#> • Formulations: 2
+#> • Individuals: 2
+#> • ObservedData: 115
+#> • ObservedDataClassifications: 47
+#> • ParameterIdentifications: 3
+#> • Protocols: 33
+#> • SimulationClassifications: 4
+#> • Simulations: 37
 
-# Access building blocks
+# Navigate the building blocks
 snapshot$individuals$`European (P-gp modified, CYP3A4 36 h)`
 #> 
 #> ── Individual: European (P-gp modified, CYP3A4 36 h) | Seed: 17189110 ──────────
@@ -72,48 +62,81 @@ snapshot$individuals$`European (P-gp modified, CYP3A4 36 h)`
 #> 
 #> ── Parameters ──
 #> 
-#> • Organism|Gallbladder|Gallbladder ejection fraction: 0.8
 #> • Organism|Liver|EHC continuous fraction: 1
 #> 
 #> ── Expression Profiles ──
 #> 
-#> • CYP3A4|Human|Healthy
-#> • AADAC|Human|Healthy
-#> • P-gp|Human|Healthy
-#> • OATP1B1|Human|Healthy
-#> • ATP1A2|Human|Healthy
-#> • UGT1A4|Human|Healthy
-#> • GABRG2|Human|Healthy
+#> • CYP3A4|Human|European (P-gp modified, CYP3A4 36 h)
+#> • AADAC|Human|European (P-gp modified, CYP3A4 36 h)
+#> • P-gp|Human|European (P-gp modified, CYP3A4 36 h)
+#> • OATP1B1|Human|European (P-gp modified, CYP3A4 36 h)
+#> • ATP1A2|Human|European (P-gp modified, CYP3A4 36 h)
+#> • UGT1A4|Human|European (P-gp modified, CYP3A4 36 h)
+#> • GABRG2|Human|European (P-gp modified, CYP3A4 36 h)
 
-# Modify parameters
-snapshot$individuals$`European (P-gp modified, CYP3A4 36 h)`$age <- 40
-
-# Convert to data frames for analysis
-individual_dfs <- get_individuals_dfs(snapshot)
+# Convert a collection to tibbles for analysis
+as_tibbles(snapshot, "individuals")
+#> $individuals
+#> # A tibble: 2 × 18
+#>   individual_id         name  description   seed species population gender   age
+#>   <chr>                 <chr> <chr>        <int> <chr>   <chr>      <chr>  <dbl>
+#> 1 European (P-gp modif… Euro… <NA>        1.72e7 Human   European_… MALE    30  
+#> 2 Korean (Yu 2004 stud… Kore… <NA>        5.30e7 Human   Asian_Tan… MALE    23.3
+#> # ℹ 10 more variables: age_unit <chr>, gestational_age <dbl>,
+#> #   gestational_age_unit <chr>, weight <dbl>, weight_unit <chr>, height <dbl>,
+#> #   height_unit <chr>, disease_state <chr>, calculation_methods <glue>,
+#> #   disease_state_parameters <chr>
+#> 
+#> $individuals_parameters
+#> # A tibble: 2 × 7
+#>   individual_id                   path  value unit  source description source_id
+#>   <chr>                           <chr> <dbl> <chr> <chr>  <chr>           <int>
+#> 1 European (P-gp modified, CYP3A… Orga…     1 <NA>  Unkno… <NA>               NA
+#> 2 Korean (Yu 2004 study)          Orga…     1 <NA>  Unkno… <NA>               NA
+#> 
+#> $individuals_expressions
+#> # A tibble: 14 × 2
+#>    individual_id                         profile                                
+#>    <chr>                                 <chr>                                  
+#>  1 European (P-gp modified, CYP3A4 36 h) CYP3A4|Human|European (P-gp modified, …
+#>  2 European (P-gp modified, CYP3A4 36 h) AADAC|Human|European (P-gp modified, C…
+#>  3 European (P-gp modified, CYP3A4 36 h) P-gp|Human|European (P-gp modified, CY…
+#>  4 European (P-gp modified, CYP3A4 36 h) OATP1B1|Human|European (P-gp modified,…
+#>  5 European (P-gp modified, CYP3A4 36 h) ATP1A2|Human|European (P-gp modified, …
+#>  6 European (P-gp modified, CYP3A4 36 h) UGT1A4|Human|European (P-gp modified, …
+#>  7 European (P-gp modified, CYP3A4 36 h) GABRG2|Human|European (P-gp modified, …
+#>  8 Korean (Yu 2004 study)                CYP3A4|Human|Korean (Yu 2004 study)    
+#>  9 Korean (Yu 2004 study)                AADAC|Human|European (P-gp modified, C…
+#> 10 Korean (Yu 2004 study)                P-gp|Human|European (P-gp modified, CY…
+#> 11 Korean (Yu 2004 study)                OATP1B1|Human|European (P-gp modified,…
+#> 12 Korean (Yu 2004 study)                ATP1A2|Human|European (P-gp modified, …
+#> 13 Korean (Yu 2004 study)                UGT1A4|Human|European (P-gp modified, …
+#> 14 Korean (Yu 2004 study)                GABRG2|Human|European (P-gp modified, …
 ```
 
-## Key Features
+## Key features
 
-- **Import/Export**: Load snapshots from JSON files, URLs, or templates;
-  export back to JSON
-- **Navigate**: Access all building blocks (individuals, compounds,
-  formulations, etc.) with intuitive R syntax
-- **Modify**: Change parameters, add/remove building blocks in place
-- **Convert**: Transform any building block collection to structured
-  data frames
-- **Integrate**: Full compatibility with `ospsuite::DataSet` objects
+- **Import and export**: Load snapshots from JSON files, URLs, or
+  templates, and export the modified snapshot back to JSON.
+- **Navigate**: Reach every building block (individuals, compounds,
+  formulations, and the rest) with R syntax.
+- **Modify**: Change parameters and add or remove building blocks in
+  place.
+- **Convert**: Turn any building block collection into structured
+  tibbles with `as_tibbles()`.
+- **Integrate**: Bridge PK-Sim observed data to `ospsuite::DataSet`
+  objects.
 
-## Learn More
+## Learn more
 
-Get started with osp.snapshots:
-
-- `vignette("osp-snapshots")` - Getting started guide
-- `vignette("exporting-snapshots-to-dataframes")` - Exporting snapshots
-  to data frames
-- `vignette("creating-building-blocks")` - Creating and managing
+- `vignette("osp-snapshots")` — getting started
+- `vignette("creating-building-blocks")` — creating and managing
   building blocks
+- `vignette("exporting-snapshots-to-dataframes")` — exporting snapshots
+  to data frames
+- `vignette("simulations")` — building simulations from scratch
 
-## Getting Help
+## Getting help
 
 - [Function
   reference](https://esqlabs.github.io/osp.snapshots/reference/)

--- a/README.md
+++ b/README.md
@@ -129,12 +129,12 @@ as_tibbles(snapshot, "individuals")
 
 ## Learn more
 
-- `vignette("osp-snapshots")` — getting started
-- `vignette("creating-building-blocks")` — creating and managing
-  building blocks
-- `vignette("exporting-snapshots-to-dataframes")` — exporting snapshots
+- `vignette("osp-snapshots")`: getting started
+- `vignette("creating-building-blocks")`: creating and managing building
+  blocks
+- `vignette("exporting-snapshots-to-dataframes")`: exporting snapshots
   to data frames
-- `vignette("simulations")` — building simulations from scratch
+- `vignette("simulations")`: building simulations from scratch
 
 ## Getting help
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -17,10 +17,12 @@ navbar:
     articles:
       text: "Articles"
       menu:
-      - text: "Exporting snapshots to data frames"
-        href: articles/exporting-snapshots-to-dataframes.html
+      - text: "Getting started with osp.snapshots"
+        href: articles/osp-snapshots.html
       - text: "Creating and managing building blocks"
         href: articles/creating-building-blocks.html
+      - text: "Exporting snapshots to data frames"
+        href: articles/exporting-snapshots-to-dataframes.html
       - text: "Building simulations from scratch"
         href: articles/simulations.html
 
@@ -35,8 +37,9 @@ articles:
 - title: "Guides"
   desc: "In-depth guides for specific tasks"
   contents:
-  - exporting-snapshots-to-dataframes
+  - osp-snapshots
   - creating-building-blocks
+  - exporting-snapshots-to-dataframes
   - simulations
 
 reference:

--- a/vignettes/creating-building-blocks.Rmd
+++ b/vignettes/creating-building-blocks.Rmd
@@ -31,6 +31,18 @@ We use the `Midazolam` template throughout:
 snapshot <- load_snapshot("Midazolam")
 ```
 
+## Starting from an empty snapshot
+
+`create_snapshot()` is the from-scratch counterpart to `load_snapshot()`. It returns an in-memory *Snapshot* that carries the current supported PK-Sim version and no *Building blocks*, touches no files, and has no path. You then populate it with the `add_*()` verbs and serialize it with `export_snapshot()`.
+
+```{r}
+empty <- create_snapshot(name = "My Project", description = "Notes")
+empty <- add_compound(empty, create_compound(name = "Drug X"))
+empty
+```
+
+The rest of this vignette mutates the `Midazolam`-based `snapshot` object, so the empty snapshot uses its own `empty` object and does not disturb that narrative.
+
 ## Individuals
 
 `create_individual()` builds an *Individual* from demographic arguments. PK-Sim seeds the underlying physiological tree at simulation time.
@@ -97,7 +109,9 @@ You can pass a list of such parameters straight to `create_individual(parameters
 
 ## Formulations
 
-`create_formulation()` covers every PK-Sim release profile (`"Dissolved"`, `"Weibull"`, `"First Order"`, `"Zero Order"`, `"Lint80"`, `"Particles"`, `"Table"`). The accepted `parameters` depend on the chosen `type`: `"Dissolved"` takes none; the kinetic profiles (`"Weibull"`, `"First Order"`, `"Zero Order"`, `"Lint80"`, `"Particles"`, `"Table"`) accept the release-kinetics parameters specific to that profile (for example a `"Weibull"` formulation accepts `dissolution_time`, `dissolution_shape`, `lag_time`, ...). See `?create_formulation` for the parameter list per type.
+`create_formulation()` builds a *Formulation* from a `type` and its `parameters`. The `type` argument is open rather than a closed set. Seven curated human aliases resolve to a known PK-Sim release profile and unlock a per-type curated parameter vocabulary: `"Dissolved"`, `"Weibull"`, `"Lint80"`, `"Particle"`, `"Table"`, `"Zero Order"`, and `"First Order"`. Any other non-empty string is accepted verbatim and written to `FormulationType`, so you can author a new or unknown PK-Sim template type the same way `create_event()` accepts an arbitrary `template`.
+
+The `parameters` argument accepts two mutually exclusive forms. The curated alias form takes bare scalar or vector values keyed by the per-type alias vocabulary, and it exists only for the seven known types. For example, `"Dissolved"` takes none, and `"Weibull"` accepts `dissolution_time`, `dissolution_shape`, `lag_time`, and related keys. See `?create_formulation` for the full parameter list per type. The raw form takes a list of `create_parameter()` objects (or raw `list(Name =, Value =, ...)` dicts) written straight to the formulation's `Parameters`, preserving `Unit`, `ValueOrigin`, and `TableFormula` verbatim, for any type. The raw form is the only valid form for an unknown type.
 
 ```{r}
 oral_solution <- create_formulation(
@@ -121,6 +135,25 @@ tablet <- create_formulation(
 )
 
 tablet
+```
+
+The raw form lets you set an arbitrary parameter `Name`, a per-parameter `ValueOrigin` (`source` and `description`), or a custom `TableFormula` on any type, including `"Dissolved"` and unknown types:
+
+```{r}
+raw_dissolved <- create_formulation(
+  name = "Suspension",
+  type = "Dissolved",
+  parameters = list(
+    create_parameter(
+      name = "Use as suspension",
+      value = 1,
+      source = "Lit",
+      description = "Reference XYZ"
+    )
+  )
+)
+
+raw_dissolved
 ```
 
 ```{r}
@@ -286,15 +319,25 @@ breakfast
 
 An *Observer* is a simulation-time formula that exposes a derived quantity (for example a tissue concentration) that is not a natural model output. Observers travel in groups called *Observer sets*. `create_observer_set()` builds a set from a name and a list of observers.
 
-Build each observer with `Observer$new()` (which validates the input and gives you typed accessors `$name`, `$type`, `$dimension`, `$formula` (the full `ExplicitFormula` list), `$formula_expression`, `$formula_dimension`, `$formula_references`, `$container_tags`), then bundle them into a set and attach the set to a snapshot:
+Build each observer with `create_observer()`. It validates the input and returns an *Observer* with typed accessors `$name`, `$type`, `$dimension`, `$formula` (the full `ExplicitFormula` list), `$formula_expression`, `$formula_dimension`, `$formula_references`, and `$container_tags`. The companions `create_formula_reference()`, `create_descriptor_condition()`, and `create_molecule_list()` build the observer's sub-properties. Bundle the observers into a set and attach the set to a snapshot:
 
 ```{r}
-brain_obs <- Observer$new(list(
-  Name = "brain_plasma_conc",
-  Type = "Container",
-  Dimension = "Concentration (molar)",
-  Formula = list(Formula = "Conc_Br")
-))
+brain_obs <- create_observer(
+  name = "brain_plasma_conc",
+  type = "Container",
+  dimension = "Concentration (molar)",
+  formula = "Conc_Br",
+  formula_references = list(
+    create_formula_reference(
+      "Conc_Br",
+      "Organism|Brain|Plasma|Midazolam|Concentration"
+    )
+  ),
+  container_criteria = list(
+    create_descriptor_condition("Brain", "InContainer")
+  ),
+  molecule_list = create_molecule_list(for_all = FALSE, include = "Midazolam")
+)
 
 brain_set <- create_observer_set(
   name = "BrainPlasmaConcentration",
@@ -308,7 +351,7 @@ snapshot <- add_observer_set(snapshot, brain_set)
 
 ## Observed data
 
-`create_observed_data()` builds an `ospsuite::DataSet` from named arguments for the time grid, measurement values, units, and optional error series. `value_dimension` is required and gates the unit validation.
+`create_observed_data()` builds an `ospsuite::DataSet` from named arguments for the time grid, measurement values, units, and optional error series. `value_dimension` is required (it has no default) and gates the unit validation. `time_unit` defaults to `"h"`, and `error`, `error_type`, `error_unit`, `molecular_weight`, `lloq`, and `metadata` are optional.
 
 ```{r}
 obs <- create_observed_data(
@@ -322,6 +365,19 @@ obs <- create_observed_data(
 
 obs
 ```
+
+`create_observed_data()` is a thin factory around `loadDataSetFromSnapshot()`, the lower-level function that converts a raw snapshot observed-data structure into an `ospsuite::DataSet`. Call `loadDataSetFromSnapshot()` directly when you already hold the raw structure (for example a slice read from a snapshot JSON) rather than the named-argument inputs.
+
+The bridge also exposes two time helpers. `convert_ospsuite_time_unit_to_lubridate()` maps an ospsuite time unit to its lubridate unit, and `convert_ospsuite_time_to_duration()` maps a value and unit to a lubridate duration. The `"ks"` (kilosecond) unit is a special case: the duration helper converts it to seconds by multiplying the value by 1000.
+
+```{r}
+convert_ospsuite_time_unit_to_lubridate("day(s)")
+convert_ospsuite_time_to_duration(2, "ks")
+```
+
+<div class="alert alert-warning">
+The observed-data export path is asymmetric. A loaded observed-data entry replays byte-for-byte from the original JSON on export, so post-load mutations of a loaded `DataSet` are not reflected on export. A `DataSet` added at runtime with `add_observed_data()` is serialized through a lossy adapter that round-trips through `osp.snapshots` itself, but its PK-Sim round-trip is unvalidated. Treat runtime-added observed data as a convenience for the R side, not as a guaranteed PK-Sim round-trip.
+</div>
 
 ## Managing building blocks
 
@@ -410,7 +466,18 @@ tryCatch(
 )
 ```
 
-The same checks are also exported as standalone helpers (`validate_species()`, `validate_gender()`, `validate_unit()`, `validate_population()`) when you need them outside a `create_*()` call.
+The same checks are exported as standalone helpers when you need them outside a `create_*()` call. Each returns `TRUE` on success and aborts with an informative message otherwise:
+
+* `validate_species()` checks a species against `ospsuite::Species`.
+* `validate_gender()` checks a gender against `ospsuite::Gender`.
+* `validate_population()` checks a population against `ospsuite::HumanPopulation`, the human population enum, not a general population list.
+* `validate_unit()` checks a unit against a dimension via ospsuite.
+* `validate_snapshot()` checks that an object is a *Snapshot*.
+
+```{r}
+validate_species("Human")
+validate_unit("mg/l", "Concentration (mass)")
+```
 
 ## Exporting
 


### PR DESCRIPTION
Closes #131

Bring the four vignettes and the README back into alignment with the current exported API, expand narrative coverage to three thin or missing areas, and modernize the README to tidyverse/posit conventions. This is a documentation-only change: no `R/` behaviour, signature, argument, default, or error path is touched, and `man/`/`NAMESPACE`/`DESCRIPTION` are unchanged. The `Particle` (human alias) versus `Formulation_Particles` (raw/curated key) split in `R/Formulation.R` stays as it is and is documented around, not fixed in code.

## Vignettes

`vignettes/creating-building-blocks.Rmd` carries every discrepancy fix and coverage addition, keeping the four-vignette set intact with no new files and no renames.

* Formulations section: `type` is reframed as open rather than a closed enumeration. The seven curated aliases are listed correctly (`"Dissolved"`, `"Weibull"`, `"Lint80"`, `"Particle"`, `"Table"`, `"Zero Order"`, `"First Order"`); every plural `"Particles"` is gone. The section now states that any non-empty `FormulationType` string is accepted verbatim (mirroring how `create_event()` treats `template`), describes the two mutually exclusive `parameters` forms (curated alias form and raw form), and adds a worked raw-parameters example that sets a per-parameter `ValueOrigin` on a `Dissolved` formulation.
* Observer sets section: constructs the observer with `create_observer()` and its companions `create_formula_reference()`, `create_descriptor_condition()`, and `create_molecule_list()`, replacing the previous direct `Observer$new()` leaf constructor. No vignette teaches direct leaf-R6 construction.
* Starting from an empty snapshot: a new short section documents `create_snapshot(name = NULL, description = NULL)` as the from-scratch counterpart to `load_snapshot()`, with an empty-and-populate worked example that adds a compound and prints the snapshot.
* Observed data section: expanded into a bridge section covering `create_observed_data()` (with its required `value_dimension`, the `"h"` default for `time_unit`, and the optional arguments), its relationship to the lower-level `loadDataSetFromSnapshot()`, and the two time helpers `convert_ospsuite_time_unit_to_lubridate()` and `convert_ospsuite_time_to_duration()` (including the `"ks"` kilosecond special case) with a worked conversion. A caveat callout states the export asymmetry exactly as the code behaves: loaded entries replay byte-for-byte, runtime-added `DataSet` objects use a lossy adapter, and the PK-Sim round-trip is unvalidated.
* Validation section: expanded into a worked section documenting all five standalone validators (`validate_snapshot()`, `validate_species()`, `validate_gender()`, `validate_population()`, `validate_unit()`), each grounded in its ospsuite enum, with `validate_population()` correctly described as checking `ospsuite::HumanPopulation`, the return-`TRUE`-or-abort contract stated, and a live success-path example.

The other three vignettes (`osp-snapshots.Rmd`, `exporting-snapshots-to-dataframes.Rmd`, `simulations.Rmd`) are reconciled without restructuring; their live chunks build clean and every printed name, path, and value resolves against the live `Midazolam` template.

## README

`README.Rmd` follows tidyverse/posit structure: a one-line summary, the badges block, an Installation section, a single minimal motivating example, a Key features section, a Learn more section, and a Getting help section. The prose uses "PK-Sim" rather than "PKSIM". The motivating example teaches the canonical `load_snapshot()` plus `as_tibbles(snapshot, "individuals")` entry point that the vignettes teach, replacing the previous `get_individuals_dfs()` example. The fragile `include=FALSE` chunk that staged a test fixture into `inst/extdata/` at build time is removed, so the example is self-contained on the `Midazolam` template. The Learn more list now names all four vignettes, including `simulations`. `README.md` is regenerated from `README.Rmd` with `devtools::build_readme()` and is never hand-edited.

## pkgdown

`_pkgdown.yml` lists all four articles in a deliberate reading order (getting started, creating building blocks, exporting to data frames, simulations) in both the navbar Articles menu and the top-level articles index, so the getting-started guide is reachable from the Articles menu rather than only the intro slot. The reference index already carried topics for every function documented in the coverage expansion, so no reference entry is added or removed.

## Coverage additions

The three coverage areas all land in `creating-building-blocks.Rmd`, the existing "construct things from named arguments" topic vignette: `create_snapshot()` for building an empty snapshot, the observed-data bridge to ospsuite, and the standalone validators. This keeps the Articles menu short and leaves every cross-reference pointing at the same four existing articles.

## Verification

* `devtools::load_all()` succeeds and a live `load_snapshot("Midazolam")` confirms the reconciliation baseline: individuals `European (P-gp modified, CYP3A4 36 h)` and `Korean (Yu 2004 study)`, formulations `Oral solution` and `Tablet (Dormicum)`, compound `Midazolam`, event `High-fat breakfast`, protocols including `iv 1 mg (bolus)` and `po 15 mg`, zero observer sets, and the `Organism|Liver|EHC continuous fraction` path on the Korean individual.
* `devtools::build_vignettes()` builds all four vignettes with no chunk errors. The new chunks render as expected: the empty snapshot prints with one compound, the raw formulation carries its `ValueOrigin` parameter, the observer set prints with one observer, the conversions render `"days"` and `"2000s (~33.33 minutes)"`, and both validators return `TRUE`.
* `devtools::build_readme()` regenerates `README.md` cleanly with live template output.
* `pkgdown::check_pkgdown()` reports no problems.
* `git diff --name-only` touches only `vignettes/creating-building-blocks.Rmd`, `README.Rmd`, `README.md`, `_pkgdown.yml`, and `NEWS.md`. No `R/`, `man/`, `NAMESPACE`, or `DESCRIPTION` change, and `inst/extdata/test_snapshot.json` is unchanged.

A single `NEWS.md` bullet records the documentation update, referencing #131.
</content>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README and site navigation to better reflect the current workflow and key features.
  * Added clearer getting-started guidance, including creating empty snapshots, loading snapshots, navigating objects, and converting collections to tables.
  * Expanded vignette content with more examples for building blocks, observers, observed data, and validation helpers.
  * Added a news entry summarizing the documentation updates and new guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->