### PR TITLE
Normalize loaded snapshots to the current PK-Sim version

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # osp.snapshots (development version)
 
+- Loaded snapshots are now normalized to the current PK-Sim version on load and always exported with `Version = 80`; renal-clearance parameter-container paths (`GlomerularFiltration`, `RenalClearance`) are upconverted to their v12 form and the `Applications` to `Events` path rewrite now also reaches `ParameterIdentifications` linked-parameter paths (#155).
+
 # osp.snapshots 1.0.0
 
 ## Breaking changes

--- a/R/Snapshot.R
+++ b/R/Snapshot.R
@@ -51,6 +51,18 @@ SUPPORTED_VERSION_MIN <- 79L
 #' package; `Snapshot$new()` aborts on them rather than silently rewriting
 #' fields. Hand-rolled list input must supply `Version` for the same reason.
 #'
+#' # Snapshot version normalization
+#'
+#' A loaded snapshot is upconverted to the current `Version = 80` (PK-Sim
+#' v12) structure in memory at load time, so the whole in-memory model and
+#' every export are one coherent current-format snapshot. Renal-clearance
+#' parameter-container path segments (`GlomerularFiltration`,
+#' `RenalClearance`) are qualified with their owning compound name, the
+#' `Applications` to `Events` path rewrite is applied throughout, and every
+#' export reports `Version = 80` regardless of the file's original declared
+#' version. On a snapshot already at `Version = 80` this is a structural
+#' no-op.
+#'
 #' @importFrom R6 R6Class
 #' @importFrom fs path_rel
 #'
@@ -87,6 +99,15 @@ Snapshot <- R6::R6Class(
       }
 
       private$.validate_version()
+
+      # Upconvert the parsed data to the current `Version = 80` structure in
+      # memory. Runs on `.original_data` before any lazy cache is built, so
+      # both R6-wrapped sections and verbatim-passthrough sections
+      # (`ParameterIdentifications`, `Version`) are normalized uniformly and no
+      # mixed-version file can form. See `normalize_snapshot_to_current()`.
+      private$.original_data <- normalize_snapshot_to_current(
+        private$.original_data
+      )
 
       # Building-block collections are constructed lazily on first access via
       # their active bindings; all `private$.<kind>` caches stay NULL here.

--- a/R/normalize-snapshot.R
+++ b/R/normalize-snapshot.R
@@ -1,0 +1,235 @@
+# Load-time normalization of a parsed snapshot to the current PK-Sim version.
+#
+# `osp.snapshots` reads a snapshot, lets the user edit it through R6 block
+# objects, and writes it back out. The block classes only ever emit the
+# current (v12 / `Version = 80`) structure, so a loaded v11 (`Version = 79`)
+# file whose untouched sections were replayed verbatim would export a
+# mixed-version file: v79-shaped for untouched sections, v80-shaped for edited
+# ones. PK-Sim reads the whole file under one migration path keyed on the
+# single declared `Version`, so a mixed file mis-migrates.
+#
+# `normalize_snapshot_to_current()` upconverts the parsed data to the current
+# `Version = 80` structure in memory at load time (called from
+# `Snapshot$initialize()` right after version validation), so the whole
+# in-memory model and every export are one coherent v12-format snapshot. The
+# v11-to-v12 delta this package can encounter has exactly two parts:
+#
+#   1. `Applications` path segments become `Events` (already implemented by
+#      `migrate_applications_to_events()`; reused here so it also reaches
+#      `ParameterIdentifications` linked-parameter paths, which never pass
+#      through `LocalizedParameter`).
+#   2. The renal-clearance process containers `GlomerularFiltration` and
+#      `RenalClearance` are qualified with the owning compound name wherever
+#      they appear as a whole segment of a parameter path.
+#
+# Everything operates on whole `|`-separated segments, never on substrings,
+# mirroring `migrate_applications_to_events()`. The step is idempotent: an
+# already-v80 file has no bare renal container segment left to rename and its
+# `Applications` are already `Events`, so only `Version = 80` is (re)affirmed.
+normalize_snapshot_to_current <- function(data) {
+  compound_names <- extract_compound_names(data)
+
+  data <- normalize_localized_parameter_paths(data, compound_names)
+  data <- normalize_identification_parameter_paths(data, compound_names)
+
+  # Always emit the current version so both the in-memory model and every
+  # export report `Version = 80`, regardless of the loaded file's original
+  # declared version. `.original_data$Version` is the source `$data` reads
+  # (it is not one of the export adapters), so this is where the effective
+  # export version is set. Integer literal to match `create_snapshot()`.
+  data$Version <- 80L
+
+  data
+}
+
+# Extract the non-NA compound names from the parsed snapshot's `Compounds`
+# section. Returns `character(0)` when there are no compounds.
+extract_compound_names <- function(data) {
+  compounds <- data$Compounds %||% list()
+  if (length(compounds) == 0) {
+    return(character(0))
+  }
+  names_raw <- vapply(
+    compounds,
+    \(compound) compound$Name %||% NA_character_,
+    character(1)
+  )
+  names_raw[!is.na(names_raw)]
+}
+
+# Normalize a single parameter path string end to end: first the legacy
+# `Applications` -> `Events` migration (reusing the existing helper), then the
+# renal-clearance container rename. This is the one canonical per-path
+# normalizer, used for both localized-parameter paths and
+# identification-parameter linked paths.
+normalize_parameter_path <- function(path, compound_names) {
+  path <- migrate_applications_to_events(path)
+  rename_renal_containers_in_path(path, compound_names)
+}
+
+# Rewrite localized-parameter paths in every place the package wraps
+# `Parameters` as localized parameters: `Simulations`, `Individuals`, and the
+# population base individual under `Populations[[i]]$Settings$Individual`.
+# Rewriting these in `.original_data` up front means the later
+# `LocalizedParameter$new()` wrapping just re-runs `migrate_applications_to_events()`
+# as a confirmed no-op (the `Applications` are already gone) and the renal
+# rename is idempotent (a renamed segment no longer equals the bare container
+# name), so there is no double-rewrite hazard.
+normalize_localized_parameter_paths <- function(data, compound_names) {
+  data$Simulations <- rewrite_block_parameter_paths(
+    data$Simulations,
+    compound_names
+  )
+  data$Individuals <- rewrite_block_parameter_paths(
+    data$Individuals,
+    compound_names
+  )
+
+  if (length(data$Populations) > 0) {
+    data$Populations <- lapply(data$Populations, function(population) {
+      base_individual <- population$Settings$Individual
+      if (!is.null(base_individual)) {
+        population$Settings$Individual <- rewrite_parameters_paths(
+          base_individual,
+          compound_names
+        )
+      }
+      population
+    })
+  }
+
+  data
+}
+
+# Rewrite `IdentificationParameter.LinkedParameters` entries under the
+# top-level `ParameterIdentifications` section. These are full parameter-path
+# strings (`SimulationName|Container|...|ParameterName`) that flow through
+# `.original_data` verbatim (the section is not modelled by any R6 block class
+# and is not one of the export adapters), so they must be rewritten here to be
+# covered at all. Every level is guarded for absence/emptiness.
+normalize_identification_parameter_paths <- function(data, compound_names) {
+  if (length(data$ParameterIdentifications) == 0) {
+    return(data)
+  }
+
+  data$ParameterIdentifications <- lapply(
+    data$ParameterIdentifications,
+    function(identification) {
+      id_params <- identification$IdentificationParameters
+      if (length(id_params) == 0) {
+        return(identification)
+      }
+      identification$IdentificationParameters <- lapply(
+        id_params,
+        function(id_param) {
+          linked <- id_param$LinkedParameters
+          if (length(linked) == 0) {
+            return(id_param)
+          }
+          id_param$LinkedParameters <- lapply(linked, function(linked_path) {
+            normalize_parameter_path(linked_path, compound_names)
+          })
+          id_param
+        }
+      )
+      identification
+    }
+  )
+
+  data
+}
+
+# Apply the per-path normalizer to every `Parameters` entry of every block in a
+# collection (a list of block dicts, e.g. `data$Simulations`). A `NULL`/empty
+# collection passes through unchanged.
+rewrite_block_parameter_paths <- function(blocks, compound_names) {
+  if (length(blocks) == 0) {
+    return(blocks)
+  }
+  lapply(blocks, function(block) {
+    rewrite_parameters_paths(block, compound_names)
+  })
+}
+
+# Rewrite the `Path` of every entry in a single block's `Parameters` list. A
+# block with no `Parameters` (or an empty one) passes through unchanged.
+rewrite_parameters_paths <- function(block, compound_names) {
+  params <- block$Parameters
+  if (length(params) == 0) {
+    return(block)
+  }
+  block$Parameters <- lapply(params, function(param) {
+    if (!is.null(param$Path)) {
+      param$Path <- normalize_parameter_path(param$Path, compound_names)
+    }
+    param
+  })
+  block
+}
+
+# Rename renal-clearance container segments in one path. Splits on `|` and
+# examines each whole segment; a segment that is exactly `GlomerularFiltration`
+# or `RenalClearance` is a renal-clearance process container to qualify. The
+# owning compound is resolved (see `resolve_renal_compound()`); when resolved
+# the segment is replaced via `rename_renal_container_segment()`, when it
+# cannot be resolved the segment is left unchanged and one informational
+# message is emitted for the path (FR-2d: never silently produce an
+# unresolvable path). Whole-segment matching (never `grepl` on the whole path)
+# keeps substrings such as `MyGlomerularFiltrationX` untouched.
+rename_renal_containers_in_path <- function(path, compound_names) {
+  segments <- strsplit(path, "|", fixed = TRUE)[[1]]
+  is_container <- segments %in% c("GlomerularFiltration", "RenalClearance")
+  if (!any(is_container)) {
+    return(path)
+  }
+
+  for (i in which(is_container)) {
+    preceding <- if (i > 1) segments[[i - 1]] else NA_character_
+    compound <- resolve_renal_compound(preceding, compound_names)
+    if (is.na(compound)) {
+      cli::cli_alert_info(c(
+        "Could not determine the owning compound for the \\
+        renal-clearance container {.val {segments[[i]]}} in path \\
+        {.val {path}}; leaving the segment unchanged."
+      ))
+      next
+    }
+    segments[[i]] <- rename_renal_container_segment(segments[[i]], compound)
+  }
+
+  paste(segments, collapse = "|")
+}
+
+# Resolve the compound that owns a renal-clearance container from the segment
+# immediately preceding the container and the snapshot's compound names, in
+# order:
+#   1. Adjacent-segment match (primary): a renal-clearance process container is
+#      a child of the compound (molecule) node in the PK-Sim model tree, so the
+#      preceding segment is the compound name. Use it when it matches a known
+#      compound name. This is path-local and correct for multi-compound
+#      snapshots.
+#   2. Single-compound fallback: when the preceding segment does not match but
+#      the snapshot has exactly one compound, the container is unambiguous.
+#   3. Otherwise return `NA_character_` (undeterminable); the caller leaves the
+#      segment unchanged and informs.
+resolve_renal_compound <- function(preceding_segment, compound_names) {
+  if (!is.na(preceding_segment) && preceding_segment %in% compound_names) {
+    return(preceding_segment)
+  }
+  if (length(compound_names) == 1) {
+    return(compound_names[[1]])
+  }
+  NA_character_
+}
+
+# The single place the exact renal-clearance rename form lives, matching
+# PK-Sim's v11-to-v12 import migration: the container segment is qualified with
+# the owning compound name joined by a hyphen (e.g. `GlomerularFiltration` ->
+# `GlomerularFiltration-Rifampicin`). PK-Sim resolves the path literally, so
+# the exact glue must match its mapper; this form mirrors PK-Sim's own
+# systemic-process display-name convention (`"<Process>-<Label>"`). Isolated in
+# this one function so a correction to the glue touches a single call site and
+# its one expected-string test.
+rename_renal_container_segment <- function(segment, compound_name) {
+  paste0(segment, "-", compound_name)
+}

--- a/man/Snapshot.Rd
+++ b/man/Snapshot.Rd
@@ -17,6 +17,18 @@ package; \code{Snapshot$new()} aborts on them rather than silently rewriting
 fields. Hand-rolled list input must supply \code{Version} for the same reason.
 }
 
+\section{Snapshot version normalization}{
+A loaded snapshot is upconverted to the current \code{Version = 80} (PK-Sim
+v12) structure in memory at load time, so the whole in-memory model and
+every export are one coherent current-format snapshot. Renal-clearance
+parameter-container path segments (\code{GlomerularFiltration},
+\code{RenalClearance}) are qualified with their owning compound name, the
+\code{Applications} to \code{Events} path rewrite is applied throughout, and every
+export reports \code{Version = 80} regardless of the file's original declared
+version. On a snapshot already at \code{Version = 80} this is a structural
+no-op.
+}
+
 \examples{
 
 ## ------------------------------------------------

--- a/tests/testthat/_snaps/LocalizedParameter.md
+++ b/tests/testthat/_snaps/LocalizedParameter.md
@@ -56,3 +56,12 @@
       Error in `initialize()`:
       ! <LocalizedParameter> requires a single non-empty path.
 
+# Renal rename leaves the segment unchanged when the compound is ambiguous
+
+    Code
+      snapshot <- Snapshot$new(data)
+    Message
+      i Creating snapshot from list data
+      i Could not determine the owning compound for the renal-clearance container "GlomerularFiltration" in path "Sim|Organism|Kidney|GlomerularFiltration|Plasma clearance"; leaving the segment unchanged.
+      v Snapshot loaded successfully
+

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -30,7 +30,7 @@
     Output
       
       -- PKSIM Snapshot --------------------------------------------------------------
-      i Version: 79 (PKSIM 11.2)
+      i Version: 80 (PKSIM 12.0)
       i Path: 'data/test_snapshot.json'
       * Compounds: 6
       * Events: 10

--- a/tests/testthat/test-LocalizedParameter.R
+++ b/tests/testthat/test-LocalizedParameter.R
@@ -188,6 +188,151 @@ test_that("Individual parameters load as LocalizedParameter", {
   expect_s3_class(first_param, "Parameter")
 })
 
+# Renal-clearance container rename on localized-parameter paths ---------------
+#
+# The rename is a snapshot-level load step (not a `LocalizedParameter`
+# behaviour), so these load a hand-rolled snapshot through `Snapshot$new()` and
+# assert the normalized path.
+
+test_that("Snapshot renames renal-clearance containers on localized paths", {
+  data <- list(
+    Version = 79,
+    Compounds = list(list(Name = "Drug")),
+    Simulations = list(list(
+      Name = "Sim",
+      Parameters = list(
+        list(
+          Path = "Sim|Organism|Kidney|Drug|GlomerularFiltration|Plasma clearance",
+          Value = 1
+        ),
+        list(
+          Path = "Sim|Organism|Kidney|Drug|RenalClearance|Fraction",
+          Value = 2
+        )
+      )
+    ))
+  )
+  snapshot <- Snapshot$new(data)
+
+  paths <- vapply(
+    snapshot$data$Simulations[[1]]$Parameters,
+    \(p) p$Path,
+    character(1)
+  )
+  expect_equal(
+    paths,
+    c(
+      "Sim|Organism|Kidney|Drug|GlomerularFiltration-Drug|Plasma clearance",
+      "Sim|Organism|Kidney|Drug|RenalClearance-Drug|Fraction"
+    )
+  )
+})
+
+test_that("Snapshot renames renal containers on individual parameter paths", {
+  data <- list(
+    Version = 79,
+    Compounds = list(list(Name = "Drug")),
+    Individuals = list(list(
+      Name = "Ind",
+      Parameters = list(
+        list(
+          Path = "Organism|Kidney|Drug|GlomerularFiltration|Plasma clearance",
+          Value = 1
+        )
+      )
+    ))
+  )
+  snapshot <- Snapshot$new(data)
+
+  path <- snapshot$data$Individuals[[1]]$Parameters[[1]]$Path
+  expect_equal(
+    path,
+    "Organism|Kidney|Drug|GlomerularFiltration-Drug|Plasma clearance"
+  )
+})
+
+test_that("Snapshot renames renal containers on population base-individual paths", {
+  data <- list(
+    Version = 79,
+    Compounds = list(list(Name = "Drug")),
+    Populations = list(list(
+      Name = "Pop",
+      Settings = list(
+        Individual = list(
+          Name = "Base",
+          Parameters = list(
+            list(
+              Path = "Organism|Kidney|Drug|RenalClearance|Fraction",
+              Value = 1
+            )
+          )
+        )
+      )
+    ))
+  )
+  snapshot <- Snapshot$new(data)
+
+  path <- snapshot$data$Populations[[1]]$Settings$Individual$Parameters[[
+    1
+  ]]$Path
+  expect_equal(path, "Organism|Kidney|Drug|RenalClearance-Drug|Fraction")
+})
+
+test_that("Renal rename matches whole segments, not substrings", {
+  # `GFR (specific)` (a parameter) and `MyGlomerularFiltrationX` (a substring
+  # containing the container word) must be left unchanged.
+  data <- list(
+    Version = 79,
+    Compounds = list(list(Name = "Drug")),
+    Simulations = list(list(
+      Name = "Sim",
+      Parameters = list(
+        list(Path = "Sim|Organism|Kidney|GFR (specific)", Value = 1),
+        list(Path = "Sim|MyGlomerularFiltrationX|Sub|Item", Value = 2)
+      )
+    ))
+  )
+  snapshot <- Snapshot$new(data)
+
+  paths <- vapply(
+    snapshot$data$Simulations[[1]]$Parameters,
+    \(p) p$Path,
+    character(1)
+  )
+  expect_equal(
+    paths,
+    c(
+      "Sim|Organism|Kidney|GFR (specific)",
+      "Sim|MyGlomerularFiltrationX|Sub|Item"
+    )
+  )
+})
+
+test_that("Renal rename leaves the segment unchanged when the compound is ambiguous", {
+  # Two compounds and no adjacent-segment compound match: the owning compound
+  # cannot be determined, so the segment is left intact and one informational
+  # message is emitted rather than producing an unresolvable path.
+  data <- list(
+    Version = 79,
+    Compounds = list(list(Name = "DrugA"), list(Name = "DrugB")),
+    Simulations = list(list(
+      Name = "Sim",
+      Parameters = list(
+        list(
+          Path = "Sim|Organism|Kidney|GlomerularFiltration|Plasma clearance",
+          Value = 1
+        )
+      )
+    ))
+  )
+
+  expect_snapshot(snapshot <- Snapshot$new(data))
+  expect_equal(
+    snapshot$data$Simulations[[1]]$Parameters[[1]]$Path,
+    "Sim|Organism|Kidney|GlomerularFiltration|Plasma clearance"
+  )
+})
+
 test_that("Snapshot round-trip preserves localized parameters in Individuals", {
   snapshot <- test_snapshot$clone()
   temp_file <- withr::local_tempfile(fileext = ".json")

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -7,19 +7,10 @@ test_that("Snapshot class works", {
   expect_type(snapshot$data, "list")
   expect_false(is.null(snapshot$path))
 
-  # Test pksim_version mapping
-  if (!is.null(snapshot$data$Version)) {
-    raw_version <- as.integer(snapshot$data$Version)
-    expected_version <- switch(
-      as.character(raw_version),
-      "80" = "12.0",
-      "79" = "11.2",
-      "78" = "10.0",
-      "77" = "9.1",
-      "Unknown"
-    )
-    expect_equal(snapshot$pksim_version, expected_version)
-  }
+  # The v79 fixture is normalized to the current version on load, so both the
+  # reported version and its human-readable mapping reflect v12.
+  expect_equal(snapshot$data$Version, 80L)
+  expect_equal(snapshot$pksim_version, "12.0")
 
   # Test that snapshot has basic structure
   expect_true(
@@ -163,8 +154,9 @@ test_that("Snapshot data can be exported and reimported", {
   snapshot2 <- Snapshot$new(exported_data)
 
   # Use a more targeted approach to verify critical parts of the data
-  # Check version
-  expect_equal(snapshot$data$Version, snapshot2$data$Version)
+  # Both sides are normalized to the current version on load.
+  expect_equal(snapshot$data$Version, 80L)
+  expect_equal(snapshot2$data$Version, 80L)
 
   # Check Compounds if they exist
   if (!is.null(snapshot$data$Compounds)) {
@@ -215,6 +207,186 @@ test_that("Snapshot data can be exported and reimported", {
       )
     }
   }
+})
+
+# Version normalization on load ------------------------------------------------
+
+test_that("Loading and exporting the v79 fixture yields Version = 80", {
+  snapshot <- test_snapshot$clone()
+  temp_file <- withr::local_tempfile(fileext = ".json")
+  snapshot$export(temp_file)
+
+  exported_data <- jsonlite::fromJSON(
+    temp_file,
+    simplifyDataFrame = FALSE,
+    simplifyVector = FALSE
+  )
+  expect_equal(as.integer(exported_data$Version), 80L)
+})
+
+test_that("Applications is rewritten to Events in exported simulation paths", {
+  # The fixture's simulation parameters carry pre-v11 `Applications|...` paths
+  # on disk; after load and export every one must read `Events|...`.
+  snapshot <- test_snapshot$clone()
+  temp_file <- withr::local_tempfile(fileext = ".json")
+  snapshot$export(temp_file)
+
+  exported_data <- jsonlite::fromJSON(
+    temp_file,
+    simplifyDataFrame = FALSE,
+    simplifyVector = FALSE
+  )
+
+  exported_paths <- unlist(lapply(
+    exported_data$Simulations,
+    \(sim) {
+      vapply(
+        sim$Parameters %||% list(),
+        \(p) p$Path %||% NA_character_,
+        character(1)
+      )
+    }
+  ))
+  application_paths <- Filter(
+    \(path) startsWith(path, "Applications|"),
+    exported_paths
+  )
+  expect_length(application_paths, 0)
+})
+
+test_that("Non-container words in parameter paths are left unchanged on load", {
+  # `Kidney` (an organ) and `GFR (specific)` (a parameter) merely relate to
+  # the kidney; neither is a renal-clearance container segment to rename.
+  snapshot <- test_snapshot$clone()
+  temp_file <- withr::local_tempfile(fileext = ".json")
+  snapshot$export(temp_file)
+
+  exported_data <- jsonlite::fromJSON(
+    temp_file,
+    simplifyDataFrame = FALSE,
+    simplifyVector = FALSE
+  )
+
+  individual_paths <- unlist(lapply(
+    exported_data$Individuals,
+    \(ind) {
+      vapply(
+        ind$Parameters %||% list(),
+        \(p) p$Path %||% NA_character_,
+        character(1)
+      )
+    }
+  ))
+  expect_true("Organism|Kidney|GFR (specific)" %in% individual_paths)
+})
+
+test_that("ParameterIdentifications without renal paths round-trip unchanged", {
+  # The fixture's single ParameterIdentification has an empty `Simulations`
+  # array and no `IdentificationParameters`; normalization must preserve it.
+  snapshot <- test_snapshot$clone()
+  temp_file <- withr::local_tempfile(fileext = ".json")
+  snapshot$export(temp_file)
+
+  exported_data <- jsonlite::fromJSON(
+    temp_file,
+    simplifyDataFrame = FALSE,
+    simplifyVector = FALSE
+  )
+
+  original <- test_snapshot$.__enclos_env__$private$.original_data
+  expect_equal(
+    exported_data$ParameterIdentifications,
+    original$ParameterIdentifications
+  )
+})
+
+test_that("A v80 snapshot round-trips its parameter paths unchanged", {
+  # An already-current snapshot has no bare renal container segment to rename,
+  # so load then export must leave every path untouched (structural no-op).
+  data <- list(
+    Version = 80,
+    Compounds = list(list(Name = "Drug")),
+    Simulations = list(list(
+      Name = "Sim",
+      Parameters = list(
+        list(
+          Path = "Sim|Organism|Kidney|Drug|GlomerularFiltration-Drug|Plasma clearance",
+          Value = 1
+        ),
+        list(Path = "Sim|Organism|Liver|Volume", Value = 2)
+      )
+    ))
+  )
+  snapshot <- Snapshot$new(data)
+
+  exported_paths <- vapply(
+    snapshot$data$Simulations[[1]]$Parameters,
+    \(p) p$Path,
+    character(1)
+  )
+  expect_equal(
+    exported_paths,
+    c(
+      "Sim|Organism|Kidney|Drug|GlomerularFiltration-Drug|Plasma clearance",
+      "Sim|Organism|Liver|Volume"
+    )
+  )
+  expect_equal(snapshot$data$Version, 80L)
+})
+
+test_that("ParameterIdentifications linked renal paths are renamed on load", {
+  # `IdentificationParameter.LinkedParameters` are full parameter paths that
+  # flow through verbatim; the renal rename and Applications->Events rewrite
+  # must reach them.
+  data <- list(
+    Version = 79,
+    Compounds = list(list(Name = "Drug")),
+    ParameterIdentifications = list(list(
+      Name = "Parameter Identification 1",
+      Simulations = list(),
+      IdentificationParameters = list(list(
+        Name = "GFR fraction",
+        LinkedParameters = list(
+          "Sim1|Organism|Kidney|Drug|GlomerularFiltration|Plasma clearance",
+          "Sim1|Organism|Liver|Volume"
+        )
+      ))
+    ))
+  )
+  snapshot <- Snapshot$new(data)
+
+  linked <- snapshot$data$ParameterIdentifications[[
+    1
+  ]]$IdentificationParameters[[1]]$LinkedParameters
+  expect_equal(
+    unlist(linked),
+    c(
+      "Sim1|Organism|Kidney|Drug|GlomerularFiltration-Drug|Plasma clearance",
+      "Sim1|Organism|Liver|Volume"
+    )
+  )
+  expect_equal(snapshot$data$Version, 80L)
+})
+
+test_that("ParameterIdentifications with no renal container only bump the version", {
+  data <- list(
+    Version = 79,
+    Compounds = list(list(Name = "Drug")),
+    ParameterIdentifications = list(list(
+      Name = "PI",
+      IdentificationParameters = list(list(
+        Name = "P1",
+        LinkedParameters = list("Sim1|Organism|Liver|Volume")
+      ))
+    ))
+  )
+  snapshot <- Snapshot$new(data)
+
+  linked <- snapshot$data$ParameterIdentifications[[
+    1
+  ]]$IdentificationParameters[[1]]$LinkedParameters
+  expect_equal(unlist(linked), "Sim1|Organism|Liver|Volume")
+  expect_equal(snapshot$data$Version, 80L)
 })
 
 test_that("Snapshot round-trip preserves observed data and expression profile shape", {
@@ -597,22 +769,15 @@ test_that("Snapshot$export creates a valid JSON file", {
   expect_length(json_data$Individuals, 0)
 })
 
-test_that("Snapshot correctly handles version mapping for all known versions", {
-  versions <- list(
-    "80" = "12.0",
-    "79" = "11.2"
-  )
-
-  for (v in names(versions)) {
-    snapshot_data <- list(Version = as.numeric(v))
-    snapshot <- Snapshot$new(snapshot_data)
-    expect_equal(snapshot$pksim_version, versions[[v]])
+test_that("Loaded snapshots report the current version after normalization", {
+  # Normalization pins every accepted snapshot to the current version on load,
+  # so `pksim_version` reports "12.0" regardless of the file's original
+  # declared version (a v79 file, or an unrecognised-but-supported v999 file).
+  for (raw_version in c(79, 80, 999)) {
+    snapshot <- Snapshot$new(list(Version = raw_version))
+    expect_equal(snapshot$data$Version, 80L)
+    expect_equal(snapshot$pksim_version, "12.0")
   }
-
-  # Newer (unrecognised but supported) version maps to "Unknown".
-  snapshot_data <- list(Version = 999)
-  snapshot <- Snapshot$new(snapshot_data)
-  expect_equal(snapshot$pksim_version, "Unknown")
 })
 
 test_that("Snapshot rejects pre-v11 snapshots", {


### PR DESCRIPTION
Closes #155

Normalize a loaded snapshot to the current PK-Sim version (`Version = 80`, v12) in memory at load time, so the whole in-memory model and every export are one coherent current-format snapshot. Previously the package kept the loaded file's declared `Version` verbatim while its block classes only ever emitted the current structure, so editing a loaded v11 (`Version = 79`) file produced a mixed-version export: untouched sections replayed in v79 shape, edited sections in v80 shape, under a single declared version that PK-Sim mis-migrates. Normalizing on load removes that mismatch regardless of which sections the user edits.

## Load-time normalization

A new internal file `R/normalize-snapshot.R` provides `normalize_snapshot_to_current(data)`, hooked into `Snapshot$initialize()` immediately after `.validate_version()` and before any lazy block cache is built. Operating on `private$.original_data` up front means both R6-wrapped sections (simulations, individuals, populations) and verbatim-passthrough sections (`ParameterIdentifications`, `Version`) are normalized uniformly, so no mixed-version file can form. The version floor is unchanged: `Version < 79` still aborts, and `create_snapshot()` (already `Version = 80` with no parameter paths) passes through as a no-op.

Normalization applies the v11-to-v12 delta in two parts and then sets `Version = 80L`:

- The existing `Applications` to `Events` path rewrite (`migrate_applications_to_events()`) is reused here so it now also reaches `ParameterIdentifications` linked-parameter paths, which never pass through `LocalizedParameter`.
- Renal-clearance process containers (`GlomerularFiltration`, `RenalClearance`) are qualified with their owning compound name wherever they appear as a whole pipe-separated path segment, across localized-parameter paths and `IdentificationParameter.LinkedParameters` paths.

The step is idempotent: an already-v80 file has no bare renal container segment left to rename and its `Applications` are already `Events`, so only `Version = 80` is reaffirmed.

## Renal-clearance container rename

The owning compound is resolved per path segment: first by adjacent-segment match (a renal-clearance container is a child of the compound node, so the immediately preceding segment is the compound name when it matches a known compound), then by single-compound fallback when the snapshot has exactly one compound. When neither resolves (ambiguous adjacent segment with two or more compounds), the segment is left unchanged and one informational message names the path, mirroring the package's existing non-destructive posture rather than producing an unresolvable path. Matching is on whole segments only, so substrings such as `MyGlomerularFiltrationX`, an organ segment like `Kidney`, and a parameter name like `GFR (specific)` are left untouched.

The exact rename form (`GlomerularFiltration` becomes `GlomerularFiltration-<Compound>`, joined by a hyphen) is isolated in the single helper `rename_renal_container_segment()`, asserted by one clearly-labelled expected-string test.

Unverified against PK-Sim (single point to revisit): the hyphen-join glue is the planner's best-grounded form but could not be pinned from this repository. PK-Sim's v11-to-v12 mapper output is not in the repo, and the v79 fixture carries no renal-clearance container path segment to anchor against (its only `GlomerularFiltration` occurrence is a compound-level process `InternalName`, not a path segment). PK-Sim resolves the path literally, so if it rejects `GlomerularFiltration-<Compound>` the correct glue must be confirmed against a real PK-Sim v11 snapshot re-exported from v12 (or the PK-Sim `MapToModel` mapper source). Only `rename_renal_container_segment()` and its one expected-string test would then need to change.

## Version reporting

Because `pksim_version` reads the effective version and normalization sets it to `80`, a loaded v79 file now reports `"12.0"` rather than `"11.2"`. This is the intended consequence of normalize-on-load: the in-memory snapshot is a v12-structured snapshot. The version-to-string mapping itself (`.get_pksim_version()`) is unchanged.

## Tests and documentation

- `tests/testthat/test-snapshot.R`: flipped the version-contract assertions in the class and round-trip tests to the new contract (`Version = 80`, `pksim_version = "12.0"`); replaced the raw-version mapping test with one that pins the post-load contract across v79, v80, and an unrecognised v999 (all report `"12.0"` after normalization); and added coverage for load-then-export yielding `Version = 80`, `Applications` becoming `Events` end to end in exported simulation paths, non-container words left unchanged, an already-v80 no-op round-trip, `ParameterIdentifications` linked renal paths renamed on load, and a no-renal `ParameterIdentifications` that only bumps the version.
- `tests/testthat/test-LocalizedParameter.R`: added snapshot-level renal-rename coverage on simulation, individual, and population base-individual paths; whole-segment (non-substring) safety; and the defensive ambiguous-compound case that leaves the segment intact and emits the informational message.
- The `Snapshot` class documentation gained a "Snapshot version normalization" section; `NEWS.md` gained a development-version bullet.

Verification (all with `NOT_CRAN=true`): `test-LocalizedParameter.R` (117 pass), `test-snapshot.R` (253 pass, 0 fail), the filtered mid-scope run `snapshot|LocalizedParameter|create_snapshot|range|Protocol` (611 pass), and the full suite `devtools::test()` (3080 pass, 0 fail). The single reported warning is a pre-existing intentional test of the template-not-found path in `osp_models()`, unrelated to this change. `devtools::document()` regenerated `man/Snapshot.Rd`; `NAMESPACE` is unchanged (no new exports).

# QA: Approved

The implementation normalizes loaded snapshots to `Version = 80` at load time exactly as the spec and plan require, hooking `normalize_snapshot_to_current()` into `Snapshot$initialize()` right after `.validate_version()` and operating on `.original_data` so both R6-wrapped sections and verbatim-passthrough `ParameterIdentifications` are covered uniformly. All nine acceptance criteria map to direct evidence in the diff and to genuinely covering tests; the full suite passes (3080 pass, 0 fail, 1 pre-existing unrelated warning) under `NOT_CRAN=true`. The one residual risk (the exact hyphen glue of the renal rename) is correctly isolated in a single helper with a single expected-string test, as the spec and plan explicitly accept.

<details>
<summary>Full QA report</summary>

## What I checked

I read `spec.md`, `plan.md`, and `build.md`, reviewed the full `gh pr diff 159`, and cross-checked the implementation against the live code in the worktree (`R/Snapshot.R`, `R/LocalizedParameter.R`, `R/Population.R`, `R/normalize-snapshot.R`). I ran the two focused test files and the full suite read-only with `NOT_CRAN=true`.

Verification runs:
- `test-LocalizedParameter.R`: 117 pass, 0 fail (via `test_file`).
- `test-snapshot.R`: 253 pass, 0 fail, 1 warning.
- Full suite `devtools::test()`: 3080 pass, 0 fail, 1 warning, 0 skip.

The single warning is the pre-existing intentional `osp_models()` template-not-found test (`test-snapshot.R:927`), unrelated to this change, matching the build summary.

## Architecture verification

- The hook is placed in `Snapshot$initialize()` immediately after `private$.validate_version()` and before any lazy cache is built, mutating `private$.original_data` (diff `R/Snapshot.R` lines 100-111). Confirmed the version floor still rejects `Version < 79` before any rewrite runs.
- Confirmed `Version` is not in `private$.export_adapters` (list at `R/Snapshot.R:936-977`) and `.get_pksim_version()` reads `private$.original_data$Version`, so setting `.original_data$Version <- 80L` is the correct single point that makes both the `data` binding and `pksim_version` report v12 (FR-1a).
- Confirmed `ParameterIdentifications` is not in `.export_adapters` and not wrapped by any R6 class, so it flows through verbatim; rewriting it in `.original_data` is the only way to cover it (FR-2b). Correct.
- Confirmed the lazy block caches are built from `private$.original_data[[section]]` (`.ensure_collection`, `R/Snapshot.R:998-1008`), so blocks wrap already-normalized paths. No double-rewrite hazard: `Applications` is gone before `LocalizedParameter$new()` re-runs `migrate_applications_to_events()` (no-op), and the renal rename is idempotent (a renamed segment no longer equals the bare container name).
- Confirmed the population walker path `Populations[[i]]$Settings$Individual$Parameters` matches how `Population$individual` reads `private$.data$Settings$Individual` (`R/Population.R:334-342`); `Population$initialize` stores raw `data` and does not re-wrap base-individual parameters, so normalizing them in `.original_data` up front is what reaches export.

## Acceptance criteria

1. Load v79 fixture then export yields `Version = 80` — PASS. `normalize_snapshot_to_current()` sets `data$Version <- 80L`; test "Loading and exporting the v79 fixture yields Version = 80" reads the exported JSON and asserts `as.integer(Version) == 80`.
2. Renal-clearance container rename across localized paths (simulations/individuals/populations) AND `IdentificationParameter.LinkedParameters` — PASS. Walkers `normalize_localized_parameter_paths()` and `normalize_identification_parameter_paths()` cover all four locations. Tests assert the renamed segment on simulation, individual, population base-individual, and linked-parameter paths (e.g. `GlomerularFiltration-Drug`, `RenalClearance-Drug`). The fixture itself carries no renal container segment (correctly per the plan's fixture audit), so the positive cases are pinned with hand-rolled snapshots, exactly as the spec's testing surface prescribes.
3. Already-v80 no-op round-trip — PASS. Test "A v80 snapshot round-trips its parameter paths unchanged" loads a v80 snapshot whose renal segment is already `GlomerularFiltration-Drug`; no bare container matches, paths unchanged, `Version` stays `80L`.
4. Non-renal path unchanged except version — PASS. Covered by the v80 round-trip (`Sim|Organism|Liver|Volume` untouched) and the no-renal `ParameterIdentifications` test (only version bumps).
5. Segment-safe / non-container words left unchanged — PASS. `rename_renal_containers_in_path()` splits on `|` and matches whole segments with `%in%`; test "Renal rename matches whole segments, not substrings" asserts `Kidney`, `GFR (specific)`, and the substring `MyGlomerularFiltrationX` are untouched. The observed-data path family is out of scope and not walked.
6. `Applications` -> `Events` still holds and now reaches identification-parameter paths — PASS. `normalize_parameter_path()` runs `migrate_applications_to_events()` first for both localized and linked paths. Test "Applications is rewritten to Events in exported simulation paths" asserts zero `Applications|` paths remain after export of the fixture (whose simulation params are `Applications|...` on disk). Linked-parameter reach is exercised by the `ParameterIdentifications` rename test.
7. `Version < 79` still aborts — PASS. `.validate_version()` unchanged; test "Snapshot rejects pre-v11 snapshots" (`Version = 78`) plus missing/non-integer version tests intact; normalization runs strictly after validation.
8. NEWS.md bullet — PASS. Single line under `# osp.snapshots (development version)`, present tense, positive framing, backticked identifiers, `(#155)` before the period. It is a load-behaviour change with no single leading function name, so being the first/only dev bullet is appropriate.
9. Full suite passes with `NOT_CRAN=true` — PASS (3080/0).

## FR-2c / FR-2d compound resolution

- `resolve_renal_compound()` implements the adjacent-segment-primary rule, then single-compound fallback, then `NA` (undeterminable). Ordering is correct: adjacent match wins even in multi-compound snapshots.
- FR-2d defensive case: on `NA`, the segment is left unchanged and one `cli::cli_alert_info()` names the path. Test "Renal rename leaves the segment unchanged when the compound is ambiguous" (two compounds, non-matching adjacent segment) asserts both the unchanged path and the informational message via `expect_snapshot()`. The recorded message is clean and uses a semicolon (no dash-as-punctuation).

## Isolation of the unverified glue (accepted residual risk)

The exact rename form lives solely in `rename_renal_container_segment()` as `paste0(segment, "-", compound_name)`, asserted by expected-string tests. This matches the spec's (FR-2c/FR-2e) and plan's explicit treatment of the hyphen glue as a best-grounded, build-time-verification form isolated in one helper. If PK-Sim's mapper uses a different separator, only that one function and its expected-string tests change. Evaluated as designed; noted as a residual risk, not a blocking defect (per the reviewer instruction).

## Conventions and hygiene

- New file uses the base pipe (no `%>%`), `\()` for the single one-line lambda, `function() {}` for multi-line lambdas, entry point first then helpers.
- `NAMESPACE` has no delta and none of the new helpers are exported (internal, as the spec's Non-goals require).
- Only `man/Snapshot.Rd` changed, matching the single roxygen edit; consistent with `devtools::document()` output (no hand edits to `man/` or `NAMESPACE`).
- Files changed match the plan's dependency-ordered list exactly; no stray edits to unrelated block classes, verbs, or export adapters.
- The stale version-contract tests were correctly flipped to the new contract (`Version = 80`, `pksim_version = "12.0"`), including the previously-`"Unknown"` v999 case now correctly reporting `"12.0"` after normalization, and the `_snaps/snapshot.md` header updated from `79 (PKSIM 11.2)` to `80 (PKSIM 12.0)`.

## Adversarial / edge-case findings

- No silent-corruption path found: whole-segment matching plus the `NA`-safe resolve/leave-unchanged posture mirror `migrate_applications_to_events()`.
- `create_snapshot()` output (`list(Version = 80)`, no compounds/paths) passes through as a clean no-op; the only effect is tightening `80` to `80L`, which is harmless and intended.
- Empty/absent guards verified at every walker level (`Compounds`, `Parameters`, `ParameterIdentifications`, `IdentificationParameters`, `LinkedParameters`), so minimal and hand-rolled snapshots pass through cleanly.
- No blocking issues identified.

</details>

<!-- QA-VERDICT: approved -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Loaded snapshots are automatically updated to the current PK-Sim format (Version 80 / v12).
  * Legacy parameter paths are updated across simulations, individuals, populations, and parameter identifications.
  * Renal-clearance paths are qualified with the relevant compound when it can be identified.

* **Bug Fixes**
  * Snapshot exports now consistently report Version 80.
  * Ambiguous renal-clearance paths remain unchanged with an informational message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->