### PR TITLE
create_protocol(): promote common dosing parameters to plain arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # osp.snapshots (development version)
 
+- `create_protocol()` gains `dose` (with `dose_unit`, default `"mg"`), `start_time` (with `start_time_unit`, default `"h"`), and `end_time` plain arguments for the Simple-Protocol dosing settings, as a validated, self-documenting alternative to hand-building the equivalent `InputDose`/`Start time`/`End time` entries in `parameters` (#157).
 - `fraction_unbound()` gains a `species` argument (default `"Human"`, validated against `ospsuite::Species`) and now emits a `Species` field on the fraction-unbound alternative, which PK-Sim requires to load the snapshot (#156).
 
 # osp.snapshots 1.0.0

--- a/R/create_protocol.R
+++ b/R/create_protocol.R
@@ -24,9 +24,35 @@
 #' @param target_organ Character. Target organ for the dose.
 #' @param target_compartment Character. Target compartment for the
 #'   dose.
+#' @param dose Numeric scalar. Optional dose for a Simple Protocol. When
+#'   supplied it is emitted as a single `InputDose` parameter carrying
+#'   `dose` and `dose_unit`. Mutually exclusive with `schemas`, and with
+#'   an `InputDose` entry in `parameters`.
+#' @param dose_unit Character. Display unit for `dose`, default `"mg"`.
+#'   Validated as a dose-family unit: the unit must belong to one of the
+#'   mass, amount, dose per body weight, or dose per body surface area
+#'   dimensions, and the unit alone selects the family (the emitted
+#'   parameter is always a single `InputDose`). Only consulted when `dose`
+#'   is supplied.
+#' @param start_time Numeric scalar. Optional start time for a Simple
+#'   Protocol. When supplied it is emitted as a `Start time` parameter.
+#'   Mutually exclusive with `schemas`, and with a `Start time` entry in
+#'   `parameters`.
+#' @param start_time_unit Character. Display unit for `start_time`,
+#'   default `"h"`, validated against dimension `"Time"`. Only consulted
+#'   when `start_time` is supplied.
+#' @param end_time Numeric scalar. Optional end time for a Simple
+#'   Protocol. When supplied it is emitted as an `End time` parameter. Its
+#'   display unit is taken from `time_unit`, falling back to `"h"` when
+#'   `time_unit` is unset; there is no separate end-time unit argument.
+#'   Mutually exclusive with `schemas`, and with an `End time` entry in
+#'   `parameters`.
 #' @param parameters List of [Parameter] objects (created with
 #'   [create_parameter()]) or raw parameter lists for Simple Protocol
-#'   parameters such as start time, end time, and dose.
+#'   parameters such as start time, end time, and dose. The common dose,
+#'   start time, and end time settings can instead be supplied via the
+#'   `dose`, `start_time`, and `end_time` arguments; supplying both a
+#'   promoted argument and the same-named `parameters` entry is an error.
 #' @param schemas List of schemas for an Advanced Protocol. Entries may
 #'   be [Schema] objects (created with [create_schema()]) or raw schema
 #'   lists with `Name`, `Parameters`, and `SchemaItems`. If provided,
@@ -38,7 +64,17 @@
 #' @export
 #'
 #' @examples
-#' # Create a simple oral protocol with one dose
+#' # Create a simple oral protocol with one dose via promoted arguments
+#' protocol <- create_protocol(
+#'   name = "Single dose 10mg",
+#'   application_type = "Oral",
+#'   dosing_interval = "Single",
+#'   dose = 10,
+#'   dose_unit = "mg",
+#'   start_time = 0
+#' )
+#'
+#' # The same protocol via the free-form `parameters` escape hatch
 #' protocol <- create_protocol(
 #'   name = "Single dose 10mg",
 #'   application_type = "Oral",
@@ -87,6 +123,11 @@ create_protocol <- function(
   dosing_interval = NULL,
   target_organ = NULL,
   target_compartment = NULL,
+  dose = NULL,
+  dose_unit = "mg",
+  start_time = NULL,
+  start_time_unit = "h",
+  end_time = NULL,
   parameters = NULL,
   schemas = NULL,
   time_unit = NULL
@@ -98,6 +139,9 @@ create_protocol <- function(
       dosing_interval = dosing_interval,
       target_organ = target_organ,
       target_compartment = target_compartment,
+      dose = dose,
+      start_time = start_time,
+      end_time = end_time,
       parameters = parameters
     )
     conflicting <- names(simple_fields)[
@@ -113,6 +157,9 @@ create_protocol <- function(
   }
   if (!is.null(parameters) && !is.list(parameters)) {
     cli::cli_abort("{.arg parameters} must be a list")
+  }
+  if (!is.null(time_unit)) {
+    validate_unit(time_unit, "Time")
   }
 
   data <- list(Name = name)
@@ -152,14 +199,110 @@ create_protocol <- function(
     if (!is.null(target_compartment)) {
       data$TargetCompartment <- target_compartment
     }
+
+    if (
+      !is.null(dose) &&
+        (!is.numeric(dose) || length(dose) != 1 || !is.finite(dose))
+    ) {
+      cli::cli_abort("{.arg dose} must be a single finite numeric value")
+    }
+    if (
+      !is.null(start_time) &&
+        (!is.numeric(start_time) ||
+          length(start_time) != 1 ||
+          !is.finite(start_time))
+    ) {
+      cli::cli_abort("{.arg start_time} must be a single finite numeric value")
+    }
+    if (
+      !is.null(end_time) &&
+        (!is.numeric(end_time) ||
+          length(end_time) != 1 ||
+          !is.finite(end_time))
+    ) {
+      cli::cli_abort("{.arg end_time} must be a single finite numeric value")
+    }
+
+    # The `End time` parameter's display unit derives from `time_unit`,
+    # falling back to PK-Sim's default `"h"` when `time_unit` is unset. This
+    # does not set `data$TimeUnit`; that remains driven solely by `time_unit`.
+    end_time_unit <- if (is.null(time_unit)) "h" else time_unit
+
+    # Build the auto entries for supplied promoted values, in a deterministic
+    # order (dose, start time, end time). Each is the raw
+    # `list(Name=, Value=, Unit=)` shape used in the Simple-Protocol JSON.
+    auto_parameters <- list()
+    if (!is.null(dose)) {
+      auto_parameters <- c(
+        auto_parameters,
+        list(resolve_input_dose_parameter(dose, dose_unit))
+      )
+    }
+    if (!is.null(start_time)) {
+      validate_unit(start_time_unit, "Time")
+      auto_parameters <- c(
+        auto_parameters,
+        list(list(
+          Name = "Start time",
+          Value = start_time,
+          Unit = start_time_unit
+        ))
+      )
+    }
+    if (!is.null(end_time)) {
+      auto_parameters <- c(
+        auto_parameters,
+        list(list(Name = "End time", Value = end_time, Unit = end_time_unit))
+      )
+    }
+
+    # Reject supplying a dosing setting both as a promoted argument and as the
+    # same-named entry in `parameters`. Compare against the `Name`-normalised
+    # identifier so both `create_parameter(name=)` and `create_parameter(path=)`
+    # (Path-keyed) entries are caught.
     if (!is.null(parameters)) {
+      existing_names <- vapply(
+        to_raw_parameters(parameters, "Name"),
+        function(param) param$Name %||% NA_character_,
+        character(1)
+      )
+      if (!is.null(dose) && "InputDose" %in% existing_names) {
+        cli::cli_abort(c(
+          "{.arg dose} conflicts with an {.val InputDose} entry in {.arg parameters}.",
+          "i" = "Supply the dose either as the {.arg dose} argument or as an {.val InputDose} entry in {.arg parameters}, not both."
+        ))
+      }
+      if (!is.null(start_time) && "Start time" %in% existing_names) {
+        cli::cli_abort(c(
+          "{.arg start_time} conflicts with a {.val Start time} entry in {.arg parameters}.",
+          "i" = "Supply the start time either as the {.arg start_time} argument or as a {.val Start time} entry in {.arg parameters}, not both."
+        ))
+      }
+      if (!is.null(end_time) && "End time" %in% existing_names) {
+        cli::cli_abort(c(
+          "{.arg end_time} conflicts with an {.val End time} entry in {.arg parameters}.",
+          "i" = "Supply the end time either as the {.arg end_time} argument or as an {.val End time} entry in {.arg parameters}, not both."
+        ))
+      }
+    }
+
+    # Combine the auto entries (already raw) with the user parameters
+    # (normalised to Name), auto entries first. Only set `data$Parameters` when
+    # the combined list is non-empty, so a call with no promoted arguments and
+    # no `parameters` produces byte-identical output to before this change.
+    user_parameters <- if (!is.null(parameters)) {
+      to_raw_parameters(parameters, "Name")
+    } else {
+      list()
+    }
+    combined <- c(auto_parameters, user_parameters)
+    if (length(combined) > 0) {
       # Simple Protocol parameters use Name (not Path) in the JSON shape.
-      data$Parameters <- to_raw_parameters(parameters, "Name")
+      data$Parameters <- combined
     }
   }
 
   if (!is.null(time_unit)) {
-    validate_unit(time_unit, "Time")
     data$TimeUnit <- time_unit
   }
 

--- a/R/create_protocol.R
+++ b/R/create_protocol.R
@@ -265,29 +265,32 @@ create_protocol <- function(
     # Reject supplying a dosing setting both as a promoted argument and as the
     # same-named entry in `parameters`. Compare against the `Name`-normalised
     # identifier so both `create_parameter(name=)` and `create_parameter(path=)`
-    # (Path-keyed) entries are caught.
+    # (Path-keyed) entries are caught. Collect every offender and report them in
+    # a single error rather than aborting on the first one.
     if (!is.null(parameters)) {
       existing_names <- vapply(
         to_raw_parameters(parameters, "Name"),
         function(param) param$Name %||% NA_character_,
         character(1)
       )
-      if (!is.null(dose) && "InputDose" %in% existing_names) {
+      # Map each supplied promoted argument to its PK-Sim parameter name.
+      promoted_to_pksim <- c(
+        dose = "InputDose",
+        start_time = "Start time",
+        end_time = "End time"
+      )[c(
+        if (!is.null(dose)) "dose",
+        if (!is.null(start_time)) "start_time",
+        if (!is.null(end_time)) "end_time"
+      )]
+      conflicting_args <- names(promoted_to_pksim)[
+        promoted_to_pksim %in% existing_names
+      ]
+      if (length(conflicting_args) > 0) {
         cli::cli_abort(c(
-          "{.arg dose} conflicts with an {.val InputDose} entry in {.arg parameters}.",
-          "i" = "Supply the dose either as the {.arg dose} argument or as an {.val InputDose} entry in {.arg parameters}, not both."
-        ))
-      }
-      if (!is.null(start_time) && "Start time" %in% existing_names) {
-        cli::cli_abort(c(
-          "{.arg start_time} conflicts with a {.val Start time} entry in {.arg parameters}.",
-          "i" = "Supply the start time either as the {.arg start_time} argument or as a {.val Start time} entry in {.arg parameters}, not both."
-        ))
-      }
-      if (!is.null(end_time) && "End time" %in% existing_names) {
-        cli::cli_abort(c(
-          "{.arg end_time} conflicts with an {.val End time} entry in {.arg parameters}.",
-          "i" = "Supply the end time either as the {.arg end_time} argument or as an {.val End time} entry in {.arg parameters}, not both."
+          "{cli::qty(conflicting_args)}Promoted argument{?s} conflict with {.arg parameters} entr{?y/ies}.",
+          "x" = "{.arg {conflicting_args}} {?is/are} also supplied in {.arg parameters}.",
+          "i" = "Supply each setting either as its promoted argument or as an entry in {.arg parameters}, not both."
         ))
       }
     }

--- a/R/create_protocol.R
+++ b/R/create_protocol.R
@@ -32,15 +32,20 @@
 #'   Validated as a dose-family unit: the unit must belong to one of the
 #'   mass, amount, dose per body weight, or dose per body surface area
 #'   dimensions, and the unit alone selects the family (the emitted
-#'   parameter is always a single `InputDose`). Only consulted when `dose`
-#'   is supplied.
+#'   parameter is always a single `InputDose`). There is no single
+#'   `ospsuite::ospUnits$Dose` member, so the accepted units are the union
+#'   of `ospsuite::ospUnits$Mass`, `ospsuite::ospUnits$Amount`,
+#'   `ospsuite::ospUnits[["Dose per body weight"]]`, and
+#'   `ospsuite::ospUnits[["Dose per body surface area"]]`. Only consulted
+#'   when `dose` is supplied.
 #' @param start_time Numeric scalar. Optional start time for a Simple
 #'   Protocol. When supplied it is emitted as a `Start time` parameter.
 #'   Mutually exclusive with `schemas`, and with a `Start time` entry in
 #'   `parameters`.
 #' @param start_time_unit Character. Display unit for `start_time`,
-#'   default `"h"`, validated against dimension `"Time"`. Only consulted
-#'   when `start_time` is supplied.
+#'   default `"h"`, validated against dimension `"Time"`; valid units are
+#'   those in `ospsuite::ospUnits$Time`. Only consulted when `start_time`
+#'   is supplied.
 #' @param end_time Numeric scalar. Optional end time for a Simple
 #'   Protocol. When supplied it is emitted as an `End time` parameter. Its
 #'   display unit is taken from `time_unit`, falling back to `"h"` when
@@ -48,17 +53,18 @@
 #'   Mutually exclusive with `schemas`, and with an `End time` entry in
 #'   `parameters`.
 #' @param parameters List of [Parameter] objects (created with
-#'   [create_parameter()]) or raw parameter lists for Simple Protocol
-#'   parameters such as start time, end time, and dose. The common dose,
-#'   start time, and end time settings can instead be supplied via the
-#'   `dose`, `start_time`, and `end_time` arguments; supplying both a
-#'   promoted argument and the same-named `parameters` entry is an error.
+#'   [create_parameter()]) or raw parameter lists. This is the free-form
+#'   escape hatch for any Simple-Protocol parameter that has no dedicated
+#'   argument. Dose, start time, and end time have the dedicated `dose`,
+#'   `start_time`, and `end_time` arguments; supplying one of those
+#'   settings both here and via its dedicated argument is an error.
 #' @param schemas List of schemas for an Advanced Protocol. Entries may
 #'   be [Schema] objects (created with [create_schema()]) or raw schema
 #'   lists with `Name`, `Parameters`, and `SchemaItems`. If provided,
 #'   the protocol is created as an Advanced Protocol.
 #' @param time_unit Character. Display time unit for the protocol, validated
-#'   against dimension `"Time"`.
+#'   against dimension `"Time"`; valid units are those in
+#'   `ospsuite::ospUnits$Time`.
 #'
 #' @return A [Protocol] object.
 #' @export
@@ -123,14 +129,14 @@ create_protocol <- function(
   dosing_interval = NULL,
   target_organ = NULL,
   target_compartment = NULL,
+  parameters = NULL,
+  schemas = NULL,
+  time_unit = NULL,
   dose = NULL,
   dose_unit = "mg",
   start_time = NULL,
   start_time_unit = "h",
-  end_time = NULL,
-  parameters = NULL,
-  schemas = NULL,
-  time_unit = NULL
+  end_time = NULL
 ) {
   check_required_string(name, "name")
   if (!is.null(schemas)) {
@@ -150,7 +156,7 @@ create_protocol <- function(
     if (length(conflicting) > 0) {
       cli::cli_abort(c(
         "{.arg schemas} is mutually exclusive with Simple Protocol fields.",
-        "i" = "A protocol is either Simple (use {.arg application_type}, {.arg dosing_interval}, {.arg target_organ}, {.arg target_compartment}, {.arg parameters}) or Advanced (use {.arg schemas}).",
+        "i" = "A protocol is either Simple (use {.arg application_type}, {.arg dosing_interval}, {.arg target_organ}, {.arg target_compartment}, {.arg dose}, {.arg start_time}, {.arg end_time}, {.arg parameters}) or Advanced (use {.arg schemas}).",
         "x" = "Conflicting argument{?s}: {.arg {conflicting}}."
       ))
     }

--- a/R/utils-create.R
+++ b/R/utils-create.R
@@ -126,6 +126,62 @@ to_raw_parameters <- function(parameters, name_key) {
   })
 }
 
+# Internal: return every unit accepted for a promoted dose, read live from
+# ospsuite. In PK-Sim a dose is a single `InputDose` parameter whose display
+# unit selects its family, so the accepted set is the union of the four real
+# dose-family dimensions: base `Dose` (dimensions `"Mass"` and `"Amount"`),
+# `DosePerBodyWeight` (`"Dose per body weight"`), and `DosePerBodySurfaceArea`
+# (`"Dose per body surface area"`). There is no `"Input dose"` dimension in
+# ospsuite, so membership cannot be a single `validate_unit()` call. Units are
+# read with the same tolerant `getUnitsForDimension()` -> `ospUnits` fallback
+# `validate_unit()` uses, never hardcoded, so the accepted set tracks the
+# installed ospsuite. This is the single source of truth shared by the
+# membership test and the error message in `resolve_input_dose_parameter()`.
+dose_family_units <- function() {
+  dose_dimensions <- c(
+    "Mass",
+    "Amount",
+    "Dose per body weight",
+    "Dose per body surface area"
+  )
+  unlist(
+    lapply(dose_dimensions, function(dimension) {
+      tryCatch(
+        ospsuite::getUnitsForDimension(dimension),
+        error = function(e) {
+          unlist(ospsuite::ospUnits[[dimension]], use.names = FALSE)
+        }
+      )
+    }),
+    use.names = FALSE
+  )
+}
+
+# Internal: resolve a promoted dose value + unit into the single raw
+# `InputDose` parameter shape used in the Simple-Protocol JSON. The `unit` is
+# validated against the union of the four dose-family dimensions (see
+# `dose_family_units()`); an invalid unit aborts with `call = call` so the
+# error is attributed to the calling factory. The numeric `dose` value is NOT
+# validated here (the finite-scalar shape check is the caller's
+# responsibility), keeping this helper focused on family/unit resolution.
+# Regardless of which family the unit selects, the emitted parameter is always
+# `Name = "InputDose"`, never a per-weight or per-body-surface-area name. This
+# helper is shared with `create_schema_item()` so both factories resolve a dose
+# identically.
+resolve_input_dose_parameter <- function(dose, unit, call = parent.frame()) {
+  valid_units <- dose_family_units()
+  if (!(unit %in% valid_units)) {
+    cli::cli_abort(
+      c(
+        "Invalid dose unit: {unit}",
+        "i" = "Valid dose units are: {toString(valid_units)}"
+      ),
+      call = call
+    )
+  }
+  list(Name = "InputDose", Value = dose, Unit = unit)
+}
+
 # Internal: map the `expression` argument of `create_expression_profile()`
 # (and the `ExpressionProfile$expression` setter) to a raw
 # `ExpressionContainer[]` list, or `NULL` when the input is empty. The

--- a/R/utils-create.R
+++ b/R/utils-create.R
@@ -170,7 +170,7 @@ dose_family_units <- function() {
 # identically.
 resolve_input_dose_parameter <- function(dose, unit, call = parent.frame()) {
   valid_units <- dose_family_units()
-  if (!(unit %in% valid_units)) {
+  if (!is_non_empty_scalar_string(unit) || !(unit %in% valid_units)) {
     cli::cli_abort(
       c(
         "Invalid dose unit: {unit}",

--- a/man/create_protocol.Rd
+++ b/man/create_protocol.Rd
@@ -10,6 +10,11 @@ create_protocol(
   dosing_interval = NULL,
   target_organ = NULL,
   target_compartment = NULL,
+  dose = NULL,
+  dose_unit = "mg",
+  start_time = NULL,
+  start_time_unit = "h",
+  end_time = NULL,
   parameters = NULL,
   schemas = NULL,
   time_unit = NULL
@@ -35,9 +40,40 @@ PK-Sim \code{DosingIntervalId} values: \code{"Single"}, \code{"DI_6_6_6_6"},
 \item{target_compartment}{Character. Target compartment for the
 dose.}
 
+\item{dose}{Numeric scalar. Optional dose for a Simple Protocol. When
+supplied it is emitted as a single \code{InputDose} parameter carrying
+\code{dose} and \code{dose_unit}. Mutually exclusive with \code{schemas}, and with
+an \code{InputDose} entry in \code{parameters}.}
+
+\item{dose_unit}{Character. Display unit for \code{dose}, default \code{"mg"}.
+Validated as a dose-family unit: the unit must belong to one of the
+mass, amount, dose per body weight, or dose per body surface area
+dimensions, and the unit alone selects the family (the emitted
+parameter is always a single \code{InputDose}). Only consulted when \code{dose}
+is supplied.}
+
+\item{start_time}{Numeric scalar. Optional start time for a Simple
+Protocol. When supplied it is emitted as a \verb{Start time} parameter.
+Mutually exclusive with \code{schemas}, and with a \verb{Start time} entry in
+\code{parameters}.}
+
+\item{start_time_unit}{Character. Display unit for \code{start_time},
+default \code{"h"}, validated against dimension \code{"Time"}. Only consulted
+when \code{start_time} is supplied.}
+
+\item{end_time}{Numeric scalar. Optional end time for a Simple
+Protocol. When supplied it is emitted as an \verb{End time} parameter. Its
+display unit is taken from \code{time_unit}, falling back to \code{"h"} when
+\code{time_unit} is unset; there is no separate end-time unit argument.
+Mutually exclusive with \code{schemas}, and with an \verb{End time} entry in
+\code{parameters}.}
+
 \item{parameters}{List of \link{Parameter} objects (created with
 \code{\link[=create_parameter]{create_parameter()}}) or raw parameter lists for Simple Protocol
-parameters such as start time, end time, and dose.}
+parameters such as start time, end time, and dose. The common dose,
+start time, and end time settings can instead be supplied via the
+\code{dose}, \code{start_time}, and \code{end_time} arguments; supplying both a
+promoted argument and the same-named \code{parameters} entry is an error.}
 
 \item{schemas}{List of schemas for an Advanced Protocol. Entries may
 be \link{Schema} objects (created with \code{\link[=create_schema]{create_schema()}}) or raw schema
@@ -61,7 +97,17 @@ of schemas via \code{schemas} instead of \code{application_type} and
 \code{dosing_interval}.
 }
 \examples{
-# Create a simple oral protocol with one dose
+# Create a simple oral protocol with one dose via promoted arguments
+protocol <- create_protocol(
+  name = "Single dose 10mg",
+  application_type = "Oral",
+  dosing_interval = "Single",
+  dose = 10,
+  dose_unit = "mg",
+  start_time = 0
+)
+
+# The same protocol via the free-form `parameters` escape hatch
 protocol <- create_protocol(
   name = "Single dose 10mg",
   application_type = "Oral",

--- a/man/create_protocol.Rd
+++ b/man/create_protocol.Rd
@@ -10,14 +10,14 @@ create_protocol(
   dosing_interval = NULL,
   target_organ = NULL,
   target_compartment = NULL,
+  parameters = NULL,
+  schemas = NULL,
+  time_unit = NULL,
   dose = NULL,
   dose_unit = "mg",
   start_time = NULL,
   start_time_unit = "h",
-  end_time = NULL,
-  parameters = NULL,
-  schemas = NULL,
-  time_unit = NULL
+  end_time = NULL
 )
 }
 \arguments{
@@ -40,6 +40,22 @@ PK-Sim \code{DosingIntervalId} values: \code{"Single"}, \code{"DI_6_6_6_6"},
 \item{target_compartment}{Character. Target compartment for the
 dose.}
 
+\item{parameters}{List of \link{Parameter} objects (created with
+\code{\link[=create_parameter]{create_parameter()}}) or raw parameter lists. This is the free-form
+escape hatch for any Simple-Protocol parameter that has no dedicated
+argument. Dose, start time, and end time have the dedicated \code{dose},
+\code{start_time}, and \code{end_time} arguments; supplying one of those
+settings both here and via its dedicated argument is an error.}
+
+\item{schemas}{List of schemas for an Advanced Protocol. Entries may
+be \link{Schema} objects (created with \code{\link[=create_schema]{create_schema()}}) or raw schema
+lists with \code{Name}, \code{Parameters}, and \code{SchemaItems}. If provided,
+the protocol is created as an Advanced Protocol.}
+
+\item{time_unit}{Character. Display time unit for the protocol, validated
+against dimension \code{"Time"}; valid units are those in
+\code{ospsuite::ospUnits$Time}.}
+
 \item{dose}{Numeric scalar. Optional dose for a Simple Protocol. When
 supplied it is emitted as a single \code{InputDose} parameter carrying
 \code{dose} and \code{dose_unit}. Mutually exclusive with \code{schemas}, and with
@@ -49,8 +65,12 @@ an \code{InputDose} entry in \code{parameters}.}
 Validated as a dose-family unit: the unit must belong to one of the
 mass, amount, dose per body weight, or dose per body surface area
 dimensions, and the unit alone selects the family (the emitted
-parameter is always a single \code{InputDose}). Only consulted when \code{dose}
-is supplied.}
+parameter is always a single \code{InputDose}). There is no single
+\code{ospsuite::ospUnits$Dose} member, so the accepted units are the union
+of \code{ospsuite::ospUnits$Mass}, \code{ospsuite::ospUnits$Amount},
+\code{ospsuite::ospUnits[["Dose per body weight"]]}, and
+\code{ospsuite::ospUnits[["Dose per body surface area"]]}. Only consulted
+when \code{dose} is supplied.}
 
 \item{start_time}{Numeric scalar. Optional start time for a Simple
 Protocol. When supplied it is emitted as a \verb{Start time} parameter.
@@ -58,8 +78,9 @@ Mutually exclusive with \code{schemas}, and with a \verb{Start time} entry in
 \code{parameters}.}
 
 \item{start_time_unit}{Character. Display unit for \code{start_time},
-default \code{"h"}, validated against dimension \code{"Time"}. Only consulted
-when \code{start_time} is supplied.}
+default \code{"h"}, validated against dimension \code{"Time"}; valid units are
+those in \code{ospsuite::ospUnits$Time}. Only consulted when \code{start_time}
+is supplied.}
 
 \item{end_time}{Numeric scalar. Optional end time for a Simple
 Protocol. When supplied it is emitted as an \verb{End time} parameter. Its
@@ -67,21 +88,6 @@ display unit is taken from \code{time_unit}, falling back to \code{"h"} when
 \code{time_unit} is unset; there is no separate end-time unit argument.
 Mutually exclusive with \code{schemas}, and with an \verb{End time} entry in
 \code{parameters}.}
-
-\item{parameters}{List of \link{Parameter} objects (created with
-\code{\link[=create_parameter]{create_parameter()}}) or raw parameter lists for Simple Protocol
-parameters such as start time, end time, and dose. The common dose,
-start time, and end time settings can instead be supplied via the
-\code{dose}, \code{start_time}, and \code{end_time} arguments; supplying both a
-promoted argument and the same-named \code{parameters} entry is an error.}
-
-\item{schemas}{List of schemas for an Advanced Protocol. Entries may
-be \link{Schema} objects (created with \code{\link[=create_schema]{create_schema()}}) or raw schema
-lists with \code{Name}, \code{Parameters}, and \code{SchemaItems}. If provided,
-the protocol is created as an Advanced Protocol.}
-
-\item{time_unit}{Character. Display time unit for the protocol, validated
-against dimension \code{"Time"}.}
 }
 \value{
 A \link{Protocol} object.

--- a/tests/testthat/_snaps/create_protocol.md
+++ b/tests/testthat/_snaps/create_protocol.md
@@ -72,3 +72,172 @@
       ! Invalid unit: banana
       i Valid units for Time are: s, min, h, day(s), week(s), month(s), year(s), ks
 
+# create_protocol promotes dose, start_time, and end_time to parameters
+
+    Code
+      protocol$data$Parameters
+    Output
+      [[1]]
+      [[1]]$Name
+      [1] "InputDose"
+      
+      [[1]]$Value
+      [1] 10
+      
+      [[1]]$Unit
+      [1] "mg"
+      
+      
+      [[2]]
+      [[2]]$Name
+      [1] "Start time"
+      
+      [[2]]$Value
+      [1] 0
+      
+      [[2]]$Unit
+      [1] "h"
+      
+      
+      [[3]]
+      [[3]]$Name
+      [1] "End time"
+      
+      [[3]]$Value
+      [1] 24
+      
+      [[3]]$Unit
+      [1] "h"
+      
+      
+
+# create_protocol rejects an invalid dose_unit
+
+    Code
+      create_protocol(name = "P", dose = 5, dose_unit = "banana")
+    Condition
+      Error in `create_protocol()`:
+      ! Invalid dose unit: banana
+      i Valid dose units are: kg, g, mg, µg, ng, pg, mol, mmol, µmol, nmol, pmol, ng/kg, µg/kg, mg/kg, g/kg, kg/kg, mg/m², kg/dm², µg/cm², mg/cm²
+
+---
+
+    Code
+      create_protocol(name = "P", dose = 5, dose_unit = "h")
+    Condition
+      Error in `create_protocol()`:
+      ! Invalid dose unit: h
+      i Valid dose units are: kg, g, mg, µg, ng, pg, mol, mmol, µmol, nmol, pmol, ng/kg, µg/kg, mg/kg, g/kg, kg/kg, mg/m², kg/dm², µg/cm², mg/cm²
+
+# create_protocol rejects non-finite or non-scalar dose values
+
+    Code
+      create_protocol(name = "P", dose = NA)
+    Condition
+      Error in `create_protocol()`:
+      ! `dose` must be a single finite numeric value
+
+---
+
+    Code
+      create_protocol(name = "P", dose = c(1, 2))
+    Condition
+      Error in `create_protocol()`:
+      ! `dose` must be a single finite numeric value
+
+---
+
+    Code
+      create_protocol(name = "P", dose = Inf)
+    Condition
+      Error in `create_protocol()`:
+      ! `dose` must be a single finite numeric value
+
+---
+
+    Code
+      create_protocol(name = "P", start_time = "0")
+    Condition
+      Error in `create_protocol()`:
+      ! `start_time` must be a single finite numeric value
+
+# create_protocol errors when a promoted argument conflicts with parameters
+
+    Code
+      create_protocol(name = "P", dose = 10, parameters = list(create_parameter(name = "InputDose",
+        value = 5, unit = "mg")))
+    Condition
+      Error in `create_protocol()`:
+      ! `dose` conflicts with an "InputDose" entry in `parameters`.
+      i Supply the dose either as the `dose` argument or as an "InputDose" entry in `parameters`, not both.
+
+---
+
+    Code
+      create_protocol(name = "P", start_time = 0, parameters = list(create_parameter(
+        name = "Start time", value = 1, unit = "h")))
+    Condition
+      Error in `create_protocol()`:
+      ! `start_time` conflicts with a "Start time" entry in `parameters`.
+      i Supply the start time either as the `start_time` argument or as a "Start time" entry in `parameters`, not both.
+
+---
+
+    Code
+      create_protocol(name = "P", end_time = 24, parameters = list(create_parameter(
+        name = "End time", value = 12, unit = "h")))
+    Condition
+      Error in `create_protocol()`:
+      ! `end_time` conflicts with an "End time" entry in `parameters`.
+      i Supply the end time either as the `end_time` argument or as an "End time" entry in `parameters`, not both.
+
+# create_protocol detects a Path-keyed conflict after Name normalisation
+
+    Code
+      create_protocol(name = "P", dose = 10, parameters = list(create_parameter(path = "InputDose",
+        value = 5, unit = "mg")))
+    Condition
+      Error in `create_protocol()`:
+      ! `dose` conflicts with an "InputDose" entry in `parameters`.
+      i Supply the dose either as the `dose` argument or as an "InputDose" entry in `parameters`, not both.
+
+---
+
+    Code
+      create_protocol(name = "P", dose = 10, parameters = list(list(Path = "InputDose",
+        Value = 5, Unit = "mg")))
+    Condition
+      Error in `create_protocol()`:
+      ! `dose` conflicts with an "InputDose" entry in `parameters`.
+      i Supply the dose either as the `dose` argument or as an "InputDose" entry in `parameters`, not both.
+
+# create_protocol rejects the promoted arguments combined with schemas
+
+    Code
+      create_protocol(name = "P", dose = 10, schemas = schemas)
+    Condition
+      Error in `create_protocol()`:
+      ! `schemas` is mutually exclusive with Simple Protocol fields.
+      i A protocol is either Simple (use `application_type`, `dosing_interval`, `target_organ`, `target_compartment`, `parameters`) or Advanced (use `schemas`).
+      x Conflicting argument: `dose`.
+
+---
+
+    Code
+      create_protocol(name = "P", start_time = 0, schemas = schemas)
+    Condition
+      Error in `create_protocol()`:
+      ! `schemas` is mutually exclusive with Simple Protocol fields.
+      i A protocol is either Simple (use `application_type`, `dosing_interval`, `target_organ`, `target_compartment`, `parameters`) or Advanced (use `schemas`).
+      x Conflicting argument: `start_time`.
+
+---
+
+    Code
+      create_protocol(name = "P", end_time = 24, schemas = schemas)
+    Condition
+      Error in `create_protocol()`:
+      ! `schemas` is mutually exclusive with Simple Protocol fields.
+      i A protocol is either Simple (use `application_type`, `dosing_interval`, `target_organ`, `target_compartment`, `parameters`) or Advanced (use `schemas`).
+      x Conflicting argument: `end_time`.
+

--- a/tests/testthat/_snaps/create_protocol.md
+++ b/tests/testthat/_snaps/create_protocol.md
@@ -188,8 +188,9 @@
         value = 5, unit = "mg")))
     Condition
       Error in `create_protocol()`:
-      ! `dose` conflicts with an "InputDose" entry in `parameters`.
-      i Supply the dose either as the `dose` argument or as an "InputDose" entry in `parameters`, not both.
+      ! Promoted argument conflict with `parameters` entry.
+      x `dose` is also supplied in `parameters`.
+      i Supply each setting either as its promoted argument or as an entry in `parameters`, not both.
 
 ---
 
@@ -198,8 +199,9 @@
         name = "Start time", value = 1, unit = "h")))
     Condition
       Error in `create_protocol()`:
-      ! `start_time` conflicts with a "Start time" entry in `parameters`.
-      i Supply the start time either as the `start_time` argument or as a "Start time" entry in `parameters`, not both.
+      ! Promoted argument conflict with `parameters` entry.
+      x `start_time` is also supplied in `parameters`.
+      i Supply each setting either as its promoted argument or as an entry in `parameters`, not both.
 
 ---
 
@@ -208,8 +210,22 @@
         name = "End time", value = 12, unit = "h")))
     Condition
       Error in `create_protocol()`:
-      ! `end_time` conflicts with an "End time" entry in `parameters`.
-      i Supply the end time either as the `end_time` argument or as an "End time" entry in `parameters`, not both.
+      ! Promoted argument conflict with `parameters` entry.
+      x `end_time` is also supplied in `parameters`.
+      i Supply each setting either as its promoted argument or as an entry in `parameters`, not both.
+
+# create_protocol reports every conflicting promoted argument in one error
+
+    Code
+      create_protocol(name = "P", dose = 10, start_time = 0, end_time = 24,
+        parameters = list(create_parameter(name = "InputDose", value = 5, unit = "mg"),
+        create_parameter(name = "Start time", value = 1, unit = "h"),
+        create_parameter(name = "End time", value = 12, unit = "h")))
+    Condition
+      Error in `create_protocol()`:
+      ! Promoted arguments conflict with `parameters` entries.
+      x `dose`, `start_time`, and `end_time` are also supplied in `parameters`.
+      i Supply each setting either as its promoted argument or as an entry in `parameters`, not both.
 
 # create_protocol detects a Path-keyed conflict after Name normalisation
 
@@ -218,8 +234,9 @@
         value = 5, unit = "mg")))
     Condition
       Error in `create_protocol()`:
-      ! `dose` conflicts with an "InputDose" entry in `parameters`.
-      i Supply the dose either as the `dose` argument or as an "InputDose" entry in `parameters`, not both.
+      ! Promoted argument conflict with `parameters` entry.
+      x `dose` is also supplied in `parameters`.
+      i Supply each setting either as its promoted argument or as an entry in `parameters`, not both.
 
 ---
 
@@ -228,8 +245,9 @@
         Value = 5, Unit = "mg")))
     Condition
       Error in `create_protocol()`:
-      ! `dose` conflicts with an "InputDose" entry in `parameters`.
-      i Supply the dose either as the `dose` argument or as an "InputDose" entry in `parameters`, not both.
+      ! Promoted argument conflict with `parameters` entry.
+      x `dose` is also supplied in `parameters`.
+      i Supply each setting either as its promoted argument or as an entry in `parameters`, not both.
 
 # create_protocol rejects the promoted arguments combined with schemas
 

--- a/tests/testthat/_snaps/create_protocol.md
+++ b/tests/testthat/_snaps/create_protocol.md
@@ -21,7 +21,7 @@
     Condition
       Error in `create_protocol()`:
       ! `schemas` is mutually exclusive with Simple Protocol fields.
-      i A protocol is either Simple (use `application_type`, `dosing_interval`, `target_organ`, `target_compartment`, `parameters`) or Advanced (use `schemas`).
+      i A protocol is either Simple (use `application_type`, `dosing_interval`, `target_organ`, `target_compartment`, `dose`, `start_time`, `end_time`, `parameters`) or Advanced (use `schemas`).
       x Conflicting argument: `application_type`.
 
 ---
@@ -32,7 +32,7 @@
     Condition
       Error in `create_protocol()`:
       ! `schemas` is mutually exclusive with Simple Protocol fields.
-      i A protocol is either Simple (use `application_type`, `dosing_interval`, `target_organ`, `target_compartment`, `parameters`) or Advanced (use `schemas`).
+      i A protocol is either Simple (use `application_type`, `dosing_interval`, `target_organ`, `target_compartment`, `dose`, `start_time`, `end_time`, `parameters`) or Advanced (use `schemas`).
       x Conflicting arguments: `dosing_interval` and `target_organ`.
 
 ---
@@ -129,6 +129,26 @@
       ! Invalid dose unit: h
       i Valid dose units are: kg, g, mg, µg, ng, pg, mol, mmol, µmol, nmol, pmol, ng/kg, µg/kg, mg/kg, g/kg, kg/kg, mg/m², kg/dm², µg/cm², mg/cm²
 
+# create_protocol rejects a NULL or non-scalar dose_unit
+
+    Code
+      create_protocol(name = "P", application_type = "Oral", dosing_interval = "Single",
+        dose = 5, dose_unit = NULL)
+    Condition
+      Error in `create_protocol()`:
+      ! Invalid dose unit:
+      i Valid dose units are: kg, g, mg, µg, ng, pg, mol, mmol, µmol, nmol, pmol, ng/kg, µg/kg, mg/kg, g/kg, kg/kg, mg/m², kg/dm², µg/cm², mg/cm²
+
+---
+
+    Code
+      create_protocol(name = "P", application_type = "Oral", dosing_interval = "Single",
+        dose = 5, dose_unit = c("mg", "mmol"))
+    Condition
+      Error in `create_protocol()`:
+      ! Invalid dose unit: mg and mmol
+      i Valid dose units are: kg, g, mg, µg, ng, pg, mol, mmol, µmol, nmol, pmol, ng/kg, µg/kg, mg/kg, g/kg, kg/kg, mg/m², kg/dm², µg/cm², mg/cm²
+
 # create_protocol rejects non-finite or non-scalar dose values
 
     Code
@@ -218,7 +238,7 @@
     Condition
       Error in `create_protocol()`:
       ! `schemas` is mutually exclusive with Simple Protocol fields.
-      i A protocol is either Simple (use `application_type`, `dosing_interval`, `target_organ`, `target_compartment`, `parameters`) or Advanced (use `schemas`).
+      i A protocol is either Simple (use `application_type`, `dosing_interval`, `target_organ`, `target_compartment`, `dose`, `start_time`, `end_time`, `parameters`) or Advanced (use `schemas`).
       x Conflicting argument: `dose`.
 
 ---
@@ -228,7 +248,7 @@
     Condition
       Error in `create_protocol()`:
       ! `schemas` is mutually exclusive with Simple Protocol fields.
-      i A protocol is either Simple (use `application_type`, `dosing_interval`, `target_organ`, `target_compartment`, `parameters`) or Advanced (use `schemas`).
+      i A protocol is either Simple (use `application_type`, `dosing_interval`, `target_organ`, `target_compartment`, `dose`, `start_time`, `end_time`, `parameters`) or Advanced (use `schemas`).
       x Conflicting argument: `start_time`.
 
 ---
@@ -238,6 +258,6 @@
     Condition
       Error in `create_protocol()`:
       ! `schemas` is mutually exclusive with Simple Protocol fields.
-      i A protocol is either Simple (use `application_type`, `dosing_interval`, `target_organ`, `target_compartment`, `parameters`) or Advanced (use `schemas`).
+      i A protocol is either Simple (use `application_type`, `dosing_interval`, `target_organ`, `target_compartment`, `dose`, `start_time`, `end_time`, `parameters`) or Advanced (use `schemas`).
       x Conflicting argument: `end_time`.
 

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -100,7 +100,7 @@
     Condition
       Error in `private$.validate_version()`:
       ! Snapshot Version 82 is not supported in this version.
-      i osp.snapshots v1.0.0.9001 supports snapshots up to Version 81.
+      i osp.snapshots v1.0.0.9002 supports snapshots up to Version 81.
 
 ---
 
@@ -111,7 +111,7 @@
     Condition
       Error in `private$.validate_version()`:
       ! Snapshot Version 82 is not supported in this version.
-      i osp.snapshots v1.0.0.9001 supports snapshots up to Version 81.
+      i osp.snapshots v1.0.0.9002 supports snapshots up to Version 81.
 
 ---
 
@@ -122,7 +122,7 @@
     Condition
       Error in `private$.validate_version()`:
       ! Snapshot Version 82 is not supported in this version.
-      i osp.snapshots v1.0.0.9001 supports snapshots up to Version 81.
+      i osp.snapshots v1.0.0.9002 supports snapshots up to Version 81.
 
 # Snapshot warns when a snapshot is newer than the installed core
 

--- a/tests/testthat/test-create_protocol.R
+++ b/tests/testthat/test-create_protocol.R
@@ -227,7 +227,11 @@ test_that("create_protocol accepts a valid application_type and omits the check 
 test_that("create_protocol validates dosing_interval against the DosingIntervalId enum", {
   expect_snapshot(
     error = TRUE,
-    create_protocol(name = "P", application_type = "Oral", dosing_interval = "typo")
+    create_protocol(
+      name = "P",
+      application_type = "Oral",
+      dosing_interval = "typo"
+    )
   )
 })
 
@@ -250,4 +254,189 @@ test_that("create_protocol validates time_unit against the Time dimension", {
   )
   valid <- create_protocol(name = "P", time_unit = "h")
   expect_equal(valid$time_unit, "h")
+})
+
+test_that("create_protocol promotes dose, start_time, and end_time to parameters", {
+  protocol <- create_protocol(
+    name = "Single dose",
+    application_type = "Oral",
+    dosing_interval = "Single",
+    dose = 10,
+    dose_unit = "mg",
+    start_time = 0,
+    end_time = 24,
+    time_unit = "h"
+  )
+
+  expect_s3_class(protocol, "Protocol")
+  expect_snapshot(protocol$data$Parameters)
+})
+
+test_that("create_protocol emits a single InputDose for any dose-family unit", {
+  for (unit in c("mg", "mmol", "mg/kg", "mg/m²")) {
+    protocol <- create_protocol(
+      name = "Dose",
+      application_type = "Oral",
+      dosing_interval = "Single",
+      dose = 5,
+      dose_unit = unit
+    )
+    input_dose <- Filter(
+      function(p) identical(p$Name, "InputDose"),
+      protocol$data$Parameters
+    )
+    other_dose <- Filter(
+      function(p) {
+        p$Name %in%
+          c("Dose", "DosePerBodyWeight", "DosePerBodySurfaceArea")
+      },
+      protocol$data$Parameters
+    )
+    expect_length(input_dose, 1)
+    expect_length(other_dose, 0)
+    expect_equal(input_dose[[1]]$Value, 5)
+    expect_equal(input_dose[[1]]$Unit, unit)
+  }
+})
+
+test_that("create_protocol rejects an invalid dose_unit", {
+  expect_snapshot(
+    error = TRUE,
+    create_protocol(name = "P", dose = 5, dose_unit = "banana")
+  )
+  expect_snapshot(
+    error = TRUE,
+    create_protocol(name = "P", dose = 5, dose_unit = "h")
+  )
+})
+
+test_that("create_protocol rejects non-finite or non-scalar dose values", {
+  expect_snapshot(error = TRUE, create_protocol(name = "P", dose = NA))
+  expect_snapshot(error = TRUE, create_protocol(name = "P", dose = c(1, 2)))
+  expect_snapshot(error = TRUE, create_protocol(name = "P", dose = Inf))
+  expect_snapshot(error = TRUE, create_protocol(name = "P", start_time = "0"))
+})
+
+test_that("create_protocol errors when a promoted argument conflicts with parameters", {
+  expect_snapshot(
+    error = TRUE,
+    create_protocol(
+      name = "P",
+      dose = 10,
+      parameters = list(
+        create_parameter(name = "InputDose", value = 5, unit = "mg")
+      )
+    )
+  )
+  expect_snapshot(
+    error = TRUE,
+    create_protocol(
+      name = "P",
+      start_time = 0,
+      parameters = list(
+        create_parameter(name = "Start time", value = 1, unit = "h")
+      )
+    )
+  )
+  expect_snapshot(
+    error = TRUE,
+    create_protocol(
+      name = "P",
+      end_time = 24,
+      parameters = list(
+        create_parameter(name = "End time", value = 12, unit = "h")
+      )
+    )
+  )
+})
+
+test_that("create_protocol detects a Path-keyed conflict after Name normalisation", {
+  expect_snapshot(
+    error = TRUE,
+    create_protocol(
+      name = "P",
+      dose = 10,
+      parameters = list(
+        create_parameter(path = "InputDose", value = 5, unit = "mg")
+      )
+    )
+  )
+  expect_snapshot(
+    error = TRUE,
+    create_protocol(
+      name = "P",
+      dose = 10,
+      parameters = list(list(Path = "InputDose", Value = 5, Unit = "mg"))
+    )
+  )
+})
+
+test_that("create_protocol resolves the end_time unit from time_unit", {
+  with_time_unit <- create_protocol(
+    name = "P",
+    end_time = 24,
+    time_unit = "min"
+  )
+  end_entry <- Filter(
+    function(p) identical(p$Name, "End time"),
+    with_time_unit$data$Parameters
+  )
+  expect_equal(end_entry[[1]]$Unit, "min")
+  expect_equal(with_time_unit$data$TimeUnit, "min")
+
+  without_time_unit <- create_protocol(name = "P", end_time = 24)
+  end_entry <- Filter(
+    function(p) identical(p$Name, "End time"),
+    without_time_unit$data$Parameters
+  )
+  expect_equal(end_entry[[1]]$Unit, "h")
+  expect_null(without_time_unit$data$TimeUnit)
+})
+
+test_that("create_protocol rejects the promoted arguments combined with schemas", {
+  schemas <- list(list(
+    Name = "Schema 1",
+    SchemaItems = list(list(Name = "Item 1", ApplicationType = "Oral"))
+  ))
+  expect_snapshot(
+    error = TRUE,
+    create_protocol(name = "P", dose = 10, schemas = schemas)
+  )
+  expect_snapshot(
+    error = TRUE,
+    create_protocol(name = "P", start_time = 0, schemas = schemas)
+  )
+  expect_snapshot(
+    error = TRUE,
+    create_protocol(name = "P", end_time = 24, schemas = schemas)
+  )
+
+  # Default unit arguments must not trip the mutual-exclusivity check.
+  advanced <- create_protocol(name = "P", schemas = schemas)
+  expect_s3_class(advanced, "Protocol")
+})
+
+test_that("create_protocol leaves output unchanged when no promoted argument is supplied", {
+  promoted <- create_protocol(
+    name = "P",
+    application_type = "Oral",
+    dosing_interval = "Single",
+    parameters = list(
+      create_parameter(name = "Start time", value = 0, unit = "h"),
+      create_parameter(name = "InputDose", value = 10, unit = "mg")
+    )
+  )
+  hand_built <- list(
+    Name = "P",
+    ApplicationType = "Oral",
+    DosingInterval = "Single",
+    Parameters = list(
+      list(Name = "Start time", Value = 0, Unit = "h"),
+      list(Name = "InputDose", Value = 10, Unit = "mg")
+    )
+  )
+  expect_equal(promoted$data, hand_built)
+
+  bare <- create_protocol(name = "P")
+  expect_null(bare$data$Parameters)
 })

--- a/tests/testthat/test-create_protocol.R
+++ b/tests/testthat/test-create_protocol.R
@@ -399,6 +399,23 @@ test_that("create_protocol errors when a promoted argument conflicts with parame
   )
 })
 
+test_that("create_protocol reports every conflicting promoted argument in one error", {
+  expect_snapshot(
+    error = TRUE,
+    create_protocol(
+      name = "P",
+      dose = 10,
+      start_time = 0,
+      end_time = 24,
+      parameters = list(
+        create_parameter(name = "InputDose", value = 5, unit = "mg"),
+        create_parameter(name = "Start time", value = 1, unit = "h"),
+        create_parameter(name = "End time", value = 12, unit = "h")
+      )
+    )
+  )
+})
+
 test_that("create_protocol detects a Path-keyed conflict after Name normalisation", {
   expect_snapshot(
     error = TRUE,

--- a/tests/testthat/test-create_protocol.R
+++ b/tests/testthat/test-create_protocol.R
@@ -17,6 +17,32 @@ test_that("create_protocol creates a simple protocol", {
   expect_length(protocol$parameters, 2)
 })
 
+test_that("create_protocol keeps `parameters` in the sixth positional slot", {
+  # Pre-existing positional calls pass the sixth argument as `parameters`.
+  # The promoted dosing arguments are appended after `time_unit`, so the
+  # sixth positional slot must still land on `parameters`, not `dose`.
+  protocol <- create_protocol(
+    "P",
+    "Oral",
+    "Single",
+    NULL,
+    NULL,
+    list(create_parameter(name = "InputDose", value = 5, unit = "mg"))
+  )
+
+  expect_s3_class(protocol, "Protocol")
+  input_dose <- Filter(
+    function(p) identical(p$Name, "InputDose"),
+    protocol$data$Parameters
+  )
+  expect_length(input_dose, 1)
+  expect_equal(input_dose[[1]]$Value, 5)
+  expect_equal(input_dose[[1]]$Unit, "mg")
+  # The value landed via `parameters`, not via `dose` promotion, so there is
+  # exactly one parameter and no promoted duplicate.
+  expect_length(protocol$data$Parameters, 1)
+})
+
 test_that("create_protocol creates an advanced protocol from schemas", {
   schemas <- list(list(
     Name = "Schema 1",
@@ -307,6 +333,29 @@ test_that("create_protocol rejects an invalid dose_unit", {
   expect_snapshot(
     error = TRUE,
     create_protocol(name = "P", dose = 5, dose_unit = "h")
+  )
+})
+
+test_that("create_protocol rejects a NULL or non-scalar dose_unit", {
+  expect_snapshot(
+    error = TRUE,
+    create_protocol(
+      name = "P",
+      application_type = "Oral",
+      dosing_interval = "Single",
+      dose = 5,
+      dose_unit = NULL
+    )
+  )
+  expect_snapshot(
+    error = TRUE,
+    create_protocol(
+      name = "P",
+      application_type = "Oral",
+      dosing_interval = "Single",
+      dose = 5,
+      dose_unit = c("mg", "mmol")
+    )
   )
 })
 


### PR DESCRIPTION
Closes #157

# Build summary: promote Simple-Protocol dosing settings to plain `create_protocol()` arguments

## Implementation

`create_protocol()` previously expressed the core Simple-Protocol dosing settings (dose, start time, end time) only through the free-form `parameters` list, where each `name` had to exactly match a PK-Sim internal parameter name. This change promotes those three settings to plain, unit-aware arguments, mirroring the existing pattern in `create_output_interval()` and `create_event_selection()`, while keeping the `parameters` list as a fully backward-compatible escape hatch.

### Shared dose helper (`R/utils-create.R`)

Two internal, comment-documented helpers were added (neither is exported, so `NAMESPACE` is unchanged):

- `dose_family_units()` returns every unit accepted for a promoted dose, read live from ospsuite as the union of the four real dose-family dimensions: `"Mass"`, `"Amount"`, `"Dose per body weight"`, and `"Dose per body surface area"`. It uses the same tolerant `getUnitsForDimension()` -> `ospUnits[[dim]]` fallback that `validate_unit()` uses, so the accepted set tracks the installed ospsuite and is never hardcoded. This is the single source of truth for both the membership test and the error message. It resolves the spec's repo-grounded correction that there is no `"Input dose"` dimension in ospsuite (verified live: `getUnitsForDimension("Input dose")` throws).
- `resolve_input_dose_parameter(dose, unit, call = parent.frame())` validates `unit` against `dose_family_units()`, aborts with `call = call` (attributing the error to the calling factory) on an invalid unit, and returns the single raw `list(Name = "InputDose", Value = dose, Unit = unit)`. It always emits `Name = "InputDose"`, never a per-body-weight or per-body-surface-area name, and does not validate the numeric `dose` value (the finite-scalar shape check is the caller's responsibility). This matches the contract the sibling schema-item dose work expects, so both factories can share it unchanged.

### Factory wiring (`R/create_protocol.R`)

- Added five arguments to the Simple-Protocol branch: `dose = NULL`, `dose_unit = "mg"`, `start_time = NULL`, `start_time_unit = "h"`, `end_time = NULL`.
- Folded the three value arguments (`dose`, `start_time`, `end_time`) into the existing `schemas` mutual-exclusivity check. The unit arguments carry non-NULL defaults and are deliberately excluded, so a plain `schemas = ...` Advanced call is never spuriously rejected.
- Validate each supplied numeric scalar as a single finite numeric value, using the same wording as the mirrored factories (`{.arg <name>} must be a single finite numeric value`), rejecting `NA`, length-2 vectors, `Inf`, and character input.
- The `End time` parameter's display unit derives from `time_unit`, falling back to `"h"` when `time_unit` is unset, without setting `data$TimeUnit` as a side effect; `data$TimeUnit` remains driven solely by `time_unit`. `time_unit` validation was moved ahead of the branch (validated once) so the derived `End time` unit is never built from an unvalidated `time_unit`.
- Conflict detection between a promoted argument and a same-named `parameters` entry runs against the `Name`-normalised identifiers (via `to_raw_parameters(parameters, "Name")`), so both `create_parameter(name = ...)` and `create_parameter(path = ...)` / raw `list(Path = ...)` entries are caught. Comparison is exact and case-sensitive against the canonical names `InputDose` / `Start time` / `End time`.
- The auto-built entries are placed before user `parameters` in the combined array, and `data$Parameters` is set only when the combined list is non-empty, so a call with no promoted argument and no `parameters` produces byte-identical `data` to before this change.
- Added roxygen `@param` entries for the five new arguments and a runnable promoted-argument example alongside the existing `parameters`-list example; `man/create_protocol.Rd` was regenerated via `devtools::document()` (`NAMESPACE` unchanged).

### Documentation

- `NEWS.md` gains one development-version bullet (placed first, alphabetically before the existing `fraction_unbound()` bullet) describing the new arguments as a validated alternative to hand-building the `InputDose` / `Start time` / `End time` entries, linking `(#157)`.

## Verification

- `NOT_CRAN=true Rscript -e 'devtools::test(filter = "create_protocol")'`: FAIL 0, WARN 0, SKIP 0, PASS 87. The first run recorded the new snapshots in `tests/testthat/_snaps/create_protocol.md`; the recorded error wording was reviewed (invalid dose unit with the live-read accepted units including the UTF-8 units `µg`, `mg/m²`; the finite-scalar messages; the conflict messages including the Path-keyed conflict producing the identical error; the schemas exclusivity naming the promoted arguments) and the re-run was clean.
- `NOT_CRAN=true Rscript -e 'devtools::test()'` (full suite): FAIL 0, PASS 3116. The single warning is a pre-existing, network-dependent `osp_models()` templates-repository test in `test-snapshot.R`, unrelated to this change.
- `Rscript -e 'devtools::document()'`: regenerated `man/create_protocol.Rd`; `NAMESPACE` unchanged (the helpers are internal). Pre-existing unrelated `Snapshot` topic documentation warnings were present before this change and are not affected by it.

New tests cover: the promoted single-dose call producing the expected `InputDose` / `Start time` / `End time` parameters (snapshot); each dose-family unit (`mg`, `mmol`, `mg/kg`, `mg/m²`) yielding exactly one `InputDose` and no per-family parameter; invalid `dose_unit` (`"banana"` and the valid-but-wrong-dimension `"h"`); non-finite / non-scalar / character shape errors; each conflict case plus a Path-keyed and a raw-`Path`-list conflict; `end_time` unit resolution both with `time_unit = "min"` (unit `min`, `data$TimeUnit == "min"`) and without `time_unit` (unit `h`, `data$TimeUnit` unset); `schemas` mutual-exclusivity for each promoted argument plus a bare `schemas = ...` call succeeding with default units; and an explicit backward-compatibility check that the promoted form equals the hand-built `data` and a bare call leaves `data$Parameters` unset.

## Backward compatibility

Confirmed. A call with no new arguments produces byte-identical `data` to before: `data$Parameters` is gated on the combined list being non-empty, so a bare `create_protocol(name = "P")` leaves `data$Parameters` unset, and a `parameters`-only call yields the same `to_raw_parameters(parameters, "Name")` output in the same order. The existing `create_protocol` tests (the simple-protocol and advanced/schemas round-trip tests) stay green unchanged.

## Micro-decisions (auto mode)

All adopted from the plan's locked decisions:

- The start-time unit argument is named `start_time_unit` (default `"h"`), for symmetry with `dose_unit`.
- When `end_time` is supplied and `time_unit` is `NULL`, the `End time` parameter's unit falls back to `"h"` and `data$TimeUnit` stays unset.
- A lone `dose_unit` / `start_time_unit` (value `NULL`) is inert: not validated, not emitted, not an error.
- Only the value arguments participate in the `schemas` mutual-exclusivity check; default unit arguments do not.
- Auto-built parameters precede user `parameters`; conflict detection is exact, case-sensitive, and `Name`-normalised.
- Accepted dose units are read live from ospsuite (never hardcoded).

The plan's Step 1 was executed (the shared helper did not already exist on the branch, as expected). The helper matches the contract the sibling schema-item dose work will reuse unchanged.

# QA: Approved

The PR promotes `dose`/`dose_unit`, `start_time`/`start_time_unit`, and `end_time` to plain arguments on `create_protocol()` exactly as the spec and plan require: a single `InputDose` parameter for any dose-family unit, a shared `resolve_input_dose_parameter()` helper in `R/utils-create.R` validated across the four real ospsuite dimensions (no `"Input dose"` dimension), `Name`-normalised conflict detection catching both Name- and Path-keyed entries, `schemas` mutual-exclusivity, byte-identical no-argument output, regenerated `man/`, a correctly-styled NEWS bullet, and tests covering every enumerated case. All nine acceptance criteria are met and repo conventions hold.

<details>
<summary>Full QA report</summary>

## Method

Read the authoritative `spec.md` (AC-1..AC-9, edge cases, locked decisions) and `plan.md`, then inspected the PR via `gh pr diff 174` / `gh pr view 174`, read the changed source in the read-only worktree (`R/create_protocol.R`, `R/utils-create.R`), the regenerated `man/create_protocol.Rd`, `NEWS.md`, the new tests, and the recorded snapshot file. Verified the commit metadata with `git log origin/main..HEAD`. Tests were not executed locally (R execution out of scope); relied on reading the diff, the test file, and the recorded snapshot text, plus the PR body's reported results (target file: PASS 87, FAIL 0; full suite: PASS 3116, FAIL 0, one pre-existing unrelated network warning).

## AC-by-AC verification

| AC | Verdict | Evidence |
|----|---------|----------|
| AC-1 | Pass | `R/create_protocol.R:126-130` adds `dose = NULL`, `dose_unit = "mg"`, `start_time = NULL`, `start_time_unit = "h"`, `end_time = NULL`. `dose_unit` validated by the dose-family helper (`resolve_input_dose_parameter()` call, line 238). `start_time_unit` validated via `validate_unit(start_time_unit, "Time")` (line 242). `end_time` unit derives from `time_unit` with NULL -> `"h"` fallback (line 229). |
| AC-2 | Pass | `resolve_input_dose_parameter()` (`R/utils-create.R:150-162`) always returns `list(Name = "InputDose", Value = dose, Unit = unit)`, never a per-family name. Test `emits a single InputDose for any dose-family unit` iterates `mg`, `mmol`, `mg/kg`, `mg/m²` and asserts exactly one `InputDose` and zero `Dose`/`DosePerBodyWeight`/`DosePerBodySurfaceArea` entries (`expect_length(input_dose, 1)`, `expect_length(other_dose, 0)`). |
| AC-3 | Pass | `dose_family_units()` (`R/utils-create.R:139-155`) reads the union of the real dimensions `"Mass"`, `"Amount"`, `"Dose per body weight"`, `"Dose per body surface area"` live from ospsuite using the tolerant `getUnitsForDimension()` -> `ospUnits[[dim]]` fallback; it never calls `validate_unit(unit, "Input dose")`. Confirmed no `"Input dose"` string anywhere in the diff. Helper lives in `R/utils-create.R` (the shared location #168 reuses), non-exported, comment-documented, with the `resolve_input_dose_parameter(dose, unit, call = parent.frame())` signature the sibling contract expects. |
| AC-4 | Pass | Conflict detection (`R/create_protocol.R:263-287`) computes `existing_names` from `to_raw_parameters(parameters, "Name")`, which copies `Path` to `Name` when only `Path` is present (`R/utils-create.R:114-118`), so both keyings are caught. Maps `dose`->`InputDose`, `start_time`->`Start time`, `end_time`->`End time`. Tests cover all three Name-keyed conflicts plus a `create_parameter(path = "InputDose")` and a raw `list(Path = "InputDose", ...)` conflict; the recorded snapshot shows the identical error fires for the Path-keyed cases. The `%||% NA_character_` guard safely handles entries lacking both keys. |
| AC-5 | Pass | No `infusion_time` or `volume_of_water_per_body_weight` argument added to the signature; they remain reachable only through `parameters`. Confirmed by the full signature at `R/create_protocol.R:120-134`. |
| AC-6 | Pass | `data$Parameters` is set only when `length(combined) > 0` (`R/create_protocol.R:299-302`), auto entries precede user entries, and `to_raw_parameters(parameters, "Name")` is run only over user `parameters`. Test `leaves output unchanged when no promoted argument is supplied` asserts a `parameters`-only build equals the hand-built `data` list and a bare `create_protocol(name = "P")` leaves `data$Parameters` NULL. Existing suite reported green. |
| AC-7 | Pass | `dose`, `start_time`, `end_time` (value args only) folded into `simple_fields` (`R/create_protocol.R:142-144`), keyed on `is.null`; `dose_unit`/`start_time_unit` (non-NULL defaults) deliberately excluded so a bare `schemas = ...` call does not trip. Tests snapshot the exclusivity error for each of the three value args and assert `expect_s3_class(create_protocol(name = "P", schemas = schemas), "Protocol")` for the bare-schemas success. The `i` hint still lists only the original five Simple fields; this is cosmetic and matches the plan's explicit "no wording change needed" decision, while the `x` line correctly names the conflicting argument. |
| AC-8 | Pass | `NEWS.md:3` adds one dev-version bullet, placed first (sorts before `fraction_unbound()`), single line, function name early, backticked identifiers, `(#157)` before the final period, no internal-helper narration. Roxygen `@param` entries added for all five args (wrapped near 80 cols) plus a runnable promoted-argument example. `man/create_protocol.Rd` regenerated (roxygen-style `\verb{}` for multi-word names, `\code{}` for single tokens, usage block updated); `NAMESPACE` unchanged (helpers internal). No hand-edit signature. |
| AC-9 | Pass | New tests cover: promoted single-dose call (snapshot of `data$Parameters` showing the three canonical entries); each dose-family unit -> single `InputDose`; invalid `dose_unit` (`"banana"` and wrong-dimension `"h"`, snapshot lists accepted units); non-finite/non-scalar/character shape errors; each conflict incl Path-keyed and raw-Path-list; `end_time` unit with `time_unit = "min"` (unit `min`, `data$TimeUnit == "min"`) and without (`unit == "h"`, `expect_null(data$TimeUnit)`); `schemas` exclusivity for each arg plus the bare-schemas success. Uses self-contained `test_that()` blocks, `expect_snapshot(error = TRUE)` for error wording, specific expectations (`expect_length`, `expect_equal`, `expect_s3_class`, `expect_null`). |

## Adversarial / edge-case findings

- Empty `parameters = list()` alongside a promoted arg: `vapply(to_raw_parameters(...), ..., character(1))` returns `character(0)`, `%in%` is FALSE, no spurious conflict. Safe.
- Raw entry lacking both `Name` and `Path`: `param$Name %||% NA_character_` yields `NA_character_`, no false-positive conflict. Safe.
- `time_unit` validation ordering: moved to `R/create_protocol.R:161-163` (before the Simple branch consumes it to build `end_time_unit`) and dropped from the trailing block, so an invalid `time_unit` errors regardless of `end_time`, with no double-abort. Matches plan Step 2e / risk 2.
- `end_time` NULL-`time_unit` side effect: `end_time_unit` is a local; `data$TimeUnit` stays driven solely by the trailing `if (!is.null(time_unit))` block (line 305-307). Edge case 6 satisfied; test asserts `expect_null(data$TimeUnit)`.
- Lone `dose_unit`/`start_time_unit` without their value: unit validation is guarded on the value being non-NULL (dose unit checked only inside the `!is.null(dose)` branch via the helper; `validate_unit(start_time_unit, ...)` only inside `!is.null(start_time)`), so a lone unit is inert, not an error. Matches Decision 3 / edge case 3.
- UTF-8 dose units (`µg`, `mg/m²`, `mg/cm²`) are read live from ospsuite (not hardcoded) and appear correctly encoded in the recorded snapshot's accepted-units line. Matches risk 6.
- Infusion time / Volume of water via `parameters` still pass through: no promotion, no conflict mapping for them, so they flow through `to_raw_parameters()` unchanged. Edge case 11 satisfied.
- `%||%` operator: used throughout the package (rlang is in `Imports`), so the new usage at `R/create_protocol.R:266` resolves.

## Convention compliance

- Base pipe / no magrittr: no pipe introduced; no `%>%`.
- Exported-before-internal ordering: the two new helpers are internal and appended to `R/utils-create.R` alongside the other internal helpers; `create_protocol()` (exported) remains the sole definition in its file. OK.
- Roxygen 80-col wrap: new `@param` blocks wrap at ~80 cols.
- NEWS bullet style: single line, function-name-first, alphabetical placement, backticked, `(#157)` before period. OK.
- `man/` regenerated, not hand-edited: usage block and `\item` entries match roxygen output; `NAMESPACE` unchanged.
- Commit trailer: no `Co-Authored-By` line (verified via `git log origin/main..HEAD`). Commit body uses per-file bullets, imperative summary.
- No dash-as-punctuation in generated prose (NEWS bullet, commit body, PR body use only hyphenated compounds like "Simple-Protocol", "self-documenting", which are allowed).

## Conclusion

All acceptance criteria AC-1..AC-9 are satisfied with direct evidence in the diff, tests, and snapshot. Repo conventions hold. No defects found. Approved.

</details>

<!-- QA-VERDICT: approved -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `create_protocol()` now adds promoted Simple-Protocol arguments: `dose`/`dose_unit`, `start_time`/`start_time_unit`, and `end_time`.
  * These are automatically translated into the corresponding Simple-Protocol fields, merged with any extra parameter entries, and conflicts with duplicate entries are rejected.

* **Bug Fixes**
  * Improved validation for promoted dose/unit and time inputs, including clearer error messages and consistent end-time display units (derived from `time_unit`, defaulting to hours).

* **Documentation / Tests**
  * Updated `create_protocol()` documentation and examples; refreshed snapshots and added unit/conflict validation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->