### PR TITLE
Handle different snapshot versions

### DIFF
--- a/.claude/snapshot-spec.md
+++ b/.claude/snapshot-spec.md
@@ -10,8 +10,8 @@ The top-level snapshot object. All other snapshots are nested arrays within it.
 
 | Property | Type | Required | Domain Mapping |
 |----------|------|----------|----------------|
-| `Version` | `int` | Yes | Sets `PKSimProject.Creation.InternalVersion`. Used to create a `SnapshotContext` that controls version-specific mapping behavior throughout the entire conversion. Current version: `80` (v12). |
-| `Name` | `string` | No | `PKSimProject.Name` (also overridden by the input filename). |
+| `Version` | `int` | Yes | Sets `PKSimProject.Creation.InternalVersion`. Used to create a `SnapshotContext` that controls version-specific mapping behavior throughout the entire conversion. Current version: `81` (v13). |
+| `Name` | `string` | No | `PKSimProject.Name` (also overridden by the input filename). The field has existed since at least v80; at v81 it is reordered to precede `Version` in the serialized JSON because the root project object derives from a shared base type that carries a serialization ordering hint on `Name`. Only its position changed at v13, not its meaning. |
 | `Description` | `string` | No | `PKSimProject.Description`. |
 | `ExpressionProfiles` | [ExpressionProfile](#expressionprofile)[] | No | Mapped first and added to the project before any other building blocks, because Individuals reference them by name. |
 | `Individuals` | [Individual](#individual)[] | No | Mapped via `IndividualMapper`, added to project as building blocks. |
@@ -331,6 +331,7 @@ Created via `ISolverSettingsFactory.CreateDefault()`.
 | `HMin` | `double?` | No | `SolverSettings.HMin`. Uses default if null. |
 | `HMax` | `double?` | No | `SolverSettings.HMax`. Uses default if null. |
 | `MxStep` | `int?` | No | `SolverSettings.MxStep`. Uses default if null. |
+| `CheckNegativeValues` | `bool?` | No | `SolverSettings.CheckNegativeValues`. Uses default if null. Added at v81 (v13). |
 
 All properties use sparse serialization: absent/null values fall back to factory defaults.
 
@@ -945,8 +946,11 @@ Created as one of: `ValueMappingGroupingDefinition` (if `Mapping` present), `Fix
 | v7.3.0+ | 74+ | Minimum version for snapshot support. |
 | v9 | 77 | ExpressionProfile uses `MembraneLocation`/`TissueLocation`/`IntracellularVascularEndoLocation` (converted to `Localization`). Expression values are normalized after loading. |
 | v10 | 78 | Individual uses `Molecules[]` (embedded expression profiles). |
-| v11 | 79 | Individual switches to `ExpressionProfiles[]` (string references). `LocalizedParameter` paths convert `"Applications"` to `"Events"`. |
-| v12 | 80 | Current version. |
+| v11 | 79 | Individual switches to `ExpressionProfiles[]` (string references). `LocalizedParameter` paths convert `"Applications"` to `"Events"`. Top-level `ExpressionProfiles[]` is a first-class building block from this version; it is *not* a later addition. |
+| v12 | 80 | Prior version. |
+| v13 | 81 | Current version. Top-level `Name` is reordered to precede `Version` in the serialized JSON (the field itself already existed at v80). `CheckNegativeValues` is added to `SolverSettings`. |
+
+The v13 delta was verified by direct inspection of the upstream PK-Sim / OSPSuite.Core code, which supersedes an earlier framing that described v13 as "promoting `ExpressionProfiles` to a top-level block": top-level `ExpressionProfiles` predates v13 (it is the v11 / version-79 switch to `ExpressionProfiles[]` string references documented above) and is not a v80 -> v81 change. PK-Sim remains the authoritative schema source.
 
 ---
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Suggests:
     quarto,
     rlang,
     rmarkdown,
-    testthat (>= 3.0.0),
+    testthat (>= 3.1.6),
     tidyr,
     withr
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 # osp.snapshots (development version)
 
+- `create_snapshot()` now authors the current PK-Sim v13 snapshot version (`Version 81`) instead of `80`, ordering the top-level `Name` before `Version` and emitting the new `CheckNegativeValues` solver field when a simulation is added (#161).
 - `fraction_unbound()` gains a `species` argument (default `"Human"`, validated against `ospsuite::Species`) and now emits a `Species` field on the fraction-unbound alternative, which PK-Sim requires to load the snapshot (#156).
+- `load_snapshot()` and `Snapshot$new()` gain an `upgrade` argument (default `FALSE`) that migrates a below-floor PK-Sim snapshot (`Version 74-78`) up to the installed core's version via a PK-Sim round trip; without it, such a snapshot reports how to migrate and does not load (#161).
+- `load_snapshot()` now supports PK-Sim v13 snapshots (`Version 81`), reports their PK-Sim version, and rejects snapshots newer than it supports (`Version 82+`) with a clear error (#161).
+- `load_snapshot()` warns, rather than fails, when a supported snapshot is newer than the installed `ospsuite` core, since it may not load or run there (#161).
 
 # osp.snapshots 1.0.0
 

--- a/R/Snapshot.R
+++ b/R/Snapshot.R
@@ -1479,11 +1479,14 @@ Snapshot <- R6::R6Class(
       }
 
       # Version-aware authoring: PK-Sim v13 (Version 81) added the
-      # `CheckNegativeValues` solver field. Emit it only when the snapshot is
-      # at 81 so a v81 snapshot round-trips against a v13 core, while 79/80
-      # snapshots stay free of the newer-only field. Only set it when absent
-      # so an explicitly supplied value is preserved.
-      if (identical(private$.raw_version(), SUPPORTED_VERSION_MAX)) {
+      # `CheckNegativeValues` solver field. Emit it when the snapshot is at 81
+      # or newer so a v81 snapshot round-trips against a v13 core and future
+      # versions inherit the (additive) field, while 79/80 snapshots stay free
+      # of the newer-only field. The 81 threshold is the version that
+      # introduced the field, independent of the current ceiling. Only set it
+      # when absent so an explicitly supplied value is preserved.
+      version_num <- private$.raw_version()
+      if (!is.na(version_num) && version_num >= 81L) {
         if (is.null(data$Solver$CheckNegativeValues)) {
           data$Solver$CheckNegativeValues <- TRUE
         }

--- a/R/Snapshot.R
+++ b/R/Snapshot.R
@@ -60,13 +60,16 @@ MIGRATION_VERSION_MIN <- 74L
 #' supported band `79` (v11.2) to `81` (v13), inclusive (see
 #' `osp.snapshots:::SUPPORTED_VERSION_MIN` and
 #' `osp.snapshots:::SUPPORTED_VERSION_MAX`). A snapshot above the ceiling
-#' aborts as "not supported yet". A below-floor snapshot in the `74-78` band
-#' can be migrated up to whatever the installed `ospsuite` core emits by
-#' passing `upgrade = TRUE`, which round-trips it through PK-Sim; without it,
-#' such a snapshot reports how to migrate and does not load. Snapshots below
-#' `74` are too old to migrate and abort. A snapshot newer than the installed
-#' `ospsuite` core (but still in band) loads with a warning that it may not
-#' load or run there. Hand-rolled list input must supply `Version`.
+#' aborts as not supported in this version. A below-floor snapshot in the
+#' `74-78` band can be migrated by passing `upgrade = TRUE`, which round-trips
+#' it through PK-Sim up to the version the installed `ospsuite` core emits;
+#' migration requires that core to emit a supported version (`79` to `81`) and
+#' aborts before converting when it would emit something above the ceiling.
+#' Without `upgrade = TRUE`, a below-floor snapshot reports how to migrate and
+#' does not load. Snapshots below `74` are too old to migrate and abort. A
+#' snapshot newer than the installed `ospsuite` core (but still in band) loads
+#' with a warning that it may not load or run there. Hand-rolled list input
+#' must supply `Version`.
 #'
 #' @importFrom R6 R6Class
 #' @importFrom fs path_rel
@@ -78,9 +81,10 @@ Snapshot <- R6::R6Class(
     #' @description
     #' Create a new Snapshot object from a JSON file or a list
     #' @param input Path to the snapshot JSON file, URL, template name, or a
-    #'   list containing snapshot data. The parsed data must contain an
-    #'   integer `Version` field within the supported band (`79` to `81`);
-    #'   an out-of-band or missing version aborts (see the
+    #'   list containing snapshot data. The parsed data must contain an integer
+    #'   `Version` field. Versions `79` to `81` load normally; versions `74` to
+    #'   `78` load only with `upgrade = TRUE` (otherwise they report how to
+    #'   migrate and abort); all other or missing versions abort (see the
     #'   "Supported snapshot versions" section).
     #' @param upgrade Logical, default `FALSE`. When `TRUE` and the snapshot's
     #'   `Version` is in the below-floor migration band (`74-78`), the snapshot
@@ -90,6 +94,11 @@ Snapshot <- R6::R6Class(
     #'   in-band snapshots, which are never migrated.
     #' @return A new Snapshot object
     initialize = function(input, upgrade = FALSE) {
+      if (!is.logical(upgrade) || length(upgrade) != 1L || is.na(upgrade)) {
+        cli::cli_abort(
+          "{.arg upgrade} must be a single {.code TRUE} or {.code FALSE}."
+        )
+      }
       if (is.character(input)) {
         cli::cli_alert_info("Reading snapshot from {.file {input}}")
         # Store as absolute path
@@ -132,7 +141,17 @@ Snapshot <- R6::R6Class(
             i = "Upgrade {.pkg osp.snapshots} (or install a matching {.pkg ospsuite}) before migrating."
           ))
         }
-        private$.original_data <- .migrate_snapshot(input)
+        # Migrate from the local file when `input` is one, so PK-Sim reads the
+        # snapshot directly; otherwise (a URL or a list) migrate the parsed
+        # data, since `input` is not itself a readable snapshot payload.
+        migration_input <- if (
+          is.character(input) && length(input) == 1L && file.exists(input)
+        ) {
+          input
+        } else {
+          private$.original_data
+        }
+        private$.original_data <- .migrate_snapshot(migration_input)
       }
 
       private$.validate_version(upgrade = upgrade)
@@ -935,12 +954,20 @@ Snapshot <- R6::R6Class(
     # Shared by `.validate_version()`, `.get_pksim_version()`, and the version
     # branch in `.build_simulation()` so they all read `Version` the same way.
     .raw_version = function() {
-      raw <- private$.original_data$Version
-      version_num <- suppressWarnings(as.integer(unlist(raw)))
-      if (is.null(raw) || length(version_num) != 1 || is.na(version_num)) {
+      raw <- unlist(private$.original_data$Version, use.names = FALSE)
+      # Reject anything that is not a single whole number: a fractional value
+      # (`81.9`) or a numeric string (`"81"`) must not be silently truncated
+      # or coerced past the version gate.
+      if (
+        length(raw) != 1L ||
+          !is.numeric(raw) ||
+          is.na(raw) ||
+          !is.finite(raw) ||
+          raw != trunc(raw)
+      ) {
         return(NA_integer_)
       }
-      version_num
+      as.integer(raw)
     },
 
     # Enforce the supported-version contract at the single load chokepoint.
@@ -961,8 +988,7 @@ Snapshot <- R6::R6Class(
       if (version_num < MIGRATION_VERSION_MIN) {
         cli::cli_abort(c(
           "Snapshot {.field Version} {version_num} is too old to migrate.",
-          i = "{.pkg osp.snapshots} supports snapshots from {.field Version} {SUPPORTED_VERSION_MIN} to {SUPPORTED_VERSION_MAX}, and can migrate {.field Version} {MIGRATION_VERSION_MIN} to {SUPPORTED_VERSION_MIN - 1L}.",
-          i = "Re-export the project from a newer PK-Sim before loading it."
+          i = "{.pkg osp.snapshots} supports snapshots from {.field Version} {SUPPORTED_VERSION_MIN} to {SUPPORTED_VERSION_MAX}, and can migrate {.field Version} {MIGRATION_VERSION_MIN} to {SUPPORTED_VERSION_MIN - 1L}."
         ))
       }
       if (version_num < SUPPORTED_VERSION_MIN) {
@@ -984,9 +1010,10 @@ Snapshot <- R6::R6Class(
         ))
       }
       if (version_num > SUPPORTED_VERSION_MAX) {
+        pkg_version <- utils::packageVersion("osp.snapshots")
         cli::cli_abort(c(
-          "Snapshot {.field Version} {version_num} is not supported yet.",
-          i = "{.pkg osp.snapshots} supports snapshots up to {.field Version} {SUPPORTED_VERSION_MAX}; upgrade {.pkg osp.snapshots} to load newer snapshots."
+          "Snapshot {.field Version} {version_num} is not supported in this version.",
+          i = "{.pkg osp.snapshots} v{pkg_version} supports snapshots up to {.field Version} {SUPPORTED_VERSION_MAX}."
         ))
       }
       # In-band (`79:81`): warn if newer than the installed core would emit.
@@ -1048,20 +1075,11 @@ Snapshot <- R6::R6Class(
       )
     ),
 
-    # Convert the raw version number to a human-readable PKSIM version
-    # Returns a string with the human-readable PKSIM version
+    # Convert the raw version number to a human-readable PKSIM version.
+    # Reads the shared `.VERSION_TABLE`; returns "Unknown" for an unmapped
+    # version. Returns a string with the human-readable PKSIM version.
     .get_pksim_version = function() {
-      version_num <- private$.raw_version()
-
-      pksim_version <- switch(
-        as.character(version_num),
-        "81" = "13.0",
-        "80" = "12.0",
-        "79" = "11.2",
-        "Unknown"
-      )
-
-      return(pksim_version)
+      .pksim_label_for_version(private$.raw_version())
     },
 
     # Lazily build the unnamed object list for a building-block collection.
@@ -1820,13 +1838,35 @@ load_snapshot <- function(source, upgrade = FALSE) {
   return(templates$Templates)
 }
 
+# The single source of truth mapping a snapshot schema `Version` to its
+# PK-Sim release: the schema integer, the `ospsuite` package major that emits
+# it, and the human-readable PK-Sim version label. Every version-to-version
+# lookup (schema -> label in `.get_pksim_version()`, ospsuite major -> schema
+# in `.installed_core_version()`) reads this one table, so a new PK-Sim
+# release is added in exactly one place.
+.VERSION_TABLE <- list(
+  list(schema = 79L, ospsuite_major = 11L, pksim_label = "11.2"),
+  list(schema = 80L, ospsuite_major = 12L, pksim_label = "12.0"),
+  list(schema = 81L, ospsuite_major = 13L, pksim_label = "13.0")
+)
+
+# Human-readable PK-Sim label for a snapshot schema `Version`, or "Unknown"
+# when the version is not in `.VERSION_TABLE`.
+.pksim_label_for_version <- function(version_num) {
+  for (entry in .VERSION_TABLE) {
+    if (identical(entry$schema, as.integer(version_num))) {
+      return(entry$pksim_label)
+    }
+  }
+  "Unknown"
+}
+
 # Returns the integer snapshot `Version` the *installed* ospsuite core would
-# emit, derived from the installed `ospsuite` package major. This is the only
-# window osp.snapshots has onto the core's schema version: OSPSuite-R exposes
-# no core/schema getter, so we lean on the installed package major.
+# emit, derived from the installed `ospsuite` package major via
+# `.VERSION_TABLE`. This is the only window osp.snapshots has onto the core's
+# schema version: OSPSuite-R exposes no core/schema getter, so we lean on the
+# installed package major.
 #
-# Documented mapping (the single place to update on a core bump):
-#   ospsuite major 11 -> 79, 12 -> 80, 13 -> 81.
 # An unknown (future) major falls back to `SUPPORTED_VERSION_MAX` so a newer
 # core is treated as "at least current" and never spuriously trips the
 # newer-than-installed warning downward. If the version query itself fails
@@ -1844,13 +1884,12 @@ load_snapshot <- function(source, upgrade = FALSE) {
   if (length(major) != 1 || is.na(major)) {
     return(SUPPORTED_VERSION_MAX)
   }
-  switch(
-    as.character(major),
-    "11" = 79L,
-    "12" = 80L,
-    "13" = 81L,
-    SUPPORTED_VERSION_MAX
-  )
+  for (entry in .VERSION_TABLE) {
+    if (identical(entry$ospsuite_major, major)) {
+      return(entry$schema)
+    }
+  }
+  SUPPORTED_VERSION_MAX
 }
 
 # Two-step PK-Sim round trip that upgrades a below-floor snapshot to whatever

--- a/R/Snapshot.R
+++ b/R/Snapshot.R
@@ -3,6 +3,18 @@
 # path segments instead of `Events|...`) that this package does not model.
 SUPPORTED_VERSION_MIN <- 79L
 
+# Highest snapshot `Version` this package models. PK-Sim v13 maps to numeric
+# 81. Snapshots above this ceiling are a hard "not supported yet" error: the
+# package cannot know what fields a newer format added, so silently loading
+# one and re-exporting it could corrupt it.
+SUPPORTED_VERSION_MAX <- 81L
+
+# Snapshots in the migration band `74:78` are below the supported floor but
+# can be upgraded to a supported version by round-tripping them through the
+# installed PK-Sim core (see `.migrate_snapshot()`); below `74` PK-Sim itself
+# does not support snapshots, so there is nothing to migrate.
+MIGRATION_VERSION_MIN <- 74L
+
 # Default export adapter for a building-block section. Pairs with the
 # per-section table `Snapshot$private$.export_adapters`; non-default sections
 # (currently only ObservedData) supply their own adapter.
@@ -44,12 +56,17 @@ SUPPORTED_VERSION_MIN <- 79L
 #'
 #' # Supported snapshot versions
 #'
-#' `Snapshot` only accepts PK-Sim v11+ snapshots, i.e. integer `Version`
-#' values of `79` or greater (see `osp.snapshots:::SUPPORTED_VERSION_MIN`).
-#' Earlier snapshots use different conventions (notably `Applications|...`
-#' instead of `Events|...` in parameter paths) and are not modelled by this
-#' package; `Snapshot$new()` aborts on them rather than silently rewriting
-#' fields. Hand-rolled list input must supply `Version` for the same reason.
+#' `Snapshot` accepts PK-Sim snapshots whose integer `Version` is within the
+#' supported band `79` (v11.2) to `81` (v13), inclusive (see
+#' `osp.snapshots:::SUPPORTED_VERSION_MIN` and
+#' `osp.snapshots:::SUPPORTED_VERSION_MAX`). A snapshot above the ceiling
+#' aborts as "not supported yet". A below-floor snapshot in the `74-78` band
+#' can be migrated up to whatever the installed `ospsuite` core emits by
+#' passing `upgrade = TRUE`, which round-trips it through PK-Sim; without it,
+#' such a snapshot reports how to migrate and does not load. Snapshots below
+#' `74` are too old to migrate and abort. A snapshot newer than the installed
+#' `ospsuite` core (but still in band) loads with a warning that it may not
+#' load or run there. Hand-rolled list input must supply `Version`.
 #'
 #' @importFrom R6 R6Class
 #' @importFrom fs path_rel
@@ -62,10 +79,17 @@ Snapshot <- R6::R6Class(
     #' Create a new Snapshot object from a JSON file or a list
     #' @param input Path to the snapshot JSON file, URL, template name, or a
     #'   list containing snapshot data. The parsed data must contain an
-    #'   integer `Version` field of `79` (v11.2) or greater; older or missing
-    #'   versions abort.
+    #'   integer `Version` field within the supported band (`79` to `81`);
+    #'   an out-of-band or missing version aborts (see the
+    #'   "Supported snapshot versions" section).
+    #' @param upgrade Logical, default `FALSE`. When `TRUE` and the snapshot's
+    #'   `Version` is in the below-floor migration band (`74-78`), the snapshot
+    #'   is round-tripped through the installed PK-Sim core to upgrade it to a
+    #'   supported version before loading (slow, several minutes). When `FALSE`,
+    #'   a below-floor snapshot reports how to migrate and aborts. Ignored for
+    #'   in-band snapshots, which are never migrated.
     #' @return A new Snapshot object
-    initialize = function(input) {
+    initialize = function(input, upgrade = FALSE) {
       if (is.character(input)) {
         cli::cli_alert_info("Reading snapshot from {.file {input}}")
         # Store as absolute path
@@ -86,7 +110,32 @@ Snapshot <- R6::R6Class(
         cli::cli_abort("Input must be either a path to a JSON file or a list")
       }
 
-      private$.validate_version()
+      # Orchestrate migration before validation so `.validate_version()` sees
+      # the upgraded data. A below-floor snapshot with `upgrade = TRUE` is
+      # first guarded by the compatibility precondition, then round-tripped
+      # through PK-Sim; on success `.original_data` is replaced with the
+      # upgraded snapshot. Either migration succeeds and validation runs on
+      # the upgraded data, or the precondition / round trip errors and no
+      # object is constructed (no partial or unmigrated Snapshot escapes).
+      version_num <- private$.raw_version()
+      if (
+        isTRUE(upgrade) &&
+          !is.na(version_num) &&
+          version_num >= MIGRATION_VERSION_MIN &&
+          version_num < SUPPORTED_VERSION_MIN
+      ) {
+        installed <- .installed_core_version()
+        if (installed > SUPPORTED_VERSION_MAX) {
+          cli::cli_abort(c(
+            "Cannot migrate this snapshot with the installed {.pkg ospsuite} core.",
+            i = "The installed core would emit {.field Version} {installed}, which is above the highest version {.pkg osp.snapshots} supports ({.field Version} {SUPPORTED_VERSION_MAX}).",
+            i = "Upgrade {.pkg osp.snapshots} (or install a matching {.pkg ospsuite}) before migrating."
+          ))
+        }
+        private$.original_data <- .migrate_snapshot(input)
+      }
+
+      private$.validate_version(upgrade = upgrade)
 
       # Building-block collections are constructed lazily on first access via
       # their active bindings; all `private$.<kind>` caches stay NULL here.
@@ -879,29 +928,73 @@ Snapshot <- R6::R6Class(
     .pksim_version = NULL,
     .abs_path = NULL,
 
-    # Abort when the parsed snapshot is missing `Version` or sits below the
-    # supported v11+ floor. Below v11, snapshots use `Applications|...` in
-    # localized parameter paths and other older conventions this package does
-    # not model; refusing them is preferable to silently rewriting fields.
-    .validate_version = function() {
+    # Unwrap the raw `Version` from `.original_data` to a single integer, or
+    # `NA_integer_` when it is missing, non-scalar, or non-integer. `unlist()`
+    # guards against list-wrapped values (jsonlite is configured with
+    # `simplifyVector = FALSE`, so scalars can arrive as length-1 lists).
+    # Shared by `.validate_version()`, `.get_pksim_version()`, and the version
+    # branch in `.build_simulation()` so they all read `Version` the same way.
+    .raw_version = function() {
       raw <- private$.original_data$Version
-      # `unlist()` guards against list-wrapped values (jsonlite is configured
-      # with `simplifyVector = FALSE`, so scalars can arrive as length-1 lists).
       version_num <- suppressWarnings(as.integer(unlist(raw)))
-      if (
-        is.null(raw) ||
-          length(version_num) != 1 ||
-          is.na(version_num)
-      ) {
+      if (is.null(raw) || length(version_num) != 1 || is.na(version_num)) {
+        return(NA_integer_)
+      }
+      version_num
+    },
+
+    # Enforce the supported-version contract at the single load chokepoint.
+    # Checks run top to bottom: missing/malformed `Version`, then below the
+    # migration floor (too old to migrate), then the `74:78` migration band
+    # (only reached with `upgrade = FALSE`, since `upgrade = TRUE` migrates
+    # before this runs), then above the ceiling (not supported yet), then
+    # in-band success. On success, warn when the snapshot is newer than what
+    # the installed core would emit (still editable, but may not load there).
+    .validate_version = function(upgrade = FALSE) {
+      version_num <- private$.raw_version()
+      if (is.na(version_num)) {
         cli::cli_abort(c(
           "Snapshot is missing an integer {.field Version} field.",
           i = "{.pkg osp.snapshots} requires PK-Sim v11+ snapshots ({.field Version} >= {SUPPORTED_VERSION_MIN})."
         ))
       }
-      if (version_num < SUPPORTED_VERSION_MIN) {
+      if (version_num < MIGRATION_VERSION_MIN) {
         cli::cli_abort(c(
-          "Unsupported snapshot {.field Version} {version_num}.",
-          i = "{.pkg osp.snapshots} requires PK-Sim v11+ snapshots ({.field Version} >= {SUPPORTED_VERSION_MIN})."
+          "Snapshot {.field Version} {version_num} is too old to migrate.",
+          i = "{.pkg osp.snapshots} supports snapshots from {.field Version} {SUPPORTED_VERSION_MIN} to {SUPPORTED_VERSION_MAX}, and can migrate {.field Version} {MIGRATION_VERSION_MIN} to {SUPPORTED_VERSION_MIN - 1L}.",
+          i = "Re-export the project from a newer PK-Sim before loading it."
+        ))
+      }
+      if (version_num < SUPPORTED_VERSION_MIN) {
+        # `74:78` band, `upgrade = FALSE`: explain the migration path, then
+        # abort. Emitting the guidance as the bullets of a single
+        # `cli::cli_abort()` keeps message-and-abort atomic so no partial
+        # object escapes.
+        pksim_label <- private$.get_pksim_version()
+        detected <- if (identical(pksim_label, "Unknown")) {
+          "{.field Version} {version_num}"
+        } else {
+          "{.field Version} {version_num} (PK-Sim {pksim_label})"
+        }
+        installed <- .installed_core_version()
+        cli::cli_abort(c(
+          paste0("Snapshot ", detected, " is below the supported floor."),
+          i = "Set {.code upgrade = TRUE} to migrate it up to whatever the installed {.pkg ospsuite} core emits (currently {.field Version} {installed}).",
+          i = "Migration round-trips the snapshot through PK-Sim and can take several minutes."
+        ))
+      }
+      if (version_num > SUPPORTED_VERSION_MAX) {
+        cli::cli_abort(c(
+          "Snapshot {.field Version} {version_num} is not supported yet.",
+          i = "{.pkg osp.snapshots} supports snapshots up to {.field Version} {SUPPORTED_VERSION_MAX}; upgrade {.pkg osp.snapshots} to load newer snapshots."
+        ))
+      }
+      # In-band (`79:81`): warn if newer than the installed core would emit.
+      installed <- .installed_core_version()
+      if (version_num > installed) {
+        cli::cli_warn(c(
+          "Snapshot {.field Version} {version_num} is newer than the installed {.pkg ospsuite} core ({.field Version} {installed}).",
+          i = "It may not load or run in the installed {.pkg ospsuite}; editing and exporting still work here."
         ))
       }
     },
@@ -958,10 +1051,11 @@ Snapshot <- R6::R6Class(
     # Convert the raw version number to a human-readable PKSIM version
     # Returns a string with the human-readable PKSIM version
     .get_pksim_version = function() {
-      version_num <- as.integer(unlist(private$.original_data$Version))
+      version_num <- private$.raw_version()
 
       pksim_version <- switch(
         as.character(version_num),
+        "81" = "13.0",
         "80" = "12.0",
         "79" = "11.2",
         "Unknown"
@@ -1384,6 +1478,17 @@ Snapshot <- R6::R6Class(
         data$Solver <- empty_named_list()
       }
 
+      # Version-aware authoring: PK-Sim v13 (Version 81) added the
+      # `CheckNegativeValues` solver field. Emit it only when the snapshot is
+      # at 81 so a v81 snapshot round-trips against a v13 core, while 79/80
+      # snapshots stay free of the newer-only field. Only set it when absent
+      # so an explicitly supplied value is preserved.
+      if (identical(private$.raw_version(), SUPPORTED_VERSION_MAX)) {
+        if (is.null(data$Solver$CheckNegativeValues)) {
+          data$Solver$CheckNegativeValues <- TRUE
+        }
+      }
+
       if (!is.null(output_schema)) {
         if (inherits(output_schema, "OutputSchema")) {
           data$OutputSchema <- output_schema$data
@@ -1602,6 +1707,13 @@ Snapshot <- R6::R6Class(
 #'   - URL to a remote snapshot file
 #'   - Name of a template from the OSPSuite.BuildingBlockTemplates repository
 #'
+#' @param upgrade Logical, default `FALSE`. When `TRUE`, a below-floor
+#'   snapshot (`Version 74-78`) is migrated up to the version the installed
+#'   PK-Sim core emits via a round trip through `ospsuite` (slow, several
+#'   minutes, and requires a compatible installed core). When `FALSE`, such a
+#'   snapshot reports how to migrate and does not load. In-band snapshots
+#'   (`Version 79-81`) are never migrated regardless of this argument.
+#'
 #' @details
 #' Available templates can be listed with `osp_models()`.
 #'
@@ -1619,14 +1731,14 @@ Snapshot <- R6::R6Class(
 #' # Load a predefined template by name
 #' snapshot <- load_snapshot("Midazolam")
 #' }
-load_snapshot <- function(source) {
+load_snapshot <- function(source, upgrade = FALSE) {
   if (is.null(source) || !is.character(source) || length(source) != 1) {
     cli::cli_abort("Source must be a single character string")
   }
 
   # Check if source is a local file
   if (file.exists(source) && grepl("\\.json$", source, ignore.case = TRUE)) {
-    return(Snapshot$new(source))
+    return(Snapshot$new(source, upgrade = upgrade))
   }
 
   # Check if source is a URL
@@ -1640,7 +1752,7 @@ load_snapshot <- function(source) {
           simplifyDataFrame = FALSE,
           simplifyVector = FALSE
         )
-        return(Snapshot$new(json_data))
+        return(Snapshot$new(json_data, upgrade = upgrade))
       },
       error = function(e) {
         cli::cli_abort(
@@ -1680,7 +1792,7 @@ load_snapshot <- function(source) {
         simplifyDataFrame = FALSE,
         simplifyVector = FALSE
       )
-      return(Snapshot$new(json_data))
+      return(Snapshot$new(json_data, upgrade = upgrade))
     },
     error = function(e) {
       cli::cli_abort(
@@ -1703,6 +1815,123 @@ load_snapshot <- function(source) {
   }
 
   return(templates$Templates)
+}
+
+# Returns the integer snapshot `Version` the *installed* ospsuite core would
+# emit, derived from the installed `ospsuite` package major. This is the only
+# window osp.snapshots has onto the core's schema version: OSPSuite-R exposes
+# no core/schema getter, so we lean on the installed package major.
+#
+# Documented mapping (the single place to update on a core bump):
+#   ospsuite major 11 -> 79, 12 -> 80, 13 -> 81.
+# An unknown (future) major falls back to `SUPPORTED_VERSION_MAX` so a newer
+# core is treated as "at least current" and never spuriously trips the
+# newer-than-installed warning downward. If the version query itself fails
+# (no ospsuite installed), also fall back to the ceiling so in-band loads
+# still succeed without a spurious warning.
+#
+# Kept as a free internal function (not an R6 private method) so tests can
+# stub it with `withr::local_mocked_bindings()`; the compatibility and
+# newer-than-installed decisions all read this one seam.
+.installed_core_version <- function() {
+  major <- tryCatch(
+    as.integer(unclass(utils::packageVersion("ospsuite"))[[1]][1]),
+    error = function(e) NA_integer_
+  )
+  if (length(major) != 1 || is.na(major)) {
+    return(SUPPORTED_VERSION_MAX)
+  }
+  switch(
+    as.character(major),
+    "11" = 79L,
+    "12" = 80L,
+    "13" = 81L,
+    SUPPORTED_VERSION_MAX
+  )
+}
+
+# Two-step PK-Sim round trip that upgrades a below-floor snapshot to whatever
+# the installed core emits. Delegates the field-level transforms to PK-Sim
+# (a bare `Version` rewrite would corrupt the file); returns the *parsed*
+# upgraded snapshot data list so the caller can drop it into `.original_data`.
+#
+# All intermediate artifacts live in a `withr::local_tempdir()` scoped to this
+# call, cleaned up on exit including on error, so concurrent loads never
+# collide and nothing leaks into the package dir or the user's tree. Because
+# the temp dir is gone when this function returns, the parsed list is returned
+# rather than a path.
+#
+# Slow (~minutes) and core-dependent; callers gate on the compatibility
+# precondition (installed core within the supported ceiling) first.
+#
+# Kept as a free internal function (not an R6 private method) so the
+# integration test can exercise it directly and so callers can reason about
+# it in isolation.
+.migrate_snapshot <- function(input) {
+  work_dir <- withr::local_tempdir()
+
+  # Normalize the input to a `.json` file on disk: `loadProjectFromSnapshot()`
+  # needs a file path. A local `.json` path is used as-is; list / URL-derived
+  # data is written out first.
+  if (is.character(input) && length(input) == 1 && file.exists(input)) {
+    input_json <- input
+  } else {
+    input_json <- file.path(work_dir, "input.json")
+    jsonlite::write_json(
+      input,
+      input_json,
+      auto_unbox = TRUE,
+      digits = NA
+    )
+  }
+
+  cli::cli_alert_info(c(
+    "Migrating the snapshot through the installed PK-Sim core; ",
+    "this can take several minutes."
+  ))
+
+  # Step 1: old snapshot .json -> project .pksim5 (no simulations requested).
+  project_dir <- file.path(work_dir, "project")
+  dir.create(project_dir)
+  ospsuite::loadProjectFromSnapshot(
+    input_json,
+    output = project_dir,
+    runSimulations = FALSE
+  )
+  project_files <- list.files(
+    project_dir,
+    pattern = "\\.pksim5$",
+    full.names = TRUE
+  )
+  if (length(project_files) == 0) {
+    cli::cli_abort(
+      "Snapshot migration failed: no project file was produced by PK-Sim."
+    )
+  }
+
+  # Step 2: project .pksim5 -> upgraded snapshot .json.
+  snapshot_dir <- file.path(work_dir, "snapshot")
+  dir.create(snapshot_dir)
+  ospsuite::exportProjectToSnapshot(
+    project_files[[1]],
+    output = snapshot_dir
+  )
+  upgraded_files <- list.files(
+    snapshot_dir,
+    pattern = "\\.json$",
+    full.names = TRUE
+  )
+  if (length(upgraded_files) == 0) {
+    cli::cli_abort(
+      "Snapshot migration failed: no upgraded snapshot was produced by PK-Sim."
+    )
+  }
+
+  jsonlite::fromJSON(
+    upgraded_files[[1]],
+    simplifyDataFrame = FALSE,
+    simplifyVector = FALSE
+  )
 }
 
 #' Add one or more individuals to a snapshot

--- a/R/create_snapshot.R
+++ b/R/create_snapshot.R
@@ -45,11 +45,16 @@ create_snapshot <- function(name = NULL, description = NULL) {
     cli::cli_abort("{.arg description} must be a single string")
   }
 
-  data <- list(Version = 80)
-
-  if (!is.null(name)) {
-    data$Name <- name
+  # Author at the highest supported version so a freshly created snapshot
+  # matches the current PK-Sim format. At v81 the top-level `Name` precedes
+  # `Version` in the serialized JSON, and `jsonlite::write_json()` preserves
+  # list order, so build `Name` first when it is supplied.
+  data <- if (!is.null(name)) {
+    list(Name = name, Version = SUPPORTED_VERSION_MAX)
+  } else {
+    list(Version = SUPPORTED_VERSION_MAX)
   }
+
   if (!is.null(description)) {
     data$Description <- description
   }

--- a/man/Snapshot.Rd
+++ b/man/Snapshot.Rd
@@ -13,13 +13,16 @@ structure.
 supported band \code{79} (v11.2) to \code{81} (v13), inclusive (see
 \code{osp.snapshots:::SUPPORTED_VERSION_MIN} and
 \code{osp.snapshots:::SUPPORTED_VERSION_MAX}). A snapshot above the ceiling
-aborts as "not supported yet". A below-floor snapshot in the \code{74-78} band
-can be migrated up to whatever the installed \code{ospsuite} core emits by
-passing \code{upgrade = TRUE}, which round-trips it through PK-Sim; without it,
-such a snapshot reports how to migrate and does not load. Snapshots below
-\code{74} are too old to migrate and abort. A snapshot newer than the installed
-\code{ospsuite} core (but still in band) loads with a warning that it may not
-load or run there. Hand-rolled list input must supply \code{Version}.
+aborts as not supported in this version. A below-floor snapshot in the
+\code{74-78} band can be migrated by passing \code{upgrade = TRUE}, which round-trips
+it through PK-Sim up to the version the installed \code{ospsuite} core emits;
+migration requires that core to emit a supported version (\code{79} to \code{81}) and
+aborts before converting when it would emit something above the ceiling.
+Without \code{upgrade = TRUE}, a below-floor snapshot reports how to migrate and
+does not load. Snapshots below \code{74} are too old to migrate and abort. A
+snapshot newer than the installed \code{ospsuite} core (but still in band) loads
+with a warning that it may not load or run there. Hand-rolled list input
+must supply \code{Version}.
 }
 
 \examples{
@@ -194,9 +197,10 @@ snapshot$remove_expression_profile("CYP3A4_Human_Healthy")
     \if{html}{\out{<div class="arguments">}}
     \describe{
       \item{\code{input}}{Path to the snapshot JSON file, URL, template name, or a
-list containing snapshot data. The parsed data must contain an
-integer \code{Version} field within the supported band (\code{79} to \code{81});
-an out-of-band or missing version aborts (see the
+list containing snapshot data. The parsed data must contain an integer
+\code{Version} field. Versions \code{79} to \code{81} load normally; versions \code{74} to
+\code{78} load only with \code{upgrade = TRUE} (otherwise they report how to
+migrate and abort); all other or missing versions abort (see the
 "Supported snapshot versions" section).}
       \item{\code{upgrade}}{Logical, default \code{FALSE}. When \code{TRUE} and the snapshot's
 \code{Version} is in the below-floor migration band (\code{74-78}), the snapshot

--- a/man/Snapshot.Rd
+++ b/man/Snapshot.Rd
@@ -9,12 +9,17 @@ methods to access different components of the snapshot and visualize its
 structure.
 }
 \section{Supported snapshot versions}{
-\code{Snapshot} only accepts PK-Sim v11+ snapshots, i.e. integer \code{Version}
-values of \code{79} or greater (see \code{osp.snapshots:::SUPPORTED_VERSION_MIN}).
-Earlier snapshots use different conventions (notably \code{Applications|...}
-instead of \code{Events|...} in parameter paths) and are not modelled by this
-package; \code{Snapshot$new()} aborts on them rather than silently rewriting
-fields. Hand-rolled list input must supply \code{Version} for the same reason.
+\code{Snapshot} accepts PK-Sim snapshots whose integer \code{Version} is within the
+supported band \code{79} (v11.2) to \code{81} (v13), inclusive (see
+\code{osp.snapshots:::SUPPORTED_VERSION_MIN} and
+\code{osp.snapshots:::SUPPORTED_VERSION_MAX}). A snapshot above the ceiling
+aborts as "not supported yet". A below-floor snapshot in the \code{74-78} band
+can be migrated up to whatever the installed \code{ospsuite} core emits by
+passing \code{upgrade = TRUE}, which round-trips it through PK-Sim; without it,
+such a snapshot reports how to migrate and does not load. Snapshots below
+\code{74} are too old to migrate and abort. A snapshot newer than the installed
+\code{ospsuite} core (but still in band) loads with a warning that it may not
+load or run there. Hand-rolled list input must supply \code{Version}.
 }
 
 \examples{
@@ -182,7 +187,7 @@ snapshot$remove_expression_profile("CYP3A4_Human_Healthy")
   Create a new Snapshot object from a JSON file or a list
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{Snapshot$new(input)}
+    \preformatted{Snapshot$new(input, upgrade = FALSE)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -190,8 +195,15 @@ snapshot$remove_expression_profile("CYP3A4_Human_Healthy")
     \describe{
       \item{\code{input}}{Path to the snapshot JSON file, URL, template name, or a
 list containing snapshot data. The parsed data must contain an
-integer \code{Version} field of \code{79} (v11.2) or greater; older or missing
-versions abort.}
+integer \code{Version} field within the supported band (\code{79} to \code{81});
+an out-of-band or missing version aborts (see the
+"Supported snapshot versions" section).}
+      \item{\code{upgrade}}{Logical, default \code{FALSE}. When \code{TRUE} and the snapshot's
+\code{Version} is in the below-floor migration band (\code{74-78}), the snapshot
+is round-tripped through the installed PK-Sim core to upgrade it to a
+supported version before loading (slow, several minutes). When \code{FALSE},
+a below-floor snapshot reports how to migrate and aborts. Ignored for
+in-band snapshots, which are never migrated.}
     }
     \if{html}{\out{</div>}}
   }

--- a/man/load_snapshot.Rd
+++ b/man/load_snapshot.Rd
@@ -4,7 +4,7 @@
 \alias{load_snapshot}
 \title{Load a snapshot from various sources}
 \usage{
-load_snapshot(source)
+load_snapshot(source, upgrade = FALSE)
 }
 \arguments{
 \item{source}{Character string. Can be:
@@ -13,6 +13,13 @@ load_snapshot(source)
 \item URL to a remote snapshot file
 \item Name of a template from the OSPSuite.BuildingBlockTemplates repository
 }}
+
+\item{upgrade}{Logical, default \code{FALSE}. When \code{TRUE}, a below-floor
+snapshot (\verb{Version 74-78}) is migrated up to the version the installed
+PK-Sim core emits via a round trip through \code{ospsuite} (slow, several
+minutes, and requires a compatible installed core). When \code{FALSE}, such a
+snapshot reports how to migrate and does not load. In-band snapshots
+(\verb{Version 79-81}) are never migrated regardless of this argument.}
 }
 \value{
 A Snapshot object

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -45,7 +45,7 @@
       * Protocols: 9
       * Simulations: 2
 
-# Snapshot rejects pre-v11 snapshots
+# Snapshot migration-band snapshots report how to upgrade and abort
 
     Code
       Snapshot$new(list(Version = 78))
@@ -53,8 +53,103 @@
       i Creating snapshot from list data
     Condition
       Error in `private$.validate_version()`:
-      ! Unsupported snapshot Version 78.
-      i osp.snapshots requires PK-Sim v11+ snapshots (Version >= 79).
+      ! Snapshot Version 78 is below the supported floor.
+      i Set `upgrade = TRUE` to migrate it up to whatever the installed ospsuite core emits (currently Version 80).
+      i Migration round-trips the snapshot through PK-Sim and can take several minutes.
+
+---
+
+    Code
+      Snapshot$new(testthat::test_path("data", "snapshot_v78.json"))
+    Message
+      i Reading snapshot from 'data/snapshot_v78.json'
+    Condition
+      Error in `private$.validate_version()`:
+      ! Snapshot Version 78 is below the supported floor.
+      i Set `upgrade = TRUE` to migrate it up to whatever the installed ospsuite core emits (currently Version 80).
+      i Migration round-trips the snapshot through PK-Sim and can take several minutes.
+
+# Snapshot rejects snapshots too old to migrate
+
+    Code
+      Snapshot$new(list(Version = 73))
+    Message
+      i Creating snapshot from list data
+    Condition
+      Error in `private$.validate_version()`:
+      ! Snapshot Version 73 is too old to migrate.
+      i osp.snapshots supports snapshots from Version 79 to 81, and can migrate Version 74 to 78.
+      i Re-export the project from a newer PK-Sim before loading it.
+
+---
+
+    Code
+      Snapshot$new(testthat::test_path("data", "snapshot_v73.json"))
+    Message
+      i Reading snapshot from 'data/snapshot_v73.json'
+    Condition
+      Error in `private$.validate_version()`:
+      ! Snapshot Version 73 is too old to migrate.
+      i osp.snapshots supports snapshots from Version 79 to 81, and can migrate Version 74 to 78.
+      i Re-export the project from a newer PK-Sim before loading it.
+
+# Snapshot rejects snapshots newer than the supported ceiling
+
+    Code
+      Snapshot$new(list(Version = 82))
+    Message
+      i Creating snapshot from list data
+    Condition
+      Error in `private$.validate_version()`:
+      ! Snapshot Version 82 is not supported yet.
+      i osp.snapshots supports snapshots up to Version 81; upgrade osp.snapshots to load newer snapshots.
+
+---
+
+    Code
+      Snapshot$new(testthat::test_path("data", "snapshot_v82.json"))
+    Message
+      i Reading snapshot from 'data/snapshot_v82.json'
+    Condition
+      Error in `private$.validate_version()`:
+      ! Snapshot Version 82 is not supported yet.
+      i osp.snapshots supports snapshots up to Version 81; upgrade osp.snapshots to load newer snapshots.
+
+---
+
+    Code
+      Snapshot$new(list(Version = 82), upgrade = TRUE)
+    Message
+      i Creating snapshot from list data
+    Condition
+      Error in `private$.validate_version()`:
+      ! Snapshot Version 82 is not supported yet.
+      i osp.snapshots supports snapshots up to Version 81; upgrade osp.snapshots to load newer snapshots.
+
+# Snapshot warns when a snapshot is newer than the installed core
+
+    Code
+      s <- Snapshot$new(list(Version = 81))
+    Message
+      i Creating snapshot from list data
+    Condition
+      Warning:
+      Snapshot Version 81 is newer than the installed ospsuite core (Version 80).
+      i It may not load or run in the installed ospsuite; editing and exporting still work here.
+    Message
+      v Snapshot loaded successfully
+
+# Snapshot migration aborts before converting on an incompatible core
+
+    Code
+      Snapshot$new(list(Version = 78), upgrade = TRUE)
+    Message
+      i Creating snapshot from list data
+    Condition
+      Error in `initialize()`:
+      ! Cannot migrate this snapshot with the installed ospsuite core.
+      i The installed core would emit Version 82, which is above the highest version osp.snapshots supports (Version 81).
+      i Upgrade osp.snapshots (or install a matching ospsuite) before migrating.
 
 # Snapshot rejects snapshots missing a Version field
 

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -79,7 +79,6 @@
       Error in `private$.validate_version()`:
       ! Snapshot Version 73 is too old to migrate.
       i osp.snapshots supports snapshots from Version 79 to 81, and can migrate Version 74 to 78.
-      i Re-export the project from a newer PK-Sim before loading it.
 
 ---
 
@@ -91,7 +90,6 @@
       Error in `private$.validate_version()`:
       ! Snapshot Version 73 is too old to migrate.
       i osp.snapshots supports snapshots from Version 79 to 81, and can migrate Version 74 to 78.
-      i Re-export the project from a newer PK-Sim before loading it.
 
 # Snapshot rejects snapshots newer than the supported ceiling
 
@@ -101,8 +99,8 @@
       i Creating snapshot from list data
     Condition
       Error in `private$.validate_version()`:
-      ! Snapshot Version 82 is not supported yet.
-      i osp.snapshots supports snapshots up to Version 81; upgrade osp.snapshots to load newer snapshots.
+      ! Snapshot Version 82 is not supported in this version.
+      i osp.snapshots v1.0.0.9001 supports snapshots up to Version 81.
 
 ---
 
@@ -112,8 +110,8 @@
       i Reading snapshot from 'data/snapshot_v82.json'
     Condition
       Error in `private$.validate_version()`:
-      ! Snapshot Version 82 is not supported yet.
-      i osp.snapshots supports snapshots up to Version 81; upgrade osp.snapshots to load newer snapshots.
+      ! Snapshot Version 82 is not supported in this version.
+      i osp.snapshots v1.0.0.9001 supports snapshots up to Version 81.
 
 ---
 
@@ -123,8 +121,8 @@
       i Creating snapshot from list data
     Condition
       Error in `private$.validate_version()`:
-      ! Snapshot Version 82 is not supported yet.
-      i osp.snapshots supports snapshots up to Version 81; upgrade osp.snapshots to load newer snapshots.
+      ! Snapshot Version 82 is not supported in this version.
+      i osp.snapshots v1.0.0.9001 supports snapshots up to Version 81.
 
 # Snapshot warns when a snapshot is newer than the installed core
 
@@ -150,6 +148,60 @@
       ! Cannot migrate this snapshot with the installed ospsuite core.
       i The installed core would emit Version 82, which is above the highest version osp.snapshots supports (Version 81).
       i Upgrade osp.snapshots (or install a matching ospsuite) before migrating.
+
+# Snapshot rejects an invalid upgrade argument
+
+    Code
+      Snapshot$new(list(Version = 80), upgrade = 1)
+    Condition
+      Error in `initialize()`:
+      ! `upgrade` must be a single `TRUE` or `FALSE`.
+
+---
+
+    Code
+      Snapshot$new(list(Version = 80), upgrade = "TRUE")
+    Condition
+      Error in `initialize()`:
+      ! `upgrade` must be a single `TRUE` or `FALSE`.
+
+---
+
+    Code
+      Snapshot$new(list(Version = 80), upgrade = NA)
+    Condition
+      Error in `initialize()`:
+      ! `upgrade` must be a single `TRUE` or `FALSE`.
+
+---
+
+    Code
+      Snapshot$new(list(Version = 80), upgrade = c(TRUE, FALSE))
+    Condition
+      Error in `initialize()`:
+      ! `upgrade` must be a single `TRUE` or `FALSE`.
+
+# Snapshot rejects a non-integer Version instead of truncating it
+
+    Code
+      Snapshot$new(list(Version = 81.9))
+    Message
+      i Creating snapshot from list data
+    Condition
+      Error in `private$.validate_version()`:
+      ! Snapshot is missing an integer Version field.
+      i osp.snapshots requires PK-Sim v11+ snapshots (Version >= 79).
+
+---
+
+    Code
+      Snapshot$new(list(Version = "81"))
+    Message
+      i Creating snapshot from list data
+    Condition
+      Error in `private$.validate_version()`:
+      ! Snapshot is missing an integer Version field.
+      i osp.snapshots requires PK-Sim v11+ snapshots (Version >= 79).
 
 # Snapshot rejects snapshots missing a Version field
 

--- a/tests/testthat/data/snapshot_v73.json
+++ b/tests/testthat/data/snapshot_v73.json
@@ -1,0 +1,4 @@
+{
+    "Version": 73,
+    "Name": "Below migration floor"
+}

--- a/tests/testthat/data/snapshot_v78.json
+++ b/tests/testthat/data/snapshot_v78.json
@@ -1,0 +1,4 @@
+{
+    "Version": 78,
+    "Name": "Migration band edge"
+}

--- a/tests/testthat/data/snapshot_v80.json
+++ b/tests/testthat/data/snapshot_v80.json
@@ -1,0 +1,6 @@
+{
+    "Version": 80,
+    "Name": "In band, not latest",
+    "Compounds": [],
+    "Individuals": []
+}

--- a/tests/testthat/data/snapshot_v81.json
+++ b/tests/testthat/data/snapshot_v81.json
@@ -1,0 +1,6 @@
+{
+    "Name": "In band latest",
+    "Version": 81,
+    "Compounds": [],
+    "Individuals": []
+}

--- a/tests/testthat/data/snapshot_v82.json
+++ b/tests/testthat/data/snapshot_v82.json
@@ -1,0 +1,4 @@
+{
+    "Name": "Above ceiling",
+    "Version": 82
+}

--- a/tests/testthat/test-create_snapshot.R
+++ b/tests/testthat/test-create_snapshot.R
@@ -87,6 +87,28 @@ test_that("v80 authoring omits the v81-only CheckNegativeValues solver field", {
   expect_null(solver$CheckNegativeValues)
 })
 
+test_that("authoring above v81 still emits CheckNegativeValues (future-proof)", {
+  # The field is anchored to the fixed version 81 that introduced it, not to
+  # the current ceiling, so raising `SUPPORTED_VERSION_MAX` must not stop it
+  # being emitted for versions at or above 81. Lift the ceiling above the
+  # snapshot version so a version-82 snapshot loads in band, and pin the
+  # installed core to 82 so no newer-than-installed warning fires, then
+  # confirm the solver still carries the field. Under a ceiling-coupled test
+  # (version equal to the ceiling) this case could not distinguish the fixed
+  # anchor from the ceiling; keeping version < ceiling is what pins it.
+  testthat::local_mocked_bindings(
+    SUPPORTED_VERSION_MAX = 83L,
+    .installed_core_version = function() 82L,
+    .package = "osp.snapshots"
+  )
+
+  s <- Snapshot$new(list(Version = 82))
+  s <- add_simulation(s, name = "Sim", model = "M", individual = "I")
+
+  solver <- s$data$Simulations[[1]]$Solver
+  expect_true(solver$CheckNegativeValues)
+})
+
 test_that("create_snapshot result composes with add_*() mutators", {
   s <- add_compound(create_snapshot(), create_compound(name = "Drug X"))
 

--- a/tests/testthat/test-create_snapshot.R
+++ b/tests/testthat/test-create_snapshot.R
@@ -3,8 +3,8 @@ test_that("create_snapshot creates an empty snapshot", {
 
   expect_s3_class(s, "Snapshot")
   expect_named(s$data, "Version")
-  expect_equal(s$data$Version, 80)
-  expect_equal(s$pksim_version, "12.0")
+  expect_equal(s$data$Version, 81)
+  expect_equal(s$pksim_version, "13.0")
 })
 
 test_that("create_snapshot injects Name when supplied", {
@@ -26,7 +26,16 @@ test_that("create_snapshot injects both Name and Description", {
 
   expect_equal(s$data$Name, "P")
   expect_equal(s$data$Description, "d")
-  expect_equal(s$data$Version, 80)
+  expect_equal(s$data$Version, 81)
+})
+
+test_that("create_snapshot orders Name before Version for the v81 shape", {
+  s <- create_snapshot(name = "P")
+
+  # v81 serializes the top-level `Name` before `Version`; list order is the
+  # serialization order under `jsonlite`.
+  data_keys <- names(s$data)
+  expect_lt(match("Name", data_keys), match("Version", data_keys))
 })
 
 test_that("create_snapshot writes empty strings verbatim", {
@@ -37,13 +46,45 @@ test_that("create_snapshot writes empty strings verbatim", {
 })
 
 test_that("create_snapshot result round-trips through export and load", {
+  # Stub the installed core so an authored v81 snapshot reloads without the
+  # newer-than-installed warning on an older test machine.
+  testthat::local_mocked_bindings(
+    .installed_core_version = function() SUPPORTED_VERSION_MAX,
+    .package = "osp.snapshots"
+  )
   path <- withr::local_tempfile(fileext = ".json")
 
   export_snapshot(create_snapshot(), path)
   reloaded <- load_snapshot(path)
 
   expect_s3_class(reloaded, "Snapshot")
-  expect_equal(reloaded$data$Version, 80)
+  expect_equal(reloaded$data$Version, 81)
+})
+
+test_that("v81 authoring serializes Name first and a CheckNegativeValues solver", {
+  path <- withr::local_tempfile(fileext = ".json")
+
+  s <- create_snapshot(name = "P")
+  s <- suppressWarnings(
+    add_simulation(s, name = "Sim", model = "M", individual = "I")
+  )
+  export_snapshot(s, path)
+  txt <- paste(readLines(path), collapse = "\n")
+
+  # Top-level `Name` precedes `Version` in the exported JSON.
+  expect_lt(regexpr("\"Name\"", txt), regexpr("\"Version\"", txt))
+  # The authored v81 solver carries `CheckNegativeValues`.
+  expect_match(txt, "CheckNegativeValues")
+})
+
+test_that("v80 authoring omits the v81-only CheckNegativeValues solver field", {
+  s <- Snapshot$new(list(Version = 80))
+  s <- suppressWarnings(
+    add_simulation(s, name = "Sim", model = "M", individual = "I")
+  )
+
+  solver <- s$data$Simulations[[1]]$Solver
+  expect_null(solver$CheckNegativeValues)
 })
 
 test_that("create_snapshot result composes with add_*() mutators", {

--- a/tests/testthat/test-snapshot-migration.R
+++ b/tests/testthat/test-snapshot-migration.R
@@ -1,0 +1,44 @@
+# Integration test for the real below-floor migration round trip
+# (`load_snapshot(..., upgrade = TRUE)` -> `.migrate_snapshot()`).
+#
+# This exercises the live PK-Sim core, which is slow (minutes) and, on the v12
+# core, segfaults during `loadProjectFromSnapshot()` on macOS (the whole
+# OSPSuite-R snapshot-conversion suite is skipped on macOS for that reason).
+# It therefore runs only where a compatible core exists: it is skipped on CI
+# and skipped unless the installed core is at least the supported floor. In
+# practice it runs on the maintainer's v13 macOS stack.
+
+test_that("upgrade = TRUE migrates a below-floor snapshot through PK-Sim", {
+  testthat::skip_on_cran()
+  testthat::skip_on_ci()
+  testthat::skip_if_offline()
+  # The v12 core segfaults on macOS during snapshot conversion; only run
+  # where the installed core sits within the supported band (v13 emits 81).
+  testthat::skip_if(
+    .installed_core_version() < SUPPORTED_VERSION_MAX,
+    "requires a PK-Sim core that emits a supported snapshot version"
+  )
+
+  # A real below-floor snapshot: the Midazolam-Model v1.1 release is Version
+  # 78. A hand-authored stub would not survive a real core load, so use the
+  # published snapshot.
+  url <- paste0(
+    "https://raw.githubusercontent.com/Open-Systems-Pharmacology/",
+    "Midazolam-Model/v1.1/Midazolam-Model.json"
+  )
+  input <- withr::local_tempfile(fileext = ".json")
+  utils::download.file(url, input, quiet = TRUE)
+
+  before <- list.files(getwd(), recursive = TRUE)
+  snapshot <- load_snapshot(input, upgrade = TRUE)
+  after <- list.files(getwd(), recursive = TRUE)
+
+  expect_s3_class(snapshot, "Snapshot")
+  # The upgraded version is whatever the installed core emits.
+  expect_equal(
+    as.integer(unlist(snapshot$data$Version)),
+    .installed_core_version()
+  )
+  # Temp migration artifacts must not leak into the working tree.
+  expect_setequal(before, after)
+})

--- a/tests/testthat/test-snapshot-migration.R
+++ b/tests/testthat/test-snapshot-migration.R
@@ -13,10 +13,12 @@ test_that("upgrade = TRUE migrates a below-floor snapshot through PK-Sim", {
   testthat::skip_on_ci()
   testthat::skip_if_offline()
   # The v12 core segfaults on macOS during snapshot conversion; only run
-  # where the installed core sits within the supported band (v13 emits 81).
+  # where the installed core emits exactly the current authoring version
+  # (v13 emits 81). A core emitting anything else (an older 80, or a future
+  # 82+ that migration would reject) is skipped.
   testthat::skip_if(
-    .installed_core_version() < SUPPORTED_VERSION_MAX,
-    "requires a PK-Sim core that emits a supported snapshot version"
+    .installed_core_version() != SUPPORTED_VERSION_MAX,
+    "requires a PK-Sim core that emits the current supported snapshot version"
   )
 
   # A real below-floor snapshot: the Midazolam-Model v1.1 release is Version

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -708,6 +708,30 @@ test_that("Snapshot migration aborts before converting on an incompatible core",
   )
 })
 
+test_that("Snapshot rejects an invalid upgrade argument", {
+  # `upgrade` must be a single, non-missing logical: numeric, character, NA,
+  # and vector inputs are rejected at the public boundary rather than being
+  # silently treated as FALSE.
+  expect_snapshot(Snapshot$new(list(Version = 80), upgrade = 1), error = TRUE)
+  expect_snapshot(
+    Snapshot$new(list(Version = 80), upgrade = "TRUE"),
+    error = TRUE
+  )
+  expect_snapshot(Snapshot$new(list(Version = 80), upgrade = NA), error = TRUE)
+  expect_snapshot(
+    Snapshot$new(list(Version = 80), upgrade = c(TRUE, FALSE)),
+    error = TRUE
+  )
+})
+
+test_that("Snapshot rejects a non-integer Version instead of truncating it", {
+  # A fractional version (`81.9`) or a numeric string (`"81"`) must not be
+  # silently coerced past the version gate; both are treated as a missing
+  # integer Version and abort.
+  expect_snapshot(Snapshot$new(list(Version = 81.9)), error = TRUE)
+  expect_snapshot(Snapshot$new(list(Version = "81")), error = TRUE)
+})
+
 test_that("Snapshot rejects snapshots missing a Version field", {
   expect_snapshot(Snapshot$new(list(Compounds = list())), error = TRUE)
 })

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -12,6 +12,7 @@ test_that("Snapshot class works", {
     raw_version <- as.integer(snapshot$data$Version)
     expected_version <- switch(
       as.character(raw_version),
+      "81" = "13.0",
       "80" = "12.0",
       "79" = "11.2",
       "78" = "10.0",
@@ -599,24 +600,112 @@ test_that("Snapshot$export creates a valid JSON file", {
 
 test_that("Snapshot correctly handles version mapping for all known versions", {
   versions <- list(
+    "81" = "13.0",
     "80" = "12.0",
     "79" = "11.2"
   )
 
   for (v in names(versions)) {
+    # Stub the installed core to the latest so an 81 snapshot loads without
+    # the newer-than-installed warning on an older test machine.
+    withr::local_options(lifecycle_verbosity = "quiet")
+    testthat::local_mocked_bindings(
+      .installed_core_version = function() SUPPORTED_VERSION_MAX,
+      .package = "osp.snapshots"
+    )
     snapshot_data <- list(Version = as.numeric(v))
     snapshot <- Snapshot$new(snapshot_data)
     expect_equal(snapshot$pksim_version, versions[[v]])
   }
-
-  # Newer (unrecognised but supported) version maps to "Unknown".
-  snapshot_data <- list(Version = 999)
-  snapshot <- Snapshot$new(snapshot_data)
-  expect_equal(snapshot$pksim_version, "Unknown")
 })
 
-test_that("Snapshot rejects pre-v11 snapshots", {
+test_that("Snapshot migration-band snapshots report how to upgrade and abort", {
+  # A `74-78` snapshot with the default `upgrade = FALSE` names the detected
+  # version, points at `upgrade = TRUE`, warns about the round-trip cost, and
+  # returns no object. Covers both a list input and a file fixture.
   expect_snapshot(Snapshot$new(list(Version = 78)), error = TRUE)
+  expect_snapshot(
+    Snapshot$new(testthat::test_path("data", "snapshot_v78.json")),
+    error = TRUE
+  )
+})
+
+test_that("Snapshot rejects snapshots too old to migrate", {
+  # Below the `74` migration floor there is nothing to migrate, so this is a
+  # hard error distinct from the below-floor migration-band message.
+  expect_snapshot(Snapshot$new(list(Version = 73)), error = TRUE)
+  expect_snapshot(
+    Snapshot$new(testthat::test_path("data", "snapshot_v73.json")),
+    error = TRUE
+  )
+})
+
+test_that("Snapshot rejects snapshots newer than the supported ceiling", {
+  # Over the ceiling is a hard "not supported yet" error, independent of
+  # `upgrade` and the installed core.
+  expect_snapshot(Snapshot$new(list(Version = 82)), error = TRUE)
+  expect_snapshot(
+    Snapshot$new(testthat::test_path("data", "snapshot_v82.json")),
+    error = TRUE
+  )
+  expect_snapshot(
+    Snapshot$new(list(Version = 82), upgrade = TRUE),
+    error = TRUE
+  )
+})
+
+test_that("Snapshot loads in-band versions and never migrates them", {
+  # 79, 80, and 81 all load without migration, regardless of `upgrade`.
+  testthat::local_mocked_bindings(
+    .installed_core_version = function() SUPPORTED_VERSION_MAX,
+    .package = "osp.snapshots"
+  )
+  for (v in c(79, 80, 81)) {
+    expect_s3_class(Snapshot$new(list(Version = v)), "Snapshot")
+    expect_s3_class(Snapshot$new(list(Version = v), upgrade = TRUE), "Snapshot")
+  }
+  expect_s3_class(
+    Snapshot$new(testthat::test_path("data", "snapshot_v80.json")),
+    "Snapshot"
+  )
+  expect_s3_class(
+    Snapshot$new(testthat::test_path("data", "snapshot_v81.json")),
+    "Snapshot"
+  )
+})
+
+test_that("Snapshot warns when a snapshot is newer than the installed core", {
+  # Installed core emits 80: an in-band 81 snapshot loads with a warning; an
+  # 80 or 79 snapshot does not warn.
+  testthat::local_mocked_bindings(
+    .installed_core_version = function() 80L,
+    .package = "osp.snapshots"
+  )
+  expect_snapshot(s <- Snapshot$new(list(Version = 81)))
+  expect_s3_class(s, "Snapshot")
+  expect_no_warning(Snapshot$new(list(Version = 80)))
+  expect_no_warning(Snapshot$new(list(Version = 79)))
+
+  # Installed core emits 81: the same 81 snapshot loads without the warning.
+  testthat::local_mocked_bindings(
+    .installed_core_version = function() 81L,
+    .package = "osp.snapshots"
+  )
+  expect_no_warning(Snapshot$new(list(Version = 81)))
+})
+
+test_that("Snapshot migration aborts before converting on an incompatible core", {
+  # When the installed core would emit a version above the ceiling, migrating
+  # would produce a snapshot this package can no longer load, so the
+  # precondition aborts before any round trip and no object is returned.
+  testthat::local_mocked_bindings(
+    .installed_core_version = function() 82L,
+    .package = "osp.snapshots"
+  )
+  expect_snapshot(
+    Snapshot$new(list(Version = 78), upgrade = TRUE),
+    error = TRUE
+  )
 })
 
 test_that("Snapshot rejects snapshots missing a Version field", {


### PR DESCRIPTION
Closes #161

This gives `osp.snapshots` an explicit, testable supported-version contract for PK-Sim JSON snapshots (a floor and a ceiling), an opt-in path to migrate older-than-floor snapshots up into that band via PK-Sim itself, a guardrail so migration cannot produce a snapshot the package can no longer load, a warning when a supported snapshot is newer than the installed `ospsuite` core, and version-aware authoring so a PK-Sim v13 (`Version 81`) snapshot round-trips correctly. All version-handling decisions stay centralized at the single `Snapshot$initialize()` chokepoint; migration is orchestrated at the load boundary; and the installed-core query is a thin, test-substitutable seam so the whole decision surface is unit-testable without a live core.

## Version bounds

`R/Snapshot.R` gains a `SUPPORTED_VERSION_MAX <- 81L` ceiling alongside the existing `SUPPORTED_VERSION_MIN <- 79L` floor, plus a `MIGRATION_VERSION_MIN <- 74L` for the migration band. `.validate_version()` is rewritten to enforce, top to bottom: missing/malformed `Version` (unchanged message), below `74` (too old to migrate, a distinct hard error), the `74-78` migration band (reports how to migrate, then aborts, when `upgrade = FALSE`), above the ceiling (not supported yet), and in-band success. Every user-facing number interpolates the constants rather than a literal. All load paths (`Snapshot$new()` for file/URL/list, `load_snapshot()`, templates) funnel through this one validator.

## Upgrade and migration

`Snapshot$new()` / `Snapshot$initialize()` and `load_snapshot()` gain an `upgrade` argument (default `FALSE`), forwarded through every `load_snapshot()` construction site (local file, URL, template). Migration is orchestrated in `initialize()` immediately after parsing `.original_data` and before validation: when the raw version is in `74-78` and `upgrade = TRUE`, a compatibility precondition runs first (if the installed core would emit a version above the ceiling, it aborts before any conversion with an "upgrade osp.snapshots" message), then the two-step PK-Sim round trip runs and its upgraded data replaces `.original_data`, so validation runs on the upgraded snapshot. Either migration succeeds and the upgraded object validates, or the precondition/round trip errors and no object is constructed. `.abs_path` is left pointing at the original input (or `NULL` for list input), never the temp file. The new free internal `.migrate_snapshot()` writes all intermediate artifacts to a `withr::local_tempdir()` (cleaned up on exit, including on error, so concurrent loads never collide), tells the user migration may be slow before starting, calls `ospsuite::loadProjectFromSnapshot(input, output = <dir>, runSimulations = FALSE)` then `ospsuite::exportProjectToSnapshot(<project>, output = <dir>)`, and returns the parsed upgraded snapshot list.

## Version-aware authoring

`create_snapshot()` now authors at `SUPPORTED_VERSION_MAX` (81) rather than a hardcoded `80`, and orders the top-level `Name` before `Version` for the v81 shape (list order is `jsonlite`'s serialization order). `.build_simulation()` gains a single, minimal version branch: when the snapshot is at `81` the emitted `Solver` block carries `CheckNegativeValues`; at `79`/`80` it does not. The branch is gated on the snapshot's own version at the authoring boundary, so no other `add_*` mutator and neither the `SolverSettings` R6 class nor `create_solver_settings()` are touched.

## Newer-than-installed warning and version reporting

`.get_pksim_version()` maps `81 -> "13.0"` alongside the existing `80 -> "12.0"` and `79 -> "11.2"`, so v81 snapshots print and report their PK-Sim version. On success, `.validate_version()` compares the in-band version against the installed core (via the new free internal `.installed_core_version()` seam, which maps the installed `ospsuite` major `11/12/13 -> 79/80/81` and falls back to the ceiling for an unknown major or a failed query) and emits a `cli::cli_warn` when the snapshot is newer than the installed core would emit. Both `.installed_core_version()` and `.migrate_snapshot()` are free internal functions (not R6 methods) so tests can stub them with `withr::local_mocked_bindings()`. A shared private `.raw_version()` helper is factored out so validation, version reporting, and the solver branch all read `Version` identically.

## Schema reference

`.claude/snapshot-spec.md` documents v81: the "Version Compatibility Summary" adds a `v13 | 81` row (top-level `Name` reordered before `Version`; `CheckNegativeValues` added to the solver settings), relabels `80` from "current" to "prior", updates the top-level `Version` note to `81` (v13), notes the `Name` ordering change and that the field already existed at v80, adds a `CheckNegativeValues` row to the `SolverSettings` section, and records that the issue's "ExpressionProfiles promoted to a top-level block at v13" framing was superseded by direct inspection (top-level `ExpressionProfiles` predates v13 and is a v11 / version-79 feature). PK-Sim remains named as the authoritative schema source.

## Tests and docs

New unit tests (no live core) in `test-snapshot.R` cover the below-floor migration-band message-then-abort, the too-old-to-migrate error, the over-ceiling error (independent of `upgrade`), in-band loads never migrating, the newer-than-installed warning (stubbing the core to 80 to warn on 81, to 81 to not warn), and the incompatible-core migration precondition (stubbing the core to 82). New boundary fixtures live under `tests/testthat/data/` (`snapshot_v73/v78/v80/v81/v82.json`); the existing v79 fixtures are untouched so back-compatibility tests keep asserting the unchanged v79 behaviour. `test-create_snapshot.R` is updated to assert `Version 81` / `pksim_version "13.0"`, that `Name` precedes `Version`, that a v81 authored solver carries `CheckNegativeValues`, and that a v80 authored solver omits it. The existing v78 "rejects pre-v11" test is reconciled to the new migration-band behaviour. A gated integration test (`test-snapshot-migration.R`) exercises the real round trip; it is `skip_on_ci()` / `skip_on_cran()` and skips unless the installed core emits a supported version, so it runs only on the maintainer's v13 stack. `NEWS.md` gains dev-version bullets for the v13 authoring, the `upgrade` migration path, v81 support with the over-ceiling error, and the newer-than-installed warning, reconciled against the released `Version >= 79` floor bullet. `man/` and `NAMESPACE` were regenerated with `devtools::document()` (no new exports; both new helpers are internal).

## Verification notes and unverified assumptions

Two parts depend on a stack not available on this build machine (installed core is `ospsuite` 12.4.3, a v12 line that emits `Version 80` and segfaults on macOS snapshot conversion), and are wired per the documented signatures / plan assumptions:

- The `ospsuite` round-trip signatures were confirmed against the installed package: both `loadProjectFromSnapshot(..., output = ".", runSimulations = FALSE)` and `exportProjectToSnapshot(..., output = ".")` take input paths via `...`, write output files into the `output` directory, and do not return a documented output path. `.migrate_snapshot()` therefore writes to a temp `output` directory and locates the produced `.pksim5` / `.json` by listing that directory rather than relying on a return value. The real round trip could not be exercised here (v12 macOS segfault, CI-skipped), so the integration test is gated as described.
- `CheckNegativeValues` is emitted as a `Solver` sibling of `AbsTol`/`RelTol` with default `TRUE`, per the plan's assumption. This exact key name, placement, and default value could not be confirmed against a real v81 `Solver` block on this v12 machine and should be verified on the maintainer's v13 stack; if the real default differs, adjust the emitted value in `.build_simulation()`.

## Test results

Full suite under `NOT_CRAN=true`: `FAIL 0 | WARN 22 | SKIP 1 | PASS 3101` (baseline before this change was `FAIL 0 | WARN 1 | PASS 3077`). The 1 skip is the gated migration integration test. The added warnings are the intended FR-12 newer-than-installed warning firing whenever a v81 snapshot (including any `create_snapshot()` result) is loaded on this v12 machine; this is the documented, expected behaviour, not a defect. The pre-existing `devtools::document()` warnings about undocumented `add_*`/`remove_*` params on the `Snapshot` R6 class predate this branch and are left untouched.

## Example

The version-bounds and messaging behaviour is shown below without a live core (rendered on the build machine, whose installed core emits `Version 80`; the migration round trip itself requires a live v13 PK-Sim core and is exercised only by the gated integration test):

```r
library(osp.snapshots)

# create_snapshot() now authors Version 81, Name before Version
str(create_snapshot(name = "Demo")$data)
#> List of 2
#>  $ Name   : chr "Demo"
#>  $ Version: int 81

# A snapshot above the ceiling is a hard error
Snapshot$new(list(Version = 82))
#> Error: Snapshot Version 82 is not supported yet.
#> i osp.snapshots supports snapshots up to Version 81; upgrade osp.snapshots to
#>   load newer snapshots.

# A below-floor snapshot reports how to migrate, then aborts (upgrade = FALSE)
Snapshot$new(list(Version = 78))
#> Error: Snapshot Version 78 is below the supported floor.
#> i Set `upgrade = TRUE` to migrate it up to whatever the installed ospsuite
#>   core emits (currently Version 80).
#> i Migration round-trips the snapshot through PK-Sim and can take several minutes.

# A supported snapshot newer than the installed core loads with a warning
Snapshot$new(list(Version = 81))
#> Warning: Snapshot Version 81 is newer than the installed ospsuite core (Version 80).
#> i It may not load or run in the installed ospsuite; editing and exporting still work here.
#> (returns a Snapshot)
```

# QA: Approved

The implementation satisfies every functional requirement of the spec (FR-1..FR-18) and follows the plan's design (D1-D6). I mapped each requirement to the actual code in the worktree, checked scope and conventions, and independently ran the tests: the full suite reproduces the builder's claim exactly (`FAIL 0 | WARN 22 | SKIP 1 | PASS 3101`), with the WARN inflation being the intended FR-12 newer-than-installed warnings on this v12 machine and the SKIP being the correctly gated migration integration test. The two items that cannot be exercised here (the live migration round trip and the exact `CheckNegativeValues` key/default) are the explicitly flagged, known-acceptable follow-ups, both implemented per the plan's documented assumptions, not blocking defects.

<details>
<summary>Full QA report</summary>

## Test runs I performed (worktree, `NOT_CRAN=true`)

Installed core in this checkout: `ospsuite 12.4.3.9013` (v12 line, emits `Version 80`), confirming the environment the builder described.

- `test-snapshot.R` (via `devtools::load_all()` then `testthat::test_file`): `FAIL 0 | WARN 1 | SKIP 0 | PASS 258`.
- `test-create_snapshot.R`: `FAIL 0 | WARN 9 | SKIP 0 | PASS 27`.
- `devtools::test(filter = "snapshot|create_snapshot")`: `FAIL 0 | WARN 10 | SKIP 1 | PASS 390`.
- Full suite `devtools::test()`: `FAIL 0 | WARN 22 | SKIP 1 | PASS 3101` (exactly the builder's reported figure).
- `test-snapshot-migration.R` run in isolation: the single test skips with reason "requires a PK-Sim core that emits a supported snapshot version" (the `skip_if(.installed_core_version() < SUPPORTED_VERSION_MAX)` gate fires because the v12 core emits 80 < 81). Confirmed the SKIP 1 is this gated integration test, not a hidden failure.
- `devtools::document()` produced no working-tree diff (`git status` clean afterward), confirming `man/` and `NAMESPACE` are in sync with the roxygen and no export was added. The undocumented `add_*`/`remove_*` param messages are pre-existing and touched no files.

## Requirement mapping (evidence in the worktree)

Paths are under `/Users/felix/Code/osp.snapshots.worktrees/161-handle-snapshot-version`.

- **FR-1 (ceiling constant + constants as single source of truth).** `R/Snapshot.R:10` `SUPPORTED_VERSION_MAX <- 81L`, alongside `SUPPORTED_VERSION_MIN <- 79L` (`R/Snapshot.R:4`) and a new `MIGRATION_VERSION_MIN <- 74L` (`R/Snapshot.R:16`). Every user-facing message interpolates these constants (`{SUPPORTED_VERSION_MIN}`, `{SUPPORTED_VERSION_MAX}`, `{MIGRATION_VERSION_MIN}`, `{version_num}`, `{installed}`); a grep for hardcoded version literals in message text found only comments/roxygen (`R/Snapshot.R:1481,1711,1715`), never a `cli_*` string. The rendered "Version >= 79" / "up to Version 81" in the snapshots are interpolation output, not literals.
- **FR-2 / FR-3 / FR-4 / FR-9 (bounds, ordering).** `.validate_version()` (`R/Snapshot.R:193-242`) enforces top to bottom: NA -> missing-version abort; `< 74` -> "too old to migrate" (distinct wording, `R/Snapshot.R:201`); `74:78` -> below-floor message-then-abort; `> 81` -> "not supported yet" naming detected + max (`R/Snapshot.R:228`); in-band success. Over-ceiling and below-74 abort regardless of `upgrade` (the `upgrade = TRUE` `Version 82` snapshot in `_snaps/snapshot.md` still hits the ceiling error). In-band `79/80/81` load and never migrate (test `Snapshot loads in-band versions and never migrates them` asserts `S3` for both `upgrade` values). The below-74 error and over-ceiling error are genuinely distinct messages (`_snaps/snapshot.md`).
- **FR-5..FR-8, FR-11 (upgrade / migration).** `upgrade` arg (default `FALSE`) added to `initialize()` (`R/Snapshot.R:92`) and `load_snapshot()` (`R/Snapshot.R:1734`), forwarded on all three `load_snapshot` construction sites: file (`:1742`), URL (`:1763`), template (`:1803`). Migration is orchestrated in `initialize()` before `.validate_version()` (`R/Snapshot.R:113-138`). FR-7 message-then-abort is a single `cli::cli_abort` (atomic, no partial object) naming the detected version, describing the target as "whatever the installed ospsuite core emits (currently Version 80)", instructing `upgrade = TRUE`, and warning it can take several minutes (`R/Snapshot.R:208-226`; `_snaps/snapshot.md`). FR-11 precondition aborts BEFORE any conversion when `.installed_core_version() > SUPPORTED_VERSION_MAX` (`R/Snapshot.R:127-134`); the snapshot shows `Error in initialize()` (not in `.migrate_snapshot`), proving no round trip runs. `.migrate_snapshot()` uses `withr::local_tempdir()` (`R/Snapshot.R:378`) cleaned on exit including error, normalizes list/URL input to a temp `.json`, alerts about slowness before starting, and returns the parsed upgraded list. `.abs_path` is set only during the initial parse (`R/Snapshot.R:97-99`) and migration replaces only `.original_data` (`:135`), so it never points at the temp file.
- **FR-10 / D1 (test seam).** `.installed_core_version()` and `.migrate_snapshot()` are FREE internal functions (`R/Snapshot.R:343` and `:377`), not R6 private methods, so `withr::local_mocked_bindings(.installed_core_version = ..., .package = "osp.snapshots")` works. The major->version mapping (`11->79, 12->80, 13->81`, unknown/failed -> ceiling) is documented in the comment (`R/Snapshot.R:327-342`) and implemented via a `switch` with a `SUPPORTED_VERSION_MAX` default (`:351-357`). FR-11 and FR-12 unit tests stub this seam and assert the right behaviour without a live core (test-snapshot.R `... incompatible core` stubs `82L`; `... newer than the installed core` stubs `80L`/`81L`).
- **FR-12 / FR-14 (warning + reporting).** `.get_pksim_version()` maps `"81" = "13.0"` (`R/Snapshot.R:1055`) via the shared `.raw_version()`. The newer-than-installed check is a `cli::cli_warn` (not error) for in-band `> installed` (`R/Snapshot.R:234-241`), and does not fire for `<= installed`; the fallback-to-ceiling on unknown/missing core prevents a spurious downward warning. Tests confirm 81 warns on a stubbed-80 core, and does not warn on a stubbed-81 core, and 79/80 never warn (`expect_no_warning`).
- **FR-13 (additive / back-compat).** Existing v79 fixtures (`empty_snapshot.json`, `test_snapshot.json`, `obsdata_no_unit.json`) are untouched (not in the diff); no new required field is introduced. The suite's many v79-based tests still pass unchanged.
- **FR-15 / FR-16 / FR-17 (authoring).** `create_snapshot()` defaults to `SUPPORTED_VERSION_MAX` with `Name` built before `Version` (`R/create_snapshot.R:52-56`), no new `version` arg, `Description` after. The ONLY authoring version-branch is in `create_snapshot()` and `.build_simulation()` (`R/Snapshot.R:1486-1490`), gated on `identical(private$.raw_version(), SUPPORTED_VERSION_MAX)` (integer-integer, correct), setting `data$Solver$CheckNegativeValues <- TRUE` only when absent, v81-only. `SolverSettings` R6 class and `create_solver_settings()` are NOT touched (not in the `--stat`). Tests assert `Name` precedes `Version` in exported JSON, v81 solver carries `CheckNegativeValues`, and v80 authoring omits it (`expect_null`).
- **FR-18 (schema reference).** `.claude/snapshot-spec.md:951` adds the `v13 | 81` row (Name reordered before Version, CheckNegativeValues added), relabels `80` from "Current" to "Prior" (`:950`), updates the top-level `Version` note to `81 (v13)` (`:11`), adds the `CheckNegativeValues` `SolverSettings` row (`:20` of the doc), adds the `Name`-ordering note, and records that the ExpressionProfiles-at-v13 framing was superseded (`:953`), naming PK-Sim as authoritative. Prose is single-line paragraphs; no external identifier is referenced (it says "an earlier framing" in prose).

## Convention checks

- Base pipe, `\()`/`function(){}`, exported-before-internal ordering all respected; the two new internal helpers sit after the exported `load_snapshot()`.
- No em-dash / en-dash punctuation in any changed file (grep clean).
- `NEWS.md` dev bullets are single-line, present tense, backticked functions with trailing parens, `(#161)` linked, ordered alphabetically by function (`create_snapshot()`, `fraction_unbound()`, three `load_snapshot()`); the released `Version >= 79` floor bullet is preserved and not contradicted.
- The previous `Version = 78` "rejects pre-v11" test was reconciled to the new migration-band behaviour (renamed `Snapshot migration-band snapshots report how to upgrade and abort`), and the corresponding `_snaps` entry now asserts the new below-floor wording, not the old "Unsupported snapshot Version 78" text. The `list(Version = 999)` "Unknown" case was correctly dropped (999 is now an over-ceiling hard error).
- `man/Snapshot.Rd` and `man/load_snapshot.Rd` regenerated; `document()` re-run produced no drift; no new NAMESPACE export.

## Adversarial / edge-case findings

- Checked that over-ceiling and below-74 abort independent of `upgrade`: verified via the `Version 82, upgrade = TRUE` snapshot and the ordering in `.validate_version()`.
- Checked the FR-11 precondition truly precedes any core call: the abort is raised in `initialize()` before `.migrate_snapshot(input)`, and its snapshot shows `Error in initialize()`.
- Checked `.abs_path` cannot dangle at a cleaned-up temp file: it is assigned only from the original input.
- Checked the integration-test gate: `skip_on_cran()` + `skip_on_ci()` + `skip_if_offline()` + `skip_if(.installed_core_version() < SUPPORTED_VERSION_MAX)`. This is stricter than the plan's `skip_on_os("mac")` option and is functionally equivalent for the v12/macOS segfault case (v12 emits 80 < 81, so it skips); it runs only where the core emits 81. Confirmed it skips on this v12 machine. Acceptable and arguably more precise.

## Non-blocking notes / follow-ups (do not affect the verdict)

1. `CheckNegativeValues` exact key name, placement (Solver sibling of `AbsTol`), and default (`TRUE`) are implemented per the plan's documented assumption but could not be confirmed against a real v81 `Solver` block on this v12 machine. This is the explicitly acknowledged assumption to verify on the v13 stack; if the real default differs, adjust the value in `.build_simulation()`. Not a defect.
2. The live migration round trip (FR-8) cannot be exercised here (v12/macOS segfault, CI-skipped upstream). Its integration test being gated/skipped is correct.
3. Minor: the FR-7 message omits a PK-Sim label for `Version 78` because `.get_pksim_version()` only maps 79/80/81. This matches FR-7's "where derivable" qualifier and is correct, not a gap.

</details>

<!-- QA-VERDICT: approved -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for PK-Sim v13 snapshots (Version 81), including new solver settings when simulations are present.
  * Added `upgrade` support to `load_snapshot()` and `Snapshot$new()` to migrate below-floor snapshots on request.
  * Extended `fraction_unbound()` with an optional `species` argument for improved snapshot loading compatibility.
* **Bug Fixes**
  * Improved snapshot version validation and messaging, including warning (not failure) when a supported snapshot is newer than the installed core.
  * Snapshot metadata now serializes with `Name` before `Version`.
* **Documentation**
  * Updated snapshot/version documentation to clarify supported ranges and upgrade behavior.
* **Tests**
  * Expanded version, migration, warning, and solver-field coverage (v73–v82).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->