### PR TITLE
Drop duplicate "Get started" entry from Articles navbar menu

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -17,8 +17,6 @@ navbar:
     articles:
       text: "Articles"
       menu:
-      - text: "Getting started with osp.snapshots"
-        href: articles/osp-snapshots.html
       - text: "Creating and managing building blocks"
         href: articles/creating-building-blocks.html
       - text: "Exporting snapshots to data frames"


### PR DESCRIPTION
The pkgdown navbar listed the "Getting started" vignette twice: once as the built-in `intro` component ("Get started"), which pkgdown auto-generates for the package-named vignette, and again as the first item in the custom `Articles` dropdown.

## Navbar

Removes the redundant "Getting started with osp.snapshots" item from the `articles` menu in `_pkgdown.yml`. The vignette keeps its dedicated top-level "Get started" link, and the Articles dropdown now lists only the other three guides. The articles index page still references all four guides, so nothing is dropped from the site itself.

## Example

Impact not shown as a reprex: this is a pkgdown site configuration change with no user-facing R function surface.

Closes #134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the site navigation so the “Getting started with osp.snapshots” article is no longer shown in the Articles menu.
  * The remaining article links are unchanged, with the next article now appearing first in the list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->