### PR TITLE
Reorient dataframe-export vignette toward reporting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,7 @@ Imports:
 Suggests:
     devtools,
     ggplot2,
+    gt,
     knitr,
     quarto,
     rlang,

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -19,10 +19,10 @@ navbar:
       menu:
       - text: "Creating and managing building blocks"
         href: articles/creating-building-blocks.html
-      - text: "Exporting snapshots to data frames"
-        href: articles/exporting-snapshots-to-dataframes.html
       - text: "Building simulations from scratch"
         href: articles/simulations.html
+      - text: "Exporting snapshots to data frames"
+        href: articles/exporting-snapshots-to-dataframes.html
 
 home:
   title: "osp.snapshots"
@@ -37,8 +37,8 @@ articles:
   contents:
   - osp-snapshots
   - creating-building-blocks
-  - exporting-snapshots-to-dataframes
   - simulations
+  - exporting-snapshots-to-dataframes
 
 reference:
 

--- a/vignettes/exporting-snapshots-to-dataframes.Rmd
+++ b/vignettes/exporting-snapshots-to-dataframes.Rmd
@@ -19,11 +19,14 @@ knitr::opts_chunk$set(
 ```{r setup}
 library(osp.snapshots)
 library(dplyr)
+library(gt)
 ```
 
-## Overview
+## Reporting the inputs that drive a simulation
 
-osp.snapshots can flatten the nested PK-Sim snapshot tree into tibbles ready for downstream analysis with `dplyr`. This vignette covers the entry point, the per-kind shapes, and a few common analysis patterns.
+A PK-Sim snapshot is mostly *configuration*: the compounds, individuals, formulations, protocols, and other building blocks that define how a simulation is set up. Observed data and simulation results are already easy to report with the wider R ecosystem; what has been awkward is reporting the **inputs**, because they live deep inside a nested JSON tree.
+
+`as_tibbles()` flattens those building blocks into tidy tibbles, one concept per table, so you can filter them with `dplyr` and render them as publication-quality tables. This vignette pairs `as_tibbles()` with [`gt`](https://gt.rstudio.com/) to turn the configuration of a model into report-ready HTML tables.
 
 ```{r}
 snapshot <- load_snapshot("Midazolam")
@@ -52,26 +55,36 @@ names(compound_dfs)
 
 The tibble layer is read-only: mutating a returned tibble does not feed changes back into the snapshot.
 
-## Compounds: `$properties` and `$processes`
+The sections below feature four kinds chosen because each has a different *shape*: a single flat table (protocols), a header split from a long-form parameter table (compounds, formulations), and several related tables keyed by an id (individuals). Every other kind follows one of these same shapes, so the same reporting recipe applies to all of them.
+
+## Compounds: a flat table and a long-form table
 
 `as_tibbles(snapshot, "compounds")` returns a list of two tibbles:
 
 * `$properties` carries one row per (compound, parameter) pair across the *Compound* physicochemical properties.
 * `$processes` is the long-form view: one row per (compound, process, parameter) triple across every biological *Process* (metabolism, transport, clearance, binding, ...).
 
+The physicochemical properties render directly as a report table:
+
 ```{r}
-head(compound_dfs$properties)
-head(compound_dfs$processes)
+compound_dfs$properties |>
+  gt() |>
+  tab_header(title = "Compound physicochemical properties")
 ```
 
-The `$processes` tibble carries a `category` column that mirrors `process$category` on the R6 side. Filtering by category gives the same view as the per-category groups on a compound:
+### Filtering before you render
 
-```{r, eval=FALSE}
+The `$processes` tibble carries a `category` column that mirrors `process$category` on the R6 side. Filtering by category with `dplyr::filter()` gives the same view as the per-category groups on a compound, and the filtered result flows straight into `gt`:
+
+```{r}
 compound_dfs$processes |>
-  filter(category == "metabolizing_enzymes")
+  filter(category == "metabolizing_enzymes") |>
+  select(process_name, molecule, parameter, value, unit) |>
+  gt() |>
+  tab_header(title = "Metabolizing enzymes")
 ```
 
-## Individuals: three related tibbles
+## Individuals: several related tables
 
 `as_tibbles(snapshot, "individuals")` returns three tibbles joinable on `individual_id`:
 
@@ -79,16 +92,19 @@ compound_dfs$processes |>
 * `$individuals_parameters` is the long-form view of the individual's parameter tree: one row per (individual, parameter path) pair, with value, unit, source, and value-origin metadata.
 * `$individuals_expressions` lists the expression profiles attached to each individual: one row per (individual, profile) pair.
 
+A focused selection of the demographic columns makes a compact subject table:
+
 ```{r}
 individual_dfs <- as_tibbles(snapshot, "individuals")
 names(individual_dfs)
 
-head(individual_dfs$individuals)
-head(individual_dfs$individuals_parameters)
-head(individual_dfs$individuals_expressions)
+individual_dfs$individuals |>
+  select(name, species, population, gender, age, age_unit, weight, weight_unit) |>
+  gt() |>
+  tab_header(title = "Individuals")
 ```
 
-## Formulations: `$formulations` and `$formulations_parameters`
+## Formulations: a header split from its parameters
 
 `as_tibbles(snapshot, "formulations")` returns two tibbles joinable on `formulation_id`:
 
@@ -98,53 +114,40 @@ head(individual_dfs$individuals_expressions)
 ```{r}
 formulation_dfs <- as_tibbles(snapshot, "formulations")
 names(formulation_dfs)
-head(formulation_dfs$formulations)
-head(formulation_dfs$formulations_parameters)
+
+formulation_dfs$formulations |>
+  gt() |>
+  tab_header(title = "Formulations")
+
+formulation_dfs$formulations_parameters |>
+  select(name, value, unit) |>
+  gt() |>
+  tab_header(title = "Formulation release parameters")
 ```
 
-## Populations: `$populations` and `$populations_parameters`
+## Protocols: a single flat table
 
-`as_tibbles(snapshot, "populations")` returns two tibbles joinable on `population_id`:
-
-* `$populations` has one row per *Population* with the sampling-recipe header: source population, individual name, sample size, proportion of females, seed, and the age, weight, height, BMI, and eGFR bound columns.
-* `$populations_parameters` is the long-form view of the sampling distributions PK-Sim will draw from: one row per (population, parameter) pair, with `distribution_type`, `statistic`, value, and unit.
+`as_tibbles(snapshot, "protocols")` returns a single tibble whether the snapshot has any protocols or not. *Advanced Protocols* contribute one row per *Schema* item, with the protocol-level, schema-level, and item-level parameters joined by name. This is the simplest shape: one kind, one table, ready to render.
 
 ```{r}
-population_dfs <- as_tibbles(snapshot, "populations")
-names(population_dfs)
-head(population_dfs$populations)
+as_tibbles(snapshot, "protocols") |>
+  select(protocol_name, dose, dose_unit, start_time, start_time_unit, dosing_interval) |>
+  gt() |>
+  tab_header(title = "Dosing protocols")
 ```
 
-## Protocols: `Schema` and `SchemaItem` rows
+## Every building block exports the same way
 
-`as_tibbles(snapshot, "protocols")` returns a single 13-column tibble whether the snapshot has any protocols or not. *Advanced Protocols* contribute one row per *Schema* item, with the protocol-level, schema-level, and item-level parameters joined by name.
+The four kinds above cover every shape `as_tibbles()` produces. The same call works for `"events"`, `"expression_profiles"`, `"populations"`, and `"observer_sets"`: each returns either a single flat tibble or a header split from a long-form parameter table, ready for the same `filter()` + `gt()` recipe. Kinds a snapshot does not define come back as empty (0-row) tibbles with the same columns, so reporting code never has to special-case a missing building block.
+
+Passing no `kind` converts everything at once, keyed by kind name, which is handy when assembling a multi-table report:
 
 ```{r}
-protocols_df <- as_tibbles(snapshot, "protocols")
-head(protocols_df)
+all_kinds <- as_tibbles(snapshot)
+names(all_kinds)
 ```
 
-## Observer sets: `$observer_sets` and `$observers`
-
-`as_tibbles(snapshot, "observer_sets")` returns a list of two tibbles joinable on `observer_set_id` (or `observer_set_name`):
-
-* `$observer_sets` has one row per *ObserverSet* with its name and the count of observers it contains.
-* `$observers` has one row per *Observer* with its name, type, dimension, `formula_expression`, `formula_dimension`, `formula_references` (the underlying `ExplicitFormula` references collapsed to `"alias=path"` pairs joined with `|`), and `container_tags` (the `|`-joined `Tag` values from the underlying `ContainerCriteria`).
-
-```{r, eval=FALSE}
-observer_dfs <- as_tibbles(snapshot, "observer_sets")
-names(observer_dfs)
-head(observer_dfs$observers)
-```
-
-## Observed data
-
-`as_tibbles(snapshot, "observed_data")` flattens every observed-data series into a long-form tibble ready for plotting.
-
-```{r}
-obs_data_df <- as_tibbles(snapshot, "observed_data")
-head(obs_data_df)
-```
+`"observed_data"` is also available and flattens every observed-data series into a long-form tibble, though it is measurement data rather than a configuration input.
 
 ## Next steps
 


### PR DESCRIPTION
Reworks the "Exporting snapshots to data frames" vignette so it reads as a guide to *reporting the inputs that drive a simulation*, the configuration building blocks that were previously awkward to surface out of the nested snapshot JSON. Exported tibbles are now rendered as publication-quality HTML tables, and the vignette is moved to last in the pkgdown Articles navigation.

## Vignette

The overview is reframed around reporting configuration inputs (compounds, individuals, formulations, protocols, and the other kinds) rather than generic `dplyr` analysis. Exported tibbles are rendered with `gt::gt()` instead of bare `head()` printing, producing self-contained HTML tables that sit inside the existing `html_vignette` output. Rather than walking every kind, the vignette features four chosen for their distinct shapes (a single flat table, a header split from a long-form parameter table, and several related tables keyed by an id) and folds the remaining kinds into a short "every building block exports the same way" section. The `$processes` category-filter example is switched from `eval=FALSE` to a live `dplyr::filter()` pipeline feeding a rendered table. The observer-sets and populations render examples are dropped because the Midazolam snapshot used throughout defines none, so they would render as empty tables; they are covered in prose instead.

## Dependencies

`gt` is added to `Suggests` (the vignette is the only consumer). It is loaded unconditionally in the vignette setup chunk, matching how the other vignettes load their Suggests packages.

## Site navigation

`_pkgdown.yml` moves the export vignette after "Building simulations from scratch" in both the navbar Articles menu and the articles index, so it is last in the dropdown.

## Example

Impact not shown as a reprex: the change is a vignette rewrite (rendered `gt` tables and prose), not a change to an exported function's behaviour, so there is no self-contained reprex that captures it. The vignette was rendered locally to confirm all tables knit without error.

Closes #136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying snapshot data as publication-ready tables in documentation examples.
  - Expanded recommended optional tooling for working with snapshot exports.

- **Documentation**
  - Reworked the export guide to focus on table-based workflows and clearer output patterns.
  - Updated navigation and article ordering for easier access to simulation and export guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->