### PR TITLE
Emit Species on fraction-unbound alternative (#156)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # osp.snapshots (development version)
 
+- `fraction_unbound()` gains a `species` argument (default `"Human"`, validated against `ospsuite::Species`) and now emits a `Species` field on the fraction-unbound alternative, which PK-Sim requires to load the snapshot (#156).
+
 # osp.snapshots 1.0.0
 
 ## Breaking changes

--- a/R/create_compound.R
+++ b/R/create_compound.R
@@ -317,14 +317,22 @@ create_compound <- function(
 # alternative array via `build_single_param_alternative()`. Shared by the
 # factory and the `Compound` writable-field setter so the unwrapping lives in
 # one place. `spec$unit` is `NULL` for fraction unbound (no unit slot), which
-# the builder treats as "omit unit".
+# the builder treats as "omit unit". Fraction unbound is the one
+# species-dependent single-parameter group, so a `fraction_unbound_spec`
+# additionally carries its `species` onto the alternative as a `Species` key
+# (PK-Sim rejects a fraction-unbound alternative without a resolvable species);
+# the other groups pass through unchanged.
 spec_to_single_param_alternative <- function(spec, param_name) {
-  build_single_param_alternative(
+  alt <- build_single_param_alternative(
     spec$name,
     param_name,
     spec$value,
     spec$unit
   )
+  if (inherits(spec, "fraction_unbound_spec")) {
+    alt[[1]]$Species <- spec$species
+  }
+  alt
 }
 
 # Internal: unwrap a `solubility_spec` into its `Solubility` alternative,

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,8 +11,9 @@
 validate_unit <- function(unit, dimension) {
   valid_units <- tryCatch(
     ospsuite::getUnitsForDimension(dimension),
-    error = function(e)
+    error = function(e) {
       unlist(ospsuite::ospUnits[[dimension]], use.names = FALSE)
+    }
   )
   if (!(unit %in% valid_units)) {
     cli::cli_abort(
@@ -31,10 +32,16 @@ validate_unit <- function(unit, dimension) {
 #' Check if a species is valid using ospsuite Species enum.
 #' Throws an error if the species is invalid.
 #'
-#' @param species Species value to validate
+#' @param species Species value to validate. Must be a single, non-`NA`
+#'   value.
 #' @return TRUE if valid, throws an error if invalid
 #' @export
 validate_species <- function(species) {
+  if (length(species) != 1L || is.na(species)) {
+    cli::cli_abort(
+      "{.arg species} must be a single, non-missing value"
+    )
+  }
   valid_species <- ospsuite::Species
   if (!species %in% valid_species) {
     cli::cli_abort(

--- a/R/value_specs.R
+++ b/R/value_specs.R
@@ -90,6 +90,10 @@ lipophilicity <- function(
 #' `"Fraction unbound (plasma, reference value)"`. Fraction unbound stores a
 #' bare value with no unit, so this helper takes no `unit` argument.
 #'
+#' Fraction unbound is the one species-dependent single-parameter group, so
+#' the emitted alternative carries a `Species` field (see `species`), which
+#' PK-Sim requires to load the snapshot.
+#'
 #' @param value Numeric scalar. Fraction-unbound value.
 #' @param name Character. `Name` of the created alternative. Defaults to
 #'   `"User defined"`.
@@ -100,6 +104,13 @@ lipophilicity <- function(
 #'   default. When a list has no element marked `default = TRUE`, the first
 #'   element is the default (unchanged behaviour); marking two or more
 #'   elements `default = TRUE` in the same list is an error.
+#' @param species Character. PK-Sim species emitted as the alternative's
+#'   `Species` field. Defaults to `"Human"` and is validated against
+#'   `ospsuite::Species`. Fraction unbound is species-dependent, and PK-Sim
+#'   rejects a snapshot whose fraction-unbound alternative has no resolvable
+#'   species, so this is emitted on every fraction-unbound alternative. A
+#'   user hand-building a raw alternative list (the `Compound$fraction_unbound`
+#'   escape hatch) is responsible for its own `Species`.
 #'
 #' @return A `fraction_unbound_spec` object to pass to [create_compound()].
 #' @family value-object helpers
@@ -118,16 +129,23 @@ lipophilicity <- function(
 #'     fraction_unbound(0.2, name = "Microsomal", default = TRUE)
 #'   )
 #' )
-fraction_unbound <- function(value, name = "User defined", default = FALSE) {
+fraction_unbound <- function(
+  value,
+  name = "User defined",
+  default = FALSE,
+  species = "Human"
+) {
   check_numeric_scalar(value, "value")
   check_required_string(name, "name")
   check_default_flag(default, "default")
+  validate_species(species)
   new_value_spec(
     "fraction_unbound_spec",
     list(
       value = value,
       name = name,
-      default = default
+      default = default,
+      species = species
     )
   )
 }

--- a/man/fraction_unbound.Rd
+++ b/man/fraction_unbound.Rd
@@ -4,7 +4,12 @@
 \alias{fraction_unbound}
 \title{Fraction unbound value object}
 \usage{
-fraction_unbound(value, name = "User defined", default = FALSE)
+fraction_unbound(
+  value,
+  name = "User defined",
+  default = FALSE,
+  species = "Human"
+)
 }
 \arguments{
 \item{value}{Numeric scalar. Fraction-unbound value.}
@@ -19,6 +24,14 @@ Ignored for a single (non-list) value object, which is always the
 default. When a list has no element marked \code{default = TRUE}, the first
 element is the default (unchanged behaviour); marking two or more
 elements \code{default = TRUE} in the same list is an error.}
+
+\item{species}{Character. PK-Sim species emitted as the alternative's
+\code{Species} field. Defaults to \code{"Human"} and is validated against
+\code{ospsuite::Species}. Fraction unbound is species-dependent, and PK-Sim
+rejects a snapshot whose fraction-unbound alternative has no resolvable
+species, so this is emitted on every fraction-unbound alternative. A
+user hand-building a raw alternative list (the \code{Compound$fraction_unbound}
+escape hatch) is responsible for its own \code{Species}.}
 }
 \value{
 A \code{fraction_unbound_spec} object to pass to \code{\link[=create_compound]{create_compound()}}.
@@ -29,6 +42,10 @@ Build a fraction-unbound value object for \code{\link[=create_compound]{create_c
 field). Produces one default \code{FractionUnbound} alternative with parameter
 \code{"Fraction unbound (plasma, reference value)"}. Fraction unbound stores a
 bare value with no unit, so this helper takes no \code{unit} argument.
+
+Fraction unbound is the one species-dependent single-parameter group, so
+the emitted alternative carries a \code{Species} field (see \code{species}), which
+PK-Sim requires to load the snapshot.
 }
 \examples{
 fraction_unbound(0.1)

--- a/man/validate_species.Rd
+++ b/man/validate_species.Rd
@@ -7,7 +7,8 @@
 validate_species(species)
 }
 \arguments{
-\item{species}{Species value to validate}
+\item{species}{Species value to validate. Must be a single, non-\code{NA}
+value.}
 }
 \value{
 TRUE if valid, throws an error if invalid

--- a/tests/testthat/_snaps/create_compound.md
+++ b/tests/testthat/_snaps/create_compound.md
@@ -150,6 +150,15 @@
 ---
 
     Code
+      fraction_unbound(1, species = "Klingon")
+    Condition
+      Error in `validate_species()`:
+      ! Invalid species: Klingon
+      i Valid species are: Beagle, Dog, Human, Minipig, Monkey, Mouse, Rabbit, Rat
+
+---
+
+    Code
       solubility("a")
     Condition
       Error in `solubility()`:

--- a/tests/testthat/_snaps/create_compound.md
+++ b/tests/testthat/_snaps/create_compound.md
@@ -159,6 +159,14 @@
 ---
 
     Code
+      fraction_unbound(1, species = c("Human", "Dog"))
+    Condition
+      Error in `validate_species()`:
+      ! `species` must be a single, non-missing value
+
+---
+
+    Code
       solubility("a")
     Condition
       Error in `solubility()`:

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -1,0 +1,16 @@
+# validate_species rejects a non-scalar or empty species with a clear message
+
+    Code
+      validate_species(c("Human", "Dog"))
+    Condition
+      Error in `validate_species()`:
+      ! `species` must be a single, non-missing value
+
+---
+
+    Code
+      validate_species(character(0))
+    Condition
+      Error in `validate_species()`:
+      ! `species` must be a single, non-missing value
+

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -14,3 +14,11 @@
       Error in `validate_species()`:
       ! `species` must be a single, non-missing value
 
+---
+
+    Code
+      validate_species(NA_character_)
+    Condition
+      Error in `validate_species()`:
+      ! `species` must be a single, non-missing value
+

--- a/tests/testthat/_snaps/value_specs.md
+++ b/tests/testthat/_snaps/value_specs.md
@@ -30,6 +30,9 @@
       $default
       [1] FALSE
       
+      $species
+      [1] "Human"
+      
 
 ---
 

--- a/tests/testthat/test-Compound.R
+++ b/tests/testthat/test-Compound.R
@@ -220,6 +220,7 @@ test_that("single-parameter physicochemical fields are writable by helper", {
   fu <- compound$data$FractionUnbound[[1]]$Parameters[[1]]
   expect_equal(fu$Value, 0.2)
   expect_null(fu$Unit)
+  expect_equal(compound$data$FractionUnbound[[1]]$Species, "Human")
 
   compound$solubility <- solubility(500)
   sol <- compound$data$Solubility[[1]]$Parameters[[1]]
@@ -231,6 +232,13 @@ test_that("single-parameter physicochemical fields are writable by helper", {
   ip <- compound$data$IntestinalPermeability[[1]]$Parameters[[1]]
   expect_equal(ip$Value, 2e-05)
   expect_equal(ip$Unit, "cm/min")
+})
+
+test_that("fraction_unbound field setter carries the species override", {
+  compound <- test_snapshot$clone()$compounds[[1]]$clone(deep = TRUE)
+
+  compound$fraction_unbound <- fraction_unbound(1, species = "Rat")
+  expect_equal(compound$data$FractionUnbound[[1]]$Species, "Rat")
 })
 
 test_that("permeability field reads and writes on a compound without the key", {

--- a/tests/testthat/test-create_compound.R
+++ b/tests/testthat/test-create_compound.R
@@ -571,6 +571,10 @@ test_that("physicochemical helpers reject non-numeric values", {
   expect_snapshot(error = TRUE, lipophilicity("a"))
   expect_snapshot(error = TRUE, fraction_unbound("a"))
   expect_snapshot(error = TRUE, fraction_unbound(1, species = "Klingon"))
+  expect_snapshot(
+    error = TRUE,
+    fraction_unbound(1, species = c("Human", "Dog"))
+  )
   expect_snapshot(error = TRUE, solubility("a"))
   expect_snapshot(error = TRUE, solubility(9999, reference_pH = "a"))
   expect_snapshot(error = TRUE, solubility(9999, gain_per_charge = "a"))

--- a/tests/testthat/test-create_compound.R
+++ b/tests/testthat/test-create_compound.R
@@ -83,10 +83,20 @@ test_that("create_compound sets a fraction unbound alternative without a unit", 
     fraction_unbound = fraction_unbound(1)
   )
 
-  param <- compound$data$FractionUnbound[[1]]$Parameters[[1]]
+  alt <- compound$data$FractionUnbound[[1]]
+  param <- alt$Parameters[[1]]
   expect_equal(param$Name, "Fraction unbound (plasma, reference value)")
   expect_equal(param$Value, 1)
   expect_null(param$Unit)
+  expect_equal(alt$Species, "Human")
+})
+
+test_that("fraction_unbound species defaults to Human and can be overridden", {
+  compound <- create_compound(
+    name = "X",
+    fraction_unbound = fraction_unbound(1, species = "Rat")
+  )
+  expect_equal(compound$data$FractionUnbound[[1]]$Species, "Rat")
 })
 
 test_that("create_compound bundles reference pH and gain per charge into solubility", {
@@ -279,6 +289,10 @@ test_that("create_compound accepts a list of alternatives for lipophilicity, fra
   expect_equal(
     vapply(compound$data$FractionUnbound, `[[`, character(1), "Name"),
     c("Plasma", "Microsomal")
+  )
+  expect_equal(
+    vapply(compound$data$FractionUnbound, `[[`, character(1), "Species"),
+    c("Human", "Human")
   )
   expect_equal(
     vapply(compound$data$IntestinalPermeability, `[[`, character(1), "Name"),
@@ -525,9 +539,38 @@ test_that("create_compound attaches processes", {
   )
 })
 
+test_that("only fraction unbound gains a Species key", {
+  compound <- create_compound(
+    name = "X",
+    lipophilicity = lipophilicity(2.5),
+    intestinal_permeability = intestinal_permeability(1.14e-05),
+    permeability = permeability(0.0069)
+  )
+  expect_false("Species" %in% names(compound$data$Lipophilicity[[1]]))
+  expect_false("Species" %in% names(compound$data$IntestinalPermeability[[1]]))
+  expect_false("Species" %in% names(compound$data$Permeability[[1]]))
+})
+
+test_that("solubility alternatives gain no Species key (scalar and table)", {
+  scalar <- create_compound(
+    name = "X",
+    solubility = solubility(9999, reference_pH = 7)
+  )
+  expect_false("Species" %in% names(scalar$data$Solubility[[1]]))
+
+  tbl <- create_compound(
+    name = "X",
+    solubility = solubility(
+      table = data.frame(pH = c(3, 6), value = c(5000, 90))
+    )
+  )
+  expect_false("Species" %in% names(tbl$data$Solubility[[1]]))
+})
+
 test_that("physicochemical helpers reject non-numeric values", {
   expect_snapshot(error = TRUE, lipophilicity("a"))
   expect_snapshot(error = TRUE, fraction_unbound("a"))
+  expect_snapshot(error = TRUE, fraction_unbound(1, species = "Klingon"))
   expect_snapshot(error = TRUE, solubility("a"))
   expect_snapshot(error = TRUE, solubility(9999, reference_pH = "a"))
   expect_snapshot(error = TRUE, solubility(9999, gain_per_charge = "a"))

--- a/tests/testthat/test-create_snapshot.R
+++ b/tests/testthat/test-create_snapshot.R
@@ -54,12 +54,16 @@ test_that("create_snapshot result composes with add_*() mutators", {
 })
 
 test_that("validate_snapshot accepts a snapshot with a fraction-unbound compound", {
-  s <- add_compound(
-    create_snapshot(),
-    create_compound(name = "Drug X", fraction_unbound = fraction_unbound(1))
+  compound <- create_compound(
+    name = "Drug X",
+    fraction_unbound = fraction_unbound(1)
   )
+  s <- add_compound(create_snapshot(), compound)
 
   expect_true(validate_snapshot(s))
+  # validate_snapshot() passes even when Species is absent, so assert the
+  # emitted fraction-unbound alternative actually carries the species.
+  expect_equal(compound$data$FractionUnbound[[1]]$Species, "Human")
 })
 
 test_that("create_snapshot rejects non-scalar or non-character arguments", {

--- a/tests/testthat/test-create_snapshot.R
+++ b/tests/testthat/test-create_snapshot.R
@@ -53,6 +53,15 @@ test_that("create_snapshot result composes with add_*() mutators", {
   expect_true("Drug X" %in% names(s$compounds))
 })
 
+test_that("validate_snapshot accepts a snapshot with a fraction-unbound compound", {
+  s <- add_compound(
+    create_snapshot(),
+    create_compound(name = "Drug X", fraction_unbound = fraction_unbound(1))
+  )
+
+  expect_true(validate_snapshot(s))
+})
+
 test_that("create_snapshot rejects non-scalar or non-character arguments", {
   expect_snapshot(error = TRUE, create_snapshot(name = 1))
   expect_snapshot(error = TRUE, create_snapshot(name = c("a", "b")))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -28,6 +28,7 @@ test_that("validate_species accepts a valid scalar species", {
 test_that("validate_species rejects a non-scalar or empty species with a clear message", {
   expect_snapshot(error = TRUE, validate_species(c("Human", "Dog")))
   expect_snapshot(error = TRUE, validate_species(character(0)))
+  expect_snapshot(error = TRUE, validate_species(NA_character_))
 })
 
 test_that("convert_ospsuite_time_unit_to_lubridate works correctly", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -21,6 +21,15 @@ test_that("validate_unit rejects invalid units", {
   )
 })
 
+test_that("validate_species accepts a valid scalar species", {
+  expect_true(validate_species("Human"))
+})
+
+test_that("validate_species rejects a non-scalar or empty species with a clear message", {
+  expect_snapshot(error = TRUE, validate_species(c("Human", "Dog")))
+  expect_snapshot(error = TRUE, validate_species(character(0)))
+})
+
 test_that("convert_ospsuite_time_unit_to_lubridate works correctly", {
   # Test mapping of ospsuite units to lubridate units
   expect_equal(convert_ospsuite_time_unit_to_lubridate("s"), "seconds")

--- a/tests/testthat/test-value_specs.R
+++ b/tests/testthat/test-value_specs.R
@@ -65,7 +65,7 @@ test_that("helpers validate units against their dimension", {
 
 test_that("fraction_unbound() carries no unit slot", {
   spec <- fraction_unbound(0.1)
-  expect_named(unclass(spec), c("value", "name", "default"))
+  expect_named(unclass(spec), c("value", "name", "default", "species"))
 })
 
 test_that("single-value helpers reject non-numeric or non-scalar values", {


### PR DESCRIPTION
Closes #156

A compound built with `create_compound()` (or the writable `Compound$fraction_unbound` field) emitted a fraction-unbound alternative carrying only `Name`, `IsDefault`, and `Parameters`, with no `Species` field. Fraction unbound is the one species-dependent single-parameter alternative group in PK-Sim, so its mapper rejected the snapshot with `SnapshotOutdatedException: Could not find species ''` and `ospsuite::loadSimulationsFromSnapshot()` failed. This PR makes every fraction-unbound alternative carry a non-empty, resolvable `Species` string so PK-Sim loads the snapshot, while leaving the other single-parameter groups (lipophilicity, intestinal permeability, permeability) and solubility untouched, since PK-Sim does not treat those as species-dependent.

## `fraction_unbound()`

`fraction_unbound()` gains a `species` argument (appended last, so all existing positional and named calls keep working), defaulting to `"Human"` and validated against `ospsuite::Species` via the existing `validate_species()` helper. An unknown species (for example `"Klingon"`) now fails fast in R rather than surfacing later as an opaque PK-Sim load error. The species is carried on the `fraction_unbound_spec` object, so both the `create_compound()` factory path and the writable-field path pick up the default and any override with one change point. This mirrors the existing `create_process()` species pattern.

## Snapshot emission

The internal converter `spec_to_single_param_alternative()` now adds the `Species` key to the alternative only when the spec is a `fraction_unbound_spec` (guarded on `inherits(spec, "fraction_unbound_spec")`). All four construction paths (factory single object, factory list of objects, field-setter single object, field-setter list of objects) funnel through this converter, so each fraction-unbound alternative independently carries its own species with no change to the shared low-level `build_single_param_alternative()` builder. Lipophilicity, intestinal permeability, permeability, and solubility flow through unchanged. The raw-alternative-list escape hatch on `Compound$fraction_unbound` still stores a hand-built list verbatim; a user supplying a raw list owns its own `Species` (documented in the roxygen).

## Tests

Added and updated tests covering the acceptance criteria: the default `"Human"` on the factory path, the `species = "Rat"` override on both the factory and field-setter paths, the invalid-species error (captured as an `expect_snapshot(error = TRUE)`), per-element species on the list-of-alternatives form, explicit absence of a `Species` key on lipophilicity, intestinal permeability, permeability, and both solubility forms (scalar and table), and that `validate_snapshot()` still returns `TRUE` for a snapshot containing a fraction-unbound compound. Fixed the existing expected-slot-names assertion for `fraction_unbound()` and regenerated the two affected snapshots (`value_specs.md` gained the `$species` slot; `create_compound.md` gained the new invalid-species error). The live PK-Sim round-trip is a manual check for a maintainer, out of CI, because it needs a PK-Sim engine; the CI proxy is these JSON-shape assertions (a non-empty, `ospsuite::Species`-valid `Species` on the fraction-unbound alternative).

Verification (all with `NOT_CRAN=true`): the full suite passes, `FAIL 0 | WARN 1 | SKIP 0 | PASS 3071`. The single warning is a pre-existing, intentional test that exercises a non-matching template pattern, not a regression. `devtools::document()` leaves only the new `species` parameter in the `man/` diff (`NAMESPACE` unchanged).

## Docs

Added a `NEWS.md` bullet under the development version noting the new `species` argument and the emitted `Species` field. Regenerated `man/fraction_unbound.Rd` via `devtools::document()`.

## Example

Impact not shown as a full reprex: the PK-Sim load requires a live PK-Sim engine. The example below shows the emitted `Species` field, whose absence caused the failure.

```r
# Default: Species is now "Human"
create_compound(
  name = "Drug X",
  fraction_unbound = fraction_unbound(1)
)$data$FractionUnbound[[1]]
#> List of 4
#>  $ Name      : chr "User defined"
#>  $ IsDefault : logi TRUE
#>  $ Parameters:List of 1
#>   ..$ :List of 2
#>   .. ..$ Name : chr "Fraction unbound (plasma, reference value)"
#>   .. ..$ Value: num 1
#>  $ Species   : chr "Human"

# Override for an animal model
create_compound(
  name = "Drug X",
  fraction_unbound = fraction_unbound(1, species = "Rat")
)$data$FractionUnbound[[1]]$Species
#> [1] "Rat"
```


# QA: Approved

The implementation adds a validated `species` argument (default `"Human"`) to `fraction_unbound()` and injects the `Species` key onto the fraction-unbound alternative only, via an `inherits(spec, "fraction_unbound_spec")` guard in the shared converter, leaving the low-level builder, the other single-parameter groups, solubility, and the raw-list escape hatch untouched. Every one of the spec's acceptance criteria 1-7 maps to explicit test evidence in the diff, criterion 8's CI proxy is in place, and I independently reproduced the full green suite (`FAIL 0 | WARN 1 | SKIP 0 | PASS 3071`). Approved.

<details>
<summary>Full QA report</summary>

## Scope reviewed

- PR #160, branch `156-fraction-unbound-species`, base `main`; diff via `gh pr diff 160` plus `git diff main...156-fraction-unbound-species`.
- Source read in worktree `/Users/felix/Code/osp.snapshots.worktrees/156-fraction-unbound-species`: `R/value_specs.R`, `R/create_compound.R` (converter + confirmation the low-level builder is unchanged), `R/utils.R` (`validate_species()`), `.claude/snapshot-spec.md` (Alternative type).
- Diff footprint: 10 files, +124/-7. No production file outside `R/value_specs.R` and `R/create_compound.R` touched; `NAMESPACE` not in the diff; `man/` change is the new `species` param only; fixtures under `tests/testthat/data/` untouched (matches plan Step 4.4).

## Requirement / acceptance-criteria mapping

Criterion 1 (default `"Human"` on factory path). PASS. `R/value_specs.R` appends `species = "Human"` and carries it in the `fraction_unbound_spec` slot list; `spec_to_single_param_alternative()` sets `alt[[1]]$Species`. Test evidence: `test-create_compound.R` block "create_compound sets a fraction unbound alternative without a unit" now asserts `expect_equal(alt$Species, "Human")`.

Criterion 2 (override + invalid species). PASS. Override tested by new block "fraction_unbound species defaults to Human and can be overridden" asserting `Species == "Rat"`. Invalid species tested via `expect_snapshot(error = TRUE, fraction_unbound(1, species = "Klingon"))` added inside the existing helper-error `test_that()`; the recorded snapshot in `create_compound.md` shows the `validate_species()` message (`Invalid species: Klingon` + valid list), which is the repo-convention error-capture form.

Criterion 3 (list form, per-element species). PASS. `test-create_compound.R` multi-alternative block adds `expect_equal(vapply(... "Species"), c("Human", "Human"))`. Mechanism is correct: the list path calls `spec_to_single_param_alternative(spec, param_name)[[1]]` per element, so each element gets its own species from its own spec with no change to the list wrapper.

Criterion 4 (field-setter path). PASS. New block "fraction_unbound field setter carries the species override" clones the fixture compound and asserts `Species == "Rat"` after `compound$fraction_unbound <- fraction_unbound(1, species = "Rat")`; additionally the existing "single-parameter physicochemical fields are writable by helper" block now asserts the default `Species == "Human"` on the setter path. Both go through `set_alternative_group()` -> the same converter, so the default flows automatically with no extra code (matches plan Step 3).

Criterion 5 (other single-param groups gain no Species) - primary regression surface. PASS. New block "only fraction unbound gains a Species key" asserts `expect_false("Species" %in% names(...))` for `Lipophilicity`, `IntestinalPermeability`, and `Permeability`. Confirmed structurally: the `inherits(spec, "fraction_unbound_spec")` guard is false for the other three spec subclasses, and the shared `build_single_param_alternative()` definition is untouched (`git diff` shows no change to that function).

Criterion 6 (solubility, scalar and table, no Species). PASS. New block "solubility alternatives gain no Species key (scalar and table)" covers both forms with `expect_false("Species" %in% names(...))`. Solubility routes through a different converter (`spec_to_solubility_alternative()`), untouched.

Criterion 7 (`validate_snapshot()` still TRUE). PASS. New block in `test-create_snapshot.R` builds `add_compound(create_snapshot(), create_compound(name = "Drug X", fraction_unbound = fraction_unbound(1)))` and asserts `expect_true(validate_snapshot(s))`.

Criterion 8 (live PK-Sim load). Correctly out of CI. The CI proxy (criteria 1-6 asserting a non-empty, `ospsuite::Species`-valid `Species` on the alternative) is present. `Species` placement as a sibling of `Name`/`IsDefault`/`Parameters` matches the schema `Alternative` type (`.claude/snapshot-spec.md:266`, "Throws SnapshotOutdatedException if not found"), which is precisely the field whose absence produced the reported failure. No automated live-load test expected; not a rejection basis.

## Additional checks

- Argument order: `species` appended last, so existing positional/named calls stay valid. Confirmed in signature and `man/fraction_unbound.Rd`.
- Validation seam: `validate_species()` (`R/utils.R:37-48`) checks against `ospsuite::Species`; `"Human"` is a member, so the default passes and an unknown species aborts fast.
- Raw-list escape hatch: unchanged; documented in the new `@param species` roxygen ("A user hand-building a raw alternative list ... is responsible for its own `Species`"). Matches spec "Out of scope".
- Docs: NEWS.md bullet is single-line, function-name-first, backticked with trailing parens, `(#156)` before the period, under `# osp.snapshots (development version)`. `man/fraction_unbound.Rd` regenerated (only the `species` param and the description sentence added); NAMESPACE untouched. Roxygen block: no line in the touched region exceeds 80 columns.
- Conventions: no hand-edited `man/`/`NAMESPACE`; tests self-contained (each clones its own fixture / builds its own compound); uses `expect_snapshot(error = TRUE)` for the error and specific expectations elsewhere. `expect_false("Species" %in% names(...))` is the appropriate way to assert key absence (no more-specific expectation exists).

## Test runs I executed (NOT_CRAN=true, in the worktree)

- `test-value_specs.R`: `FAIL 0 | WARN 0 | SKIP 0 | PASS 65`.
- `test-create_compound.R`: `FAIL 0 | WARN 0 | SKIP 0 | PASS 150`.
- `test-create_snapshot.R`: `FAIL 0 | WARN 0 | SKIP 0 | PASS 22`.
- `test-Compound.R` standalone via `load_all()`: `FAIL 8 | PASS 175`. The 8 failures are all pre-existing deprecation-warning assertions (`Compound$protein_binding_partners` etc. "was deprecated in osp.snapshots 0.3.0"), an artifact of the once-per-session deprecation warning firing under a standalone `load_all()` run. Verified pre-existing: running the same file on `main` gives the identical 8 failures (`FAIL 8 | PASS 173`; the +2 on the branch are this PR's two new assertions). Not a regression.
- Targeted filter `devtools::test(filter = "value_specs|create_compound|Compound|create_snapshot")`: `FAIL 0 | WARN 0 | SKIP 0 | PASS 504` (the 8 standalone deprecation failures clear when run through `devtools::test()`, confirming the session-artifact explanation).
- Full suite `devtools::test()`: `FAIL 0 | WARN 1 | SKIP 0 | PASS 3071`, matching the build summary's headline exactly. The single WARN is `test-snapshot.R:762` ("No templates found matching pattern"), unrelated to species/fraction-unbound and pre-existing/intentional.

## Adversarial and edge-case findings

- Regression risk (Species leaking to the other three groups): closed. Guard is in the converter, not the shared builder; the shared builder's definition is byte-for-byte unchanged, and criterion-5 negatives assert absence explicitly.
- List-form species propagation: correct by construction (per-element spec carries its own species); test asserts `c("Human", "Human")`.
- Field-setter vs factory divergence: both go through the same converter and both are tested; default and override each covered.
- Snapshot drift: exactly the two expected snapshots changed (`value_specs.md` gained `$species [1] "Human"`; `create_compound.md` gained the invalid-species error). No unexpected snapshot ripple.
- Escape hatch not rewritten: verified in roxygen and by the untouched `Compound` setter escape-hatch path.

## Concerns

None blocking. Note (informational, not a rejection basis): the PR is currently in DRAFT state; the caller/maintainer should mark it ready before merge.

</details>

<!-- QA-VERDICT: approved -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `species` option to `fraction_unbound()` (default: `"Human"`), including support for overrides (e.g., `"Rat"`).
  * Fraction-unbound alternatives now include species metadata to better support snapshot loading.
* **Bug Fixes**
  * Improved species validation to require a single, non-missing value, with clearer error messages.
  * Enhanced snapshot validation for compounds using `fraction_unbound`.
* **Documentation**
  * Updated `fraction_unbound` and `validate_species` docs to reflect `species` requirements and behavior.
* **Tests**
  * Expanded snapshots and unit tests to verify defaulting, overrides, validation failures, and correct presence/absence of species metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->