### PR TITLE
Print only major.minor.patch in the unsupported-version message

### DIFF
--- a/R/Snapshot.R
+++ b/R/Snapshot.R
@@ -1010,7 +1010,9 @@ Snapshot <- R6::R6Class(
         ))
       }
       if (version_num > SUPPORTED_VERSION_MAX) {
-        pkg_version <- utils::packageVersion("osp.snapshots")
+        # Report only the released major.minor.patch, not the dev suffix, so
+        # the message (and its snapshot) is stable across dev-version bumps.
+        pkg_version <- utils::packageVersion("osp.snapshots")[, 1:3]
         cli::cli_abort(c(
           "Snapshot {.field Version} {version_num} is not supported in this version.",
           i = "{.pkg osp.snapshots} v{pkg_version} supports snapshots up to {.field Version} {SUPPORTED_VERSION_MAX}."

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -100,7 +100,7 @@
     Condition
       Error in `private$.validate_version()`:
       ! Snapshot Version 82 is not supported in this version.
-      i osp.snapshots v1.0.0.9001 supports snapshots up to Version 81.
+      i osp.snapshots v1.0.0 supports snapshots up to Version 81.
 
 ---
 
@@ -111,7 +111,7 @@
     Condition
       Error in `private$.validate_version()`:
       ! Snapshot Version 82 is not supported in this version.
-      i osp.snapshots v1.0.0.9001 supports snapshots up to Version 81.
+      i osp.snapshots v1.0.0 supports snapshots up to Version 81.
 
 ---
 
@@ -122,7 +122,7 @@
     Condition
       Error in `private$.validate_version()`:
       ! Snapshot Version 82 is not supported in this version.
-      i osp.snapshots v1.0.0.9001 supports snapshots up to Version 81.
+      i osp.snapshots v1.0.0 supports snapshots up to Version 81.
 
 # Snapshot warns when a snapshot is newer than the installed core
 


### PR DESCRIPTION
The error raised when a snapshot is newer than this package supports embeds the installed `osp.snapshots` version. It printed the full development version (for example `1.0.0.9002`), so the message and its recorded snapshot changed on every dev-version bump, causing spurious snapshot-test churn. This truncates the reported version to its released `major.minor.patch` so the message is stable across dev-version bumps.

## Message

`R/Snapshot.R` now truncates `utils::packageVersion("osp.snapshots")` to its first three components before interpolating it into the "not supported in this version" abort, so the hint reads `osp.snapshots v1.0.0 supports snapshots up to Version 81` regardless of the dev suffix.

## Tests

The `test-snapshot.R` fixture line for that error is re-recorded to the truncated form. The change is the version string only; the surrounding message and all other snapshots are unchanged.